### PR TITLE
Add script to create JWTs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,8 @@ ATLASSIAN_URL=
 JIRA_ADMIN_EMAIL=
 # Create a new API token in Jira [https://id.atlassian.com/manage-profile/security/api-tokens]
 JIRA_ADMIN_API_TOKEN=
+
+
+# Below variables are only required for the create jwt script. Get these values from the app database
+INSTALLATION_CLIENT_KEY=
+INSTALLATION_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -88,6 +88,28 @@ the following steps:
 - Click Upload.
 - That's it! You're done. 🎉
 
+## Generating JWTs for local testing
+
+Endpoints that are called by Jira use `authHeaderSymmetricJwtMiddleware` which expects a JWT Authorization header that will be verified against a `ConnectInstallation`.
+
+Because the JWT contains a query string hash `qsh`, you will require a unique JWT token **for each endpoint** you want to test.
+
+See [Understanding JWT for Connect apps](https://developer.atlassian.com/cloud/jira/platform/understanding-jwt-for-connect-apps/) for more details.
+
+**Steps to generate a JWT:**
+
+1. Ensure you have the app and database running, and have installed the app on a Jira instance
+2. Enter values for `INSTALLATION_CLIENT_KEY` and `INSTALLATION_CLIENT_SECRET` in your `.env` file. You can find these values by inspecting the `ConnectInstallation` table of your database.
+3. Run the `npm run jwt:generate <request_method> <url>` script for each endpoint you need to test
+
+**Example:**
+
+```
+npm run jwt:generate POST http://localhost:3000/entities/associateEntity
+```
+
+You can then use this value as the `Authorization` header for your cURL / Postman / Insomnia requests.
+
 ## Database
 
 This repository uses [Prisma](https://www.prisma.io/) as an ORM for interacting with a Postgres database.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"db:migrate": "prisma migrate dev",
 		"db:reset:dev": "prisma migrate reset",
 		"db:reset:test": "dotenv -e .env.test -- prisma migrate reset -f",
+		"jwt:generate": "dotenv -e .env -- ts-node ./scripts/create-jwt.ts",
 		"format": "prettier . --write",
 		"format:check": "prettier . --check",
 		"jira:installApp": "./scripts/app-install.sh",

--- a/scripts/create-jwt.ts
+++ b/scripts/create-jwt.ts
@@ -1,0 +1,23 @@
+import { createJwtToken } from '../src/infrastructure/jira/jira-client/jwt-utils';
+import { Duration } from '../src/common/duration';
+
+const { INSTALLATION_CLIENT_KEY, INSTALLATION_CLIENT_SECRET } = process.env;
+
+if (!INSTALLATION_CLIENT_KEY || !INSTALLATION_CLIENT_SECRET) {
+	throw new Error('Missing required environment variables');
+}
+
+const method = process.argv[2];
+const url = new URL(process.argv[3]);
+
+const jwt = createJwtToken({
+	request: {
+		method,
+		pathname: url.pathname,
+	},
+	connectClientKey: INSTALLATION_CLIENT_KEY,
+	connectSharedSecret: INSTALLATION_CLIENT_SECRET,
+	expiresIn: Duration.ofMinutes(99999),
+});
+
+console.log(`JWT ${jwt}`);

--- a/src/infrastructure/jira/jira-client/jira-client.ts
+++ b/src/infrastructure/jira/jira-client/jira-client.ts
@@ -171,7 +171,7 @@ class JiraClient {
 		url: URL,
 		method: Method,
 		{
-			key: connectAppKey,
+			key: connectClientKey,
 			sharedSecret: connectSharedSecret,
 		}: ConnectInstallation,
 	) {
@@ -181,7 +181,7 @@ class JiraClient {
 				pathname: url.pathname,
 			},
 			expiresIn: TOKEN_EXPIRES_IN,
-			connectAppKey,
+			connectClientKey,
 			connectSharedSecret,
 		});
 		return `JWT ${jwtToken}`;

--- a/src/infrastructure/jira/jira-client/jwt-utils.test.ts
+++ b/src/infrastructure/jira/jira-client/jwt-utils.test.ts
@@ -28,7 +28,7 @@ describe('createJwtToken', () => {
 		expect(decodedToken).toEqual({
 			iat: Math.floor(now / 1000),
 			exp: Math.floor(now / 1000) + MOCK_JWT_TOKEN_PARAMS.expiresIn.asSeconds,
-			iss: MOCK_JWT_TOKEN_PARAMS.connectAppKey,
+			iss: MOCK_JWT_TOKEN_PARAMS.connectClientKey,
 			qsh: createQueryStringHash(MOCK_JWT_TOKEN_PARAMS.request),
 		});
 	});

--- a/src/infrastructure/jira/jira-client/jwt-utils.ts
+++ b/src/infrastructure/jira/jira-client/jwt-utils.ts
@@ -9,7 +9,7 @@ export type JwtTokenParams = {
 		readonly query?: Record<string, unknown>;
 		readonly body?: Record<string, unknown>;
 	};
-	readonly connectAppKey: string;
+	readonly connectClientKey: string;
 	readonly connectSharedSecret: string;
 	readonly expiresIn: Duration;
 };
@@ -25,7 +25,7 @@ export const createJwtToken = (params: JwtTokenParams): string => {
 		{
 			iat: nowInSeconds,
 			exp: nowInSeconds + params.expiresIn.asSeconds,
-			iss: params.connectAppKey,
+			iss: params.connectClientKey,
 			qsh: createQueryStringHash(params.request),
 		},
 		params.connectSharedSecret,

--- a/src/infrastructure/jira/jira-client/testing/mocks.ts
+++ b/src/infrastructure/jira/jira-client/testing/mocks.ts
@@ -17,7 +17,7 @@ export const MOCK_JWT_TOKEN_PARAMS: JwtTokenParams = {
 			param1: uuidv4,
 		},
 	},
-	connectAppKey: uuidv4(),
+	connectClientKey: uuidv4(),
 	connectSharedSecret: uuidv4(),
 	expiresIn: Duration.ofMinutes(10),
 };


### PR DESCRIPTION
Generating JWTs for local testing is pretty cumbersome. Added a new `npm run jwt:generate <request_method> <url>` script and new `.env` variables to streamline this a bit.