### PR TITLE
MDTZ-963 Change lastUpdated to be lastModified for the Figma file

### DIFF
--- a/src/infrastructure/figma/figma-transformer.ts
+++ b/src/infrastructure/figma/figma-transformer.ts
@@ -147,8 +147,8 @@ export const transformNodeToAtlassianDesign = ({
 			? mapNodeStatusToDevStatus(node.devStatus)
 			: AtlassianDesignStatus.NONE,
 		type: mapNodeTypeToDesignType(node.type, isPrototype),
-		// TODO: lastUpdated should come from the app database once polling is added
-		lastUpdated: new Date().toISOString(),
+		// TODO: lastUpdated should be determined by the nearest parent node's lastModified time once Figma have implemented lastModified
+		lastUpdated: fileNodesResponse.lastModified,
 		updateSequenceNumber: getUpdateSequenceNumber(fileNodesResponse.version),
 	};
 };
@@ -176,8 +176,7 @@ export const transformFileToAtlassianDesign = ({
 		type: isPrototype
 			? AtlassianDesignType.PROTOTYPE
 			: AtlassianDesignType.FILE,
-		// TODO: lastUpdated should come from the app database once polling is added
-		lastUpdated: new Date().toISOString(),
+		lastUpdated: fileResponse.lastModified,
 		updateSequenceNumber: getUpdateSequenceNumber(fileResponse.version),
 	};
 };

--- a/src/web/routes/entities/integration.test.ts
+++ b/src/web/routes/entities/integration.test.ts
@@ -132,15 +132,11 @@ describe('/associateEntity', () => {
 	const validCredentialsParams = generateFigmaUserCredentialsCreateParams();
 	describe('success case', () => {
 		beforeEach(async () => {
-			jest.useFakeTimers({
-				doNotFake: ['nextTick'],
-			});
 			await figmaOAuth2UserCredentialsRepository.upsert(validCredentialsParams);
 			await connectInstallationRepository.upsert(MOCK_CONNECT_INSTALLATION);
 		});
 
 		afterEach(async () => {
-			jest.useRealTimers();
 			await connectInstallationRepository
 				.deleteByClientKey(MOCK_CLIENT_KEY)
 				.catch(console.log);


### PR DESCRIPTION
## Changes
* Changes `lastUpdated` to be the `lastModified` time of the Figma file for both files and nodes.

## Caveats

This is not ideal for detecting new changes on nodes in Jira, because we will encounter false positives where a node appears to have changed, but in reality something unrelated in the file was changed.

We hope to move to a better state for this once `lastModified` is available in Figma APIs for top-level nodes/frames.