### PR TITLE
MDTZ-968 Add AssociatedDesign table

### DIFF
--- a/prisma/migrations/20230911014359_add_associated_design_table/migration.sql
+++ b/prisma/migrations/20230911014359_add_associated_design_table/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "AssociatedDesign" (
+    "id" SERIAL NOT NULL,
+    "url" TEXT NOT NULL,
+    "fileKey" TEXT NOT NULL,
+
+    CONSTRAINT "AssociatedDesign_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AssociatedDesign_url_key" ON "AssociatedDesign"("url");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,12 @@ model ConnectInstallation {
   displayUrl   String
 }
 
+model AssociatedDesign {
+  id      Int    @id @default(autoincrement())
+  url     String @unique
+  fileKey String
+}
+
 model FigmaOAuth2UserCredentials {
   id              Int      @id @default(autoincrement())
   atlassianUserId String   @unique


### PR DESCRIPTION
This PR adds an `AssociatedDesign` for tracking associated designs that we need to sync.

The sync process will look something like:

1. Receive a `FILE_UPDATE` (or `FILE_DELETE`) webhook event
2. Use `webhook_id ` from the event payload to look up a `FigmaWebhook` in our DB
3. Use `figmaAdminAtlassianUserId` from the `FigmaWebhook` record to get a 3LO token for the Figma team admin
4. Use `file_key` from the webhook payload to look up all `AssociatedDesign` records with a matching `fileKey`
5. Use the 3LO token from step 3 to ingest the designs from step 4, using the `url` column from the `AssociatedDesign` records to fetch design data from the Figma API

Please let me know if you see any issues with this, or if there are any extra columns we require in the new table to sync designs.