### PR TITLE
NONE Run Prisma client generation in Docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,10 @@ USER node
 
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
-COPY prisma ./prisma
-COPY entrypoint.sh .
 # Copy the compiled JS from the build image
 COPY --from=build /app/build ./
-# Copy the generated Prisma client from build image
-COPY --from=build /app/node_modules/prisma/prisma-client ./node_modules/prisma/prisma-client
+COPY prisma ./prisma
+COPY entrypoint.sh .
 
 EXPOSE 8080
 ENTRYPOINT ["/opt/service/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,5 @@ set -e
 
 export DATABASE_URL=postgresql://${PG_FIGMA_FOR_JIRA_DB_ROLE}:${PG_FIGMA_FOR_JIRA_DB_PASSWORD}@${PG_FIGMA_FOR_JIRA_DB_HOST}:${PG_FIGMA_FOR_JIRA_DB_PORT}/${PG_FIGMA_FOR_JIRA_DB_SCHEMA}
 npx prisma migrate deploy
+npx prisma generate
 node server.js


### PR DESCRIPTION
Was seeing this error when upserting OAuth creds in our Micros deploy:

```
Error: @prisma/client did not initialize yet. Please run "prisma generate" and try to import it again.
```

Looks like we need to actually run `prisma generate` before running the deployed app, where previously we were just copying the generated client files from the initial build image.