### PR TITLE
Add back the util scripts in package.json that were accidentally removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
 		"lint": "eslint .",
 		"lint:fix": "eslint . --fix",
 		"format": "prettier . --write",
-		"format:check": "prettier . --check"
+		"format:check": "prettier . --check",
+		"util:makeTunnel": "./scripts/make-tunnel.sh",
+		"util:updateAppUrl": "ts-node ./scripts/update-app-url.ts"
 	},
 	"dependencies": {
 		"@prisma/client": "^5.1.1",


### PR DESCRIPTION
I must've smooth brained a merge conflict at some point which removed these.
Adding them back as they're needed.