### PR TITLE
MDTZ-941 Disassociate entity

### DIFF
--- a/src/domain/entities/atlassian-design.test.ts
+++ b/src/domain/entities/atlassian-design.test.ts
@@ -1,6 +1,8 @@
 import { AtlassianAssociation } from './atlassian-design';
 import { generateIssueAri } from './testing';
 
+import { JIRA_ISSUE_ATI } from '../../common/constants';
+
 describe('AtlassianDesign', () => {
 	describe('createDesignIssueAssociation', () => {
 		test('should return issue-associated-design association', () => {
@@ -10,7 +12,7 @@ describe('AtlassianDesign', () => {
 				AtlassianAssociation.createDesignIssueAssociation(issueAri);
 
 			expect(association).toEqual({
-				associationType: 'issue-associated-design',
+				associationType: JIRA_ISSUE_ATI,
 				values: [issueAri],
 			});
 		});

--- a/src/domain/entities/atlassian-design.ts
+++ b/src/domain/entities/atlassian-design.ts
@@ -1,4 +1,4 @@
-const ISSUE_ASSOCIATED_DESIGN_RELATIONSHIP_TYPE = 'issue-associated-design';
+import { JIRA_ISSUE_ATI } from '../../common/constants';
 
 export enum AtlassianDesignStatus {
 	READY_FOR_DEVELOPMENT = 'READY_FOR_DEVELOPMENT',
@@ -22,9 +22,7 @@ export class AtlassianAssociation {
 	) {}
 
 	static createDesignIssueAssociation(issueAri: string): AtlassianAssociation {
-		return new AtlassianAssociation(ISSUE_ASSOCIATED_DESIGN_RELATIONSHIP_TYPE, [
-			issueAri,
-		]);
+		return new AtlassianAssociation(JIRA_ISSUE_ATI, [issueAri]);
 	}
 }
 

--- a/src/infrastructure/figma/figma-client.ts
+++ b/src/infrastructure/figma/figma-client.ts
@@ -76,6 +76,22 @@ export type CreateDevResourcesResponse = {
 	readonly errors: CreateDevResourceError[];
 };
 
+type GetDevResourcesRequest = {
+	readonly fileKey: string;
+	readonly nodeIds?: string;
+	readonly accessToken: string;
+};
+
+type GetDevResourcesResponse = {
+	readonly dev_resources: DevResource[];
+};
+
+type DeleteDevResourceRequest = {
+	readonly fileKey: string;
+	readonly devResourceId: string;
+	readonly accessToken: string;
+};
+
 /**
  * A generic Figma API client.
  *
@@ -207,6 +223,55 @@ export class FigmaClient {
 			{
 				dev_resources: devResources,
 			},
+			{
+				headers: {
+					['Authorization']: `Bearer ${accessToken}`,
+				},
+			},
+		);
+
+		return response.data;
+	};
+
+	/**
+	 * Fetches Figma Dev Resources using the GET dev resources endpoint
+	 *
+	 * @see https://www.figma.com/developers/api#get-dev-resources-endpoint
+	 */
+	getDevResources = async ({
+		fileKey,
+		nodeIds: node_ids,
+		accessToken,
+	}: GetDevResourcesRequest): Promise<GetDevResourcesResponse> => {
+		const response = await axios.get<GetDevResourcesResponse>(
+			`${getConfig().figma.apiBaseUrl}/v1/files/${fileKey}/dev_resources`,
+			{
+				params: {
+					node_ids,
+				},
+				headers: {
+					['Authorization']: `Bearer ${accessToken}`,
+				},
+			},
+		);
+
+		return response.data;
+	};
+
+	/**
+	 * Deletes a Figma Dev Resource using the DELETE dev resources endpoint
+	 *
+	 * @see https://www.figma.com/developers/api#delete-dev-resources-endpoint
+	 */
+	deleteDevResource = async ({
+		fileKey,
+		devResourceId,
+		accessToken,
+	}: DeleteDevResourceRequest): Promise<void> => {
+		const response = await axios.delete<void>(
+			`${
+				getConfig().figma.apiBaseUrl
+			}/v1/files/${fileKey}/dev_resources/${devResourceId}`,
 			{
 				headers: {
 					['Authorization']: `Bearer ${accessToken}`,

--- a/src/infrastructure/figma/figma-client.ts
+++ b/src/infrastructure/figma/figma-client.ts
@@ -82,7 +82,7 @@ type GetDevResourcesRequest = {
 	readonly accessToken: string;
 };
 
-type GetDevResourcesResponse = {
+export type GetDevResourcesResponse = {
 	readonly dev_resources: DevResource[];
 };
 

--- a/src/infrastructure/figma/figma-service.ts
+++ b/src/infrastructure/figma/figma-service.ts
@@ -175,7 +175,7 @@ export class FigmaService {
 
 		const { dev_resources } = await figmaClient.getDevResources({
 			fileKey,
-			...(nodeId && { nodeIds: unprettifyNodeId(nodeId) }),
+			...(nodeId && { nodeIds: transformNodeIdForStorage(nodeId) }),
 			accessToken,
 		});
 

--- a/src/infrastructure/figma/figma-transformer.test.ts
+++ b/src/infrastructure/figma/figma-transformer.test.ts
@@ -56,14 +56,14 @@ describe('FigmaTransformer', () => {
 		it('should return fileKey, nodeId and isPrototype if both fileKey and nodeId are present in the url', () => {
 			expect(extractDataFromFigmaUrl(MOCK_DESIGN_URL_WITH_NODE)).toStrictEqual({
 				fileKey: MOCK_FILE_KEY,
-				nodeId: MOCK_NODE_ID_URL,
+				nodeId: MOCK_NODE_ID,
 				isPrototype: false,
 			});
 		});
 		it('should return `isPrototype: true` if the url is for a prototype', () => {
 			expect(extractDataFromFigmaUrl(MOCK_PROTOTYPE_URL)).toStrictEqual({
 				fileKey: MOCK_FILE_KEY,
-				nodeId: MOCK_NODE_ID_URL,
+				nodeId: MOCK_NODE_ID,
 				isPrototype: true,
 			});
 		});

--- a/src/infrastructure/figma/figma-transformer.test.ts
+++ b/src/infrastructure/figma/figma-transformer.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_FIGMA_FILE_NODE_ID } from './figma-service';
 import {
 	buildDesignUrl,
 	buildInspectUrl,
@@ -78,7 +79,6 @@ describe('FigmaTransformer', () => {
 			const expected = new URL('https://www.figma.com/embed');
 			expected.searchParams.append('embed_host', 'atlassian');
 			expected.searchParams.append('url', MOCK_DESIGN_URL_WITH_NODE);
-			console.log('expected.toSTring', expected.toString());
 			expect(
 				buildLiveEmbedUrl({
 					fileKey: MOCK_FILE_KEY,
@@ -125,7 +125,7 @@ describe('FigmaTransformer', () => {
 				nodeId: MOCK_NODE_ID,
 			});
 			const expected: AtlassianDesign = {
-				id: MOCK_NODE_ID,
+				id: `${MOCK_FILE_KEY}/${MOCK_NODE_ID}`,
 				displayName: mockApiResponse.nodes[MOCK_NODE_ID].document.name,
 				url: buildDesignUrl({
 					fileKey: MOCK_FILE_KEY,
@@ -163,7 +163,7 @@ describe('FigmaTransformer', () => {
 		it('should correctly map to atlassian design', () => {
 			const mockApiResponse = generateGetFileResponse();
 			const expected: AtlassianDesign = {
-				id: MOCK_FILE_KEY,
+				id: `${MOCK_FILE_KEY}/${DEFAULT_FIGMA_FILE_NODE_ID}`,
 				displayName: mockApiResponse.name,
 				url: buildDesignUrl({
 					fileKey: MOCK_FILE_KEY,

--- a/src/infrastructure/figma/figma-transformer.ts
+++ b/src/infrastructure/figma/figma-transformer.ts
@@ -34,7 +34,7 @@ export const extractDataFromFigmaUrl = (url: string): FigmaUrlData | null => {
 	}
 
 	const fileKey = fileKeyMatch ? fileKeyMatch[1] : prototypeMatch![1];
-	const nodeId = nodeIdMatch ? nodeIdMatch[1] : undefined;
+	const nodeId = nodeIdMatch ? unprettifyNodeId(nodeIdMatch[1]) : undefined;
 
 	return {
 		fileKey,

--- a/src/infrastructure/figma/testing/mocks.ts
+++ b/src/infrastructure/figma/testing/mocks.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { Duration } from '../../../common/duration';
 import type {
+	GetDevResourcesResponse,
 	GetOAuth2TokenResponse,
 	NodeDetails,
 	RefreshOAuth2TokenResponse,
@@ -20,6 +21,7 @@ export const MOCK_VERSION = '4067551197';
 export const MOCK_ISSUE_URL =
 	'https://myjirainstance.atlassian.net/browse/FIG-1';
 export const MOCK_ISSUE_TITLE = 'Test Jira Issue';
+export const MOCK_DEV_RESOURCE_ID = uuidv4();
 export const MOCK_DOCUMENT: NodeDetails = {
 	id: MOCK_NODE_ID,
 	name: 'Test Node',
@@ -118,3 +120,24 @@ export const generateGetFileResponse = ({
 	linkAccess: 'org_edit',
 	document: MOCK_DOCUMENT,
 });
+
+export const generateGetDevResourcesResponse = ({
+	id = MOCK_DEV_RESOURCE_ID,
+	name = 'Mock dev resource',
+	url = MOCK_ISSUE_URL,
+	file_key = MOCK_ISSUE_URL,
+	node_id = MOCK_ISSUE_URL,
+}: {
+	id?: string;
+	name?: string;
+	url?: string;
+	file_key?: string;
+	node_id?: string;
+} = {}): GetDevResourcesResponse => ({
+	dev_resources: [{ id, name, url, file_key, node_id }],
+});
+
+export const generateEmptyDevResourcesResponse =
+	(): GetDevResourcesResponse => ({
+		dev_resources: [],
+	});

--- a/src/usecases/associate-entity-use-case.ts
+++ b/src/usecases/associate-entity-use-case.ts
@@ -1,20 +1,15 @@
+import type { AtlassianEntity } from './types';
+
 import type { AtlassianDesign, ConnectInstallation } from '../domain/entities';
 import { AtlassianAssociation } from '../domain/entities';
 import { figmaService } from '../infrastructure/figma';
 import { jiraService } from '../infrastructure/jira';
 
-export type AssociateWith = {
-	readonly ati: string;
-	readonly ari: string;
-	readonly cloudId: string;
-	readonly id: string;
-};
-
 export type AssociateEntityUseCaseParams = {
 	readonly entity: {
 		readonly url: string;
 	};
-	readonly associateWith: AssociateWith;
+	readonly associateWith: AtlassianEntity;
 	readonly atlassianUserId: string;
 	readonly connectInstallation: ConnectInstallation;
 };

--- a/src/usecases/disassociate-entity-use-case.ts
+++ b/src/usecases/disassociate-entity-use-case.ts
@@ -1,0 +1,56 @@
+import type { AtlassianEntity } from './types';
+
+import { JIRA_ISSUE_ATI } from '../common/constants';
+import type { AtlassianDesign, ConnectInstallation } from '../domain/entities';
+import { AtlassianAssociation } from '../domain/entities';
+import { figmaService } from '../infrastructure/figma';
+import { jiraService } from '../infrastructure/jira';
+
+export type DisassociateEntityUseCaseParams = {
+	readonly entity: {
+		readonly ari: string;
+		readonly id: string;
+	};
+	readonly disassociateFrom: AtlassianEntity;
+	readonly atlassianUserId: string;
+	readonly connectInstallation: ConnectInstallation;
+};
+
+export const disassociateEntityUseCase = {
+	execute: async ({
+		entity,
+		disassociateFrom,
+		atlassianUserId,
+		connectInstallation,
+	}: DisassociateEntityUseCaseParams): Promise<AtlassianDesign> => {
+		if (disassociateFrom.ati !== JIRA_ISSUE_ATI) {
+			throw new Error('Unrecognised ATI');
+		}
+		const [design, issue] = await Promise.all([
+			figmaService.fetchDesignById(entity.id, atlassianUserId),
+			jiraService.getIssue(disassociateFrom.id, connectInstallation),
+		]);
+
+		const designIssueAssociation =
+			AtlassianAssociation.createDesignIssueAssociation(disassociateFrom.ari);
+
+		const { self: issueUrl } = issue;
+
+		await Promise.all([
+			jiraService.submitDesign(
+				{
+					design,
+					removeAssociations: [designIssueAssociation],
+				},
+				connectInstallation,
+			),
+			figmaService.deleteDevResourceIfExists({
+				designId: entity.id,
+				issueUrl,
+				atlassianUserId,
+			}),
+		]);
+
+		return design;
+	},
+};

--- a/src/usecases/index.ts
+++ b/src/usecases/index.ts
@@ -3,3 +3,4 @@ export * from './installed-use-case';
 export * from './uninstalled-use-case';
 export * from './check-3lo-use-case';
 export * from './associate-entity-use-case';
+export * from './disassociate-entity-use-case';

--- a/src/usecases/types.ts
+++ b/src/usecases/types.ts
@@ -1,0 +1,6 @@
+export type AtlassianEntity = {
+	readonly ati: string;
+	readonly ari: string;
+	readonly cloudId: string;
+	readonly id: string;
+};

--- a/src/web/middleware/error-handler-middleware.ts
+++ b/src/web/middleware/error-handler-middleware.ts
@@ -5,6 +5,7 @@ import { JwtVerificationError } from './jwt-utils';
 
 import { FigmaServiceCredentialsError } from '../../infrastructure/figma';
 import { RepositoryRecordNotFoundError } from '../../infrastructure/repositories';
+import { UnauthorizedError } from '../routes/entities';
 
 export const errorHandlerMiddleware = (
 	err: Error,
@@ -20,7 +21,7 @@ export const errorHandlerMiddleware = (
 	// Setting `err` on the response so it can be picked up by the `pino-http` logger
 	res.err = err;
 
-	if (err instanceof JwtVerificationError) {
+	if (err instanceof JwtVerificationError || err instanceof UnauthorizedError) {
 		res.status(HttpStatusCode.Unauthorized).send(err.message);
 	} else if (err instanceof RepositoryRecordNotFoundError) {
 		res.status(HttpStatusCode.NotFound).send(err.message);

--- a/src/web/routes/atlassian-connect.ts
+++ b/src/web/routes/atlassian-connect.ts
@@ -98,20 +98,20 @@ export const connectAppDescriptor = {
 				'https://help.figma.com/hc/en-us/articles/360039827834-Jira-and-Figma',
 			actions: {
 				associateEntity: {
-					urlTemplate: `${getConfig().app.baseUrl}/entities/associateEntity`,
+					templateUrl: `${getConfig().app.baseUrl}/entities/associateEntity`,
 				},
 				disassociateEntity: {
-					urlTemplate: `${getConfig().app.baseUrl}/entities/disassociateEntity`,
+					templateUrl: `${getConfig().app.baseUrl}/entities/disassociateEntity`,
 				},
 				grant3LO: {
-					urlTemplate: `${getConfig().figma.apiBaseUrl}/oauth?client_id=${
+					templateUrl: `${getConfig().figma.apiBaseUrl}/oauth?client_id=${
 						getConfig().figma.clientId
 					}&redirect_uri=${
 						getConfig().app.baseUrl
 					}/auth/callback&scope=${figmaScope}&state={state}&response_type=code`,
 				},
 				check3LO: {
-					urlTemplate: `${getConfig().app.baseUrl}/auth/check3LO`,
+					templateUrl: `${getConfig().app.baseUrl}/auth/check3LO`,
 				},
 			},
 		},

--- a/src/web/routes/entities/index.ts
+++ b/src/web/routes/entities/index.ts
@@ -66,7 +66,7 @@ entitiesRouter.post(
 				atlassianUserId,
 				connectInstallation: res.locals.connectInstallation,
 			})
-			.then((design) => res.status(HttpStatusCode.Created).send({ design }))
+			.then((design) => res.status(HttpStatusCode.Ok).send({ design }))
 			.catch((error) => next(error));
 	},
 );
@@ -86,7 +86,7 @@ entitiesRouter.post(
 				atlassianUserId,
 				connectInstallation: res.locals.connectInstallation,
 			})
-			.then((design) => res.status(HttpStatusCode.Created).send({ design }))
+			.then((design) => res.status(HttpStatusCode.Ok).send({ design }))
 			.catch((error) => next(error));
 	},
 );

--- a/src/web/routes/entities/integration.test.ts
+++ b/src/web/routes/entities/integration.test.ts
@@ -13,11 +13,13 @@ import {
 } from '../../../domain/entities/testing';
 import { transformNodeToAtlassianDesign } from '../../../infrastructure/figma/figma-transformer';
 import {
+	generateEmptyDevResourcesResponse,
+	generateGetDevResourcesResponse,
 	generateGetFileNodesResponse,
 	MOCK_DESIGN_URL_WITH_NODE,
+	MOCK_DEV_RESOURCE_ID,
 	MOCK_FILE_KEY,
 	MOCK_NODE_ID,
-	MOCK_NODE_ID_URL,
 } from '../../../infrastructure/figma/testing';
 import type { GetIssuePropertyResponse } from '../../../infrastructure/jira/jira-client';
 import {
@@ -30,7 +32,10 @@ import {
 	figmaOAuth2UserCredentialsRepository,
 } from '../../../infrastructure/repositories';
 
-import type { AssociateEntityRequestParams } from '.';
+import type {
+	AssociateEntityRequestParams,
+	DisassociateEntityRequestParams,
+} from '.';
 
 const MOCK_CLIENT_KEY = '4561b8be-e38b-43d4-84d9-f09e8195d117';
 const MOCK_SHARED_SECRET = '903b6b9e-b82b-48ea-a9b2-40b9e700df32';
@@ -41,8 +46,10 @@ const MOCK_CONNECT_INSTALLATION = {
 	baseUrl: 'https://myjirainstance.atlassian.net',
 	displayUrl: 'https://myjirainstance.atlassian.net',
 };
-const JWT_TOKEN =
+const ASSOCIATE_JWT_TOKEN =
 	'JWT eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2OTM5NTcyMDUsImV4cCI6NjAwMDAwMDE2OTM5NTcxNDQsImlzcyI6IjQ1NjFiOGJlLWUzOGItNDNkNC04NGQ5LWYwOWU4MTk1ZDExNyIsInFzaCI6IjQ2ZDE3MDU4OWU0MjM2Y2U0YTQ5MTFlMGQ1YWE4YjdkOWYzZjNlODZlN2E0ZTgzMzFhM2MyNWE5NTI0MWNjMmYifQ.E71S-uGRlVmEY8-iEEj4bl3SiOcDUlJ-36XGoq8tDHE';
+const DISASSOCIATE_JWT_TOKEN =
+	'JWT eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2OTQ0MzU0NjcsImV4cCI6NjAwMDAwMDE2OTQ0MzU0MDAsImlzcyI6IjQ1NjFiOGJlLWUzOGItNDNkNC04NGQ5LWYwOWU4MTk1ZDExNyIsInFzaCI6ImEzYTcwOGIxNDQwMjdlM2U2ZWRjYWYzY2MzZTBkNzYzYWRhMzI4NDgwMTFjNzMzNGQwMjRkZGE2ZGQ5OWU2NWUifQ.j_Bb4M76LpldZglEY7wQE7KY1KsMIsuvTyqppQd2wBY';
 
 const endpoints = {
 	figma: {
@@ -57,6 +64,7 @@ const endpoints = {
 		ISSUE_PROPERTY: '/rest/api/2/issue',
 	},
 	ASSOCIATE_ENTITY: '/entities/associateEntity',
+	DISASSOCIATE_ENTITY: '/entities/disassociateEntity',
 };
 
 const mockMeEndpoint = ({
@@ -91,7 +99,7 @@ const mockGetFileNodesEndpoint = ({
 		},
 	})
 		.get(`${endpoints.figma.FILE_NODES}/${MOCK_FILE_KEY}/nodes`)
-		.query({ ids: MOCK_NODE_ID_URL })
+		.query({ ids: MOCK_NODE_ID })
 		.reply(statusCode, response ?? {});
 };
 
@@ -173,11 +181,49 @@ const mockSetIssuePropertyEndpoint = ({
 		.reply(statusCode);
 };
 
-const MOCK_REQUEST: AssociateEntityRequestParams = {
+const mockGetDevResourcesEndpoint = ({
+	withDevResources = true,
+}: { withDevResources?: boolean } = {}) => {
+	const response = withDevResources
+		? generateGetDevResourcesResponse()
+		: generateEmptyDevResourcesResponse();
+	nock(endpoints.figma.API_BASE_URL)
+		.get(`${endpoints.figma.FILE_NODES}/${MOCK_FILE_KEY}/dev_resources`)
+		.query({ node_ids: MOCK_NODE_ID })
+		.reply(HttpStatusCode.Ok, response);
+};
+
+const mockDeleteDevResourcesEndpoint = ({
+	success = true,
+}: {
+	success?: boolean;
+} = {}) => {
+	const statusCode = success ? HttpStatusCode.Ok : HttpStatusCode.NotFound;
+	nock(endpoints.figma.API_BASE_URL)
+		.delete(
+			`${endpoints.figma.FILE_NODES}/${MOCK_FILE_KEY}/dev_resources/${MOCK_DEV_RESOURCE_ID}`,
+		)
+		.reply(statusCode);
+};
+
+const MOCK_ASSOCIATE_REQUEST: AssociateEntityRequestParams = {
 	entity: {
 		url: MOCK_DESIGN_URL_WITH_NODE,
 	},
 	associateWith: {
+		ati: JIRA_ISSUE_ATI,
+		ari: generateIssueAri(MOCK_ISSUE_ID),
+		cloudId: uuidv4(),
+		id: MOCK_ISSUE_ID,
+	},
+};
+
+const MOCK_DISASSOCIATE_REQUEST: DisassociateEntityRequestParams = {
+	entity: {
+		ari: 'TODO',
+		id: `${MOCK_FILE_KEY}/${MOCK_NODE_ID}`,
+	},
+	disassociateFrom: {
 		ati: JIRA_ISSUE_ATI,
 		ari: generateIssueAri(MOCK_ISSUE_ID),
 		cloudId: uuidv4(),
@@ -247,8 +293,8 @@ describe('/associateEntity', () => {
 
 			return request(app)
 				.post(endpoints.ASSOCIATE_ENTITY)
-				.send(MOCK_REQUEST)
-				.set('Authorization', JWT_TOKEN)
+				.send(MOCK_ASSOCIATE_REQUEST)
+				.set('Authorization', ASSOCIATE_JWT_TOKEN)
 				.set('Content-Type', 'application/json')
 				.set('User-Id', validCredentialsParams.atlassianUserId)
 				.expect(HttpStatusCode.Ok)
@@ -272,8 +318,8 @@ describe('/associateEntity', () => {
 		it('should respond with 401 "User-Id" header is not set', () => {
 			return request(app)
 				.post(endpoints.ASSOCIATE_ENTITY)
-				.send(MOCK_REQUEST)
-				.set('Authorization', JWT_TOKEN)
+				.send(MOCK_ASSOCIATE_REQUEST)
+				.set('Authorization', ASSOCIATE_JWT_TOKEN)
 				.set('Content-Type', 'application/json')
 				.expect(HttpStatusCode.Unauthorized);
 		});
@@ -283,8 +329,8 @@ describe('/associateEntity', () => {
 
 			return request(app)
 				.post(endpoints.ASSOCIATE_ENTITY)
-				.send(MOCK_REQUEST)
-				.set('Authorization', JWT_TOKEN)
+				.send(MOCK_ASSOCIATE_REQUEST)
+				.set('Authorization', ASSOCIATE_JWT_TOKEN)
 				.set('Content-Type', 'application/json')
 				.set('User-Id', validCredentialsParams.atlassianUserId)
 				.expect(HttpStatusCode.Forbidden);
@@ -317,8 +363,8 @@ describe('/associateEntity', () => {
 
 				return request(app)
 					.post(endpoints.ASSOCIATE_ENTITY)
-					.send(MOCK_REQUEST)
-					.set('Authorization', JWT_TOKEN)
+					.send(MOCK_ASSOCIATE_REQUEST)
+					.set('Authorization', ASSOCIATE_JWT_TOKEN)
 					.set('Content-Type', 'application/json')
 					.set('User-Id', validCredentialsParams.atlassianUserId)
 					.expect(HttpStatusCode.InternalServerError);
@@ -336,8 +382,8 @@ describe('/associateEntity', () => {
 
 				return request(app)
 					.post(endpoints.ASSOCIATE_ENTITY)
-					.send(MOCK_REQUEST)
-					.set('Authorization', JWT_TOKEN)
+					.send(MOCK_ASSOCIATE_REQUEST)
+					.set('Authorization', ASSOCIATE_JWT_TOKEN)
 					.set('Content-Type', 'application/json')
 					.set('User-Id', validCredentialsParams.atlassianUserId)
 					.expect(HttpStatusCode.InternalServerError);
@@ -367,8 +413,8 @@ describe('/associateEntity', () => {
 
 				return request(app)
 					.post(endpoints.ASSOCIATE_ENTITY)
-					.send(MOCK_REQUEST)
-					.set('Authorization', JWT_TOKEN)
+					.send(MOCK_ASSOCIATE_REQUEST)
+					.set('Authorization', ASSOCIATE_JWT_TOKEN)
 					.set('Content-Type', 'application/json')
 					.set('User-Id', validCredentialsParams.atlassianUserId)
 					.expect(HttpStatusCode.InternalServerError);
@@ -398,8 +444,8 @@ describe('/associateEntity', () => {
 
 				return request(app)
 					.post(endpoints.ASSOCIATE_ENTITY)
-					.send(MOCK_REQUEST)
-					.set('Authorization', JWT_TOKEN)
+					.send(MOCK_ASSOCIATE_REQUEST)
+					.set('Authorization', ASSOCIATE_JWT_TOKEN)
 					.set('Content-Type', 'application/json')
 					.set('User-Id', validCredentialsParams.atlassianUserId)
 					.expect(HttpStatusCode.InternalServerError);
@@ -430,8 +476,226 @@ describe('/associateEntity', () => {
 
 				return request(app)
 					.post(endpoints.ASSOCIATE_ENTITY)
-					.send(MOCK_REQUEST)
-					.set('Authorization', JWT_TOKEN)
+					.send(MOCK_ASSOCIATE_REQUEST)
+					.set('Authorization', ASSOCIATE_JWT_TOKEN)
+					.set('Content-Type', 'application/json')
+					.set('User-Id', validCredentialsParams.atlassianUserId)
+					.expect(HttpStatusCode.InternalServerError);
+			});
+		});
+	});
+});
+
+describe('/disassociateEntity', () => {
+	const validCredentialsParams = generateFigmaUserCredentialsCreateParams();
+	describe('success case', () => {
+		beforeEach(async () => {
+			await figmaOAuth2UserCredentialsRepository.upsert(validCredentialsParams);
+			await connectInstallationRepository.upsert(MOCK_CONNECT_INSTALLATION);
+		});
+
+		afterEach(async () => {
+			await connectInstallationRepository
+				.deleteByClientKey(MOCK_CLIENT_KEY)
+				.catch(console.log);
+			await figmaOAuth2UserCredentialsRepository
+				.delete(validCredentialsParams.atlassianUserId)
+				.catch(console.log);
+			1;
+		});
+
+		it('should respond with created design entity', async () => {
+			const credentials = await figmaOAuth2UserCredentialsRepository.get(
+				validCredentialsParams.atlassianUserId,
+			);
+			const mockFileNodesResponse = generateGetFileNodesResponse();
+
+			mockMeEndpoint({ success: true, times: 2 });
+			mockGetFileNodesEndpoint({
+				accessToken: credentials?.accessToken,
+				response: mockFileNodesResponse,
+			});
+			mockGetIssueEndpoint();
+			mockSubmitDesignsEndpoint();
+			mockGetDevResourcesEndpoint();
+			mockDeleteDevResourcesEndpoint();
+
+			const expectedResponse = {
+				design: transformNodeToAtlassianDesign({
+					fileKey: MOCK_FILE_KEY,
+					nodeId: MOCK_NODE_ID,
+					isPrototype: false,
+					fileNodesResponse: mockFileNodesResponse,
+				}),
+			};
+
+			return request(app)
+				.post(endpoints.DISASSOCIATE_ENTITY)
+				.send(MOCK_DISASSOCIATE_REQUEST)
+				.set('Authorization', DISASSOCIATE_JWT_TOKEN)
+				.set('Content-Type', 'application/json')
+				.set('User-Id', validCredentialsParams.atlassianUserId)
+				.expect(HttpStatusCode.Ok)
+				.expect(expectedResponse);
+		});
+	});
+
+	describe('error scenarios', () => {
+		const validCredentialsParams = generateFigmaUserCredentialsCreateParams();
+
+		beforeEach(async () => {
+			await connectInstallationRepository.upsert(MOCK_CONNECT_INSTALLATION);
+		});
+
+		afterEach(async () => {
+			await connectInstallationRepository
+				.deleteByClientKey(MOCK_CLIENT_KEY)
+				.catch(console.log);
+		});
+
+		it('should respond with 401 "User-Id" header is not set', () => {
+			return request(app)
+				.post(endpoints.DISASSOCIATE_ENTITY)
+				.send(MOCK_DISASSOCIATE_REQUEST)
+				.set('Authorization', DISASSOCIATE_JWT_TOKEN)
+				.set('Content-Type', 'application/json')
+				.expect(HttpStatusCode.Unauthorized);
+		});
+
+		it('should respond with 403 if credentials are not found', () => {
+			mockGetIssueEndpoint();
+
+			return request(app)
+				.post(endpoints.DISASSOCIATE_ENTITY)
+				.send(MOCK_DISASSOCIATE_REQUEST)
+				.set('Authorization', DISASSOCIATE_JWT_TOKEN)
+				.set('Content-Type', 'application/json')
+				.set('User-Id', validCredentialsParams.atlassianUserId)
+				.expect(HttpStatusCode.Forbidden);
+		});
+
+		describe('with valid auth and upstream errors', () => {
+			beforeEach(async () => {
+				await figmaOAuth2UserCredentialsRepository.upsert(
+					validCredentialsParams,
+				);
+			});
+
+			afterEach(async () => {
+				await figmaOAuth2UserCredentialsRepository
+					.delete(validCredentialsParams.atlassianUserId)
+					.catch(console.log);
+			});
+
+			it('should respond with 500 if fetching design details fails', async () => {
+				const credentials = await figmaOAuth2UserCredentialsRepository.get(
+					validCredentialsParams.atlassianUserId,
+				);
+
+				mockMeEndpoint({ success: true });
+				mockGetIssueEndpoint();
+				mockGetFileNodesEndpoint({
+					accessToken: credentials?.accessToken,
+					success: false,
+				});
+
+				return request(app)
+					.post(endpoints.DISASSOCIATE_ENTITY)
+					.send(MOCK_DISASSOCIATE_REQUEST)
+					.set('Authorization', DISASSOCIATE_JWT_TOKEN)
+					.set('Content-Type', 'application/json')
+					.set('User-Id', validCredentialsParams.atlassianUserId)
+					.expect(HttpStatusCode.InternalServerError);
+			});
+
+			it('should respond with 500 if fetching issue details fails', async () => {
+				const credentials = await figmaOAuth2UserCredentialsRepository.get(
+					validCredentialsParams.atlassianUserId,
+				);
+				mockGetFileNodesEndpoint({
+					accessToken: credentials?.accessToken,
+				});
+				mockMeEndpoint();
+				mockGetIssueEndpoint({ success: false });
+
+				return request(app)
+					.post(endpoints.DISASSOCIATE_ENTITY)
+					.send(MOCK_DISASSOCIATE_REQUEST)
+					.set('Authorization', DISASSOCIATE_JWT_TOKEN)
+					.set('Content-Type', 'application/json')
+					.set('User-Id', validCredentialsParams.atlassianUserId)
+					.expect(HttpStatusCode.InternalServerError);
+			});
+
+			it('should respond with 500 if design ingestion fails', async () => {
+				const credentials = await figmaOAuth2UserCredentialsRepository.get(
+					validCredentialsParams.atlassianUserId,
+				);
+				const mockFileNodesResponse = generateGetFileNodesResponse();
+
+				mockMeEndpoint({ success: true, times: 2 });
+				mockGetFileNodesEndpoint({
+					accessToken: credentials?.accessToken,
+					response: mockFileNodesResponse,
+				});
+				mockGetIssueEndpoint();
+				mockGetDevResourcesEndpoint();
+				mockDeleteDevResourcesEndpoint();
+				mockSubmitDesignsEndpoint({ success: false });
+
+				return request(app)
+					.post(endpoints.DISASSOCIATE_ENTITY)
+					.send(MOCK_DISASSOCIATE_REQUEST)
+					.set('Authorization', DISASSOCIATE_JWT_TOKEN)
+					.set('Content-Type', 'application/json')
+					.set('User-Id', validCredentialsParams.atlassianUserId)
+					.expect(HttpStatusCode.InternalServerError);
+			});
+
+			it('should respond with 200 if getDevResource returns no resources', async () => {
+				const credentials = await figmaOAuth2UserCredentialsRepository.get(
+					validCredentialsParams.atlassianUserId,
+				);
+				const mockFileNodesResponse = generateGetFileNodesResponse();
+
+				mockMeEndpoint({ success: true, times: 2 });
+				mockGetFileNodesEndpoint({
+					accessToken: credentials?.accessToken,
+					response: mockFileNodesResponse,
+				});
+				mockGetIssueEndpoint();
+				mockSubmitDesignsEndpoint();
+				mockGetDevResourcesEndpoint({ withDevResources: false });
+
+				return request(app)
+					.post(endpoints.DISASSOCIATE_ENTITY)
+					.send(MOCK_DISASSOCIATE_REQUEST)
+					.set('Authorization', DISASSOCIATE_JWT_TOKEN)
+					.set('Content-Type', 'application/json')
+					.set('User-Id', validCredentialsParams.atlassianUserId)
+					.expect(HttpStatusCode.Ok);
+			});
+
+			it('should respond with 500 if deleteDevResource request fails', async () => {
+				const credentials = await figmaOAuth2UserCredentialsRepository.get(
+					validCredentialsParams.atlassianUserId,
+				);
+				const mockFileNodesResponse = generateGetFileNodesResponse();
+
+				mockMeEndpoint({ success: true, times: 2 });
+				mockGetFileNodesEndpoint({
+					accessToken: credentials?.accessToken,
+					response: mockFileNodesResponse,
+				});
+				mockGetIssueEndpoint();
+				mockSubmitDesignsEndpoint();
+				mockGetDevResourcesEndpoint();
+				mockDeleteDevResourcesEndpoint({ success: false });
+
+				return request(app)
+					.post(endpoints.DISASSOCIATE_ENTITY)
+					.send(MOCK_DISASSOCIATE_REQUEST)
+					.set('Authorization', DISASSOCIATE_JWT_TOKEN)
 					.set('Content-Type', 'application/json')
 					.set('User-Id', validCredentialsParams.atlassianUserId)
 					.expect(HttpStatusCode.InternalServerError);

--- a/src/web/routes/entities/integration.test.ts
+++ b/src/web/routes/entities/integration.test.ts
@@ -3,6 +3,11 @@ import nock from 'nock';
 import request from 'supertest';
 import { v4 as uuidv4 } from 'uuid';
 
+import type {
+	AssociateEntityRequestParams,
+	DisassociateEntityRequestParams,
+} from './types';
+
 import app from '../../../app';
 import { JIRA_ISSUE_ATI } from '../../../common/constants';
 import { getConfig } from '../../../config';
@@ -31,11 +36,6 @@ import {
 	connectInstallationRepository,
 	figmaOAuth2UserCredentialsRepository,
 } from '../../../infrastructure/repositories';
-
-import type {
-	AssociateEntityRequestParams,
-	DisassociateEntityRequestParams,
-} from '.';
 
 const MOCK_CLIENT_KEY = '4561b8be-e38b-43d4-84d9-f09e8195d117';
 const MOCK_SHARED_SECRET = '903b6b9e-b82b-48ea-a9b2-40b9e700df32';

--- a/src/web/routes/entities/types.ts
+++ b/src/web/routes/entities/types.ts
@@ -1,0 +1,30 @@
+import type { Response } from 'express';
+
+import type {
+	AtlassianDesign,
+	ConnectInstallation,
+} from '../../../domain/entities';
+import type {
+	AssociateEntityUseCaseParams,
+	DisassociateEntityUseCaseParams,
+} from '../../../usecases';
+
+export type AssociateEntityRequestParams = Omit<
+	AssociateEntityUseCaseParams,
+	'atlassianUserId' | 'connectInstallation'
+>;
+
+export type AssociateEntityResponse = Response<
+	{ design: AtlassianDesign } | string,
+	{ connectInstallation: ConnectInstallation }
+>;
+
+export type DisassociateEntityRequestParams = Omit<
+	DisassociateEntityUseCaseParams,
+	'atlassianUserId' | 'connectInstallation'
+>;
+
+export type DisassociateEntityResponse = Response<
+	{ design: AtlassianDesign } | string,
+	{ connectInstallation: ConnectInstallation }
+>;


### PR DESCRIPTION
This PR is currently inclusive of changes in https://github.com/atlassian-labs/figma-for-jira/pull/55 which should be merged first.

## Changes in this PR
* Added an `/entities/disassociateEntity` route and use case to handle disassociating Jira issues from Figma designs
* Standardised how ids are generated for `AtlassianDesign` entities. What's stored will always be a composite of `{fileKey}/{nodeId}`
* Consolidated `associateWith` and `disassociateFrom` types into a single `AtlassianEntity` type