### PR TITLE
MDTZ-924 add auth redirect static webpage and add redirect to auth route

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -10,5 +10,9 @@ authRouter.get('/callback', function (req, res) {
 	// 3. store in database using by calling `delegateOAuthUseCase` here
 	// 4. redirect user to './static/index.html'
 	req.log.info('Received auth callback');
-	res.sendFile(resolve('./static/index.html'));
+	const success = true;
+	const errorMessage = '';
+	res.redirect(
+		`/public/index.html?success=${success}&errorMessage=${errorMessage}`,
+	);
 });

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -1,4 +1,5 @@
-import { Router } from 'express';
+import { join } from 'path';
+import { Router, static as Static } from 'express';
 import { connectDescriptorGet } from './atlassian-connect';
 import { lifecycleEventsRouter } from './lifecycle-events';
 import { authRouter } from './auth';
@@ -9,6 +10,9 @@ export const RootRouter = Router();
 RootRouter.get('/', (_req, res) =>
 	res.status(200).send('Server up and working.'),
 );
+
+// Static resources
+RootRouter.use('/public', Static(join(process.cwd(), 'static')));
 
 // Connect app manifest
 RootRouter.get('/atlassian-connect.json', connectDescriptorGet);

--- a/static/index.html
+++ b/static/index.html
@@ -1,7 +1,42 @@
 <!doctype html>
-<html>
-  <head></head>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title></title>
+  </head>
   <body>
-    Hello Figma
+    <script>
+      if (window.opener) {
+        function parseQueryParamAsBoolean(value) {
+          return value.toLowerCase() === 'true';
+        }
+
+        const params = new URLSearchParams(window.location.search);
+
+        if (params.has('success')) {
+          const success = parseQueryParamAsBoolean(params.get('success'));
+          const errorMessage = params.get('errorMessage');
+
+          // Send the authentication result to the opener window
+          if (success) {
+            window.opener.postMessage(
+              {
+                type: 'auth:success',
+              },
+              '*',
+            );
+          } else {
+            window.opener.postMessage(
+              {
+                type: 'auth:failure',
+                message: errorMessage || 'Unable to connect the account.',
+                errorType,
+              },
+              '*',
+            );
+          }
+        }
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
* Adds a `/public` route for serving static assets from the `static` folder
* Adds a static webpage which will be redirected to at the end of the auth flow, which posts success/fail window messages
* Redirect to the static webpage in the `/auth/callback` endpoint