### PR TITLE
MDTZ-969 Add FigmaWebhook table

### DIFF
--- a/prisma/migrations/20230907074824_add_figma_webhook_table/migration.sql
+++ b/prisma/migrations/20230907074824_add_figma_webhook_table/migration.sql
@@ -1,0 +1,20 @@
+-- CreateEnum
+CREATE TYPE "FigmaWebhookStatus" AS ENUM ('PENDING', 'ACTIVE', 'PAUSED', 'ERROR');
+
+-- CreateTable
+CREATE TABLE "FigmaWebhook" (
+    "id" SERIAL NOT NULL,
+    "webhookId" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "teamName" TEXT NOT NULL,
+    "figmaAdminAtlassianUserId" TEXT NOT NULL,
+    "status" "FigmaWebhookStatus" NOT NULL,
+
+    CONSTRAINT "FigmaWebhook_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FigmaWebhook_webhookId_key" ON "FigmaWebhook"("webhookId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FigmaWebhook_teamId_key" ON "FigmaWebhook"("teamId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,3 +23,20 @@ model FigmaOAuth2UserCredentials {
   refreshToken    String
   expiresAt       DateTime @db.Timestamptz
 }
+
+enum FigmaWebhookStatus {
+  PENDING
+  ACTIVE
+  PAUSED
+  ERROR
+}
+
+model FigmaWebhook {
+  id                        Int                @id @default(autoincrement())
+  webhookId                 String             @unique
+  teamId                    String             @unique
+  teamName                  String
+  // Atlassian user ID of the Figma admin that configured this webhook
+  figmaAdminAtlassianUserId String
+  status                    FigmaWebhookStatus
+}


### PR DESCRIPTION
Adds the table for storing Figma team information when a Figma admin configures the app via the UI.