### PR TITLE
Remove handling of prototype urls

### DIFF
--- a/src/infrastructure/figma/figma-service.test.ts
+++ b/src/infrastructure/figma/figma-service.test.ts
@@ -159,7 +159,6 @@ describe('FigmaService', () => {
 			const expectedEntity = transformNodeToAtlassianDesign({
 				fileKey: MOCK_FILE_KEY,
 				nodeId: MOCK_NODE_ID,
-				isPrototype: false,
 				fileNodesResponse: mockResponse,
 			});
 
@@ -188,7 +187,6 @@ describe('FigmaService', () => {
 
 			const expectedEntity = transformFileToAtlassianDesign({
 				fileKey: MOCK_FILE_KEY,
-				isPrototype: false,
 				fileResponse: mockResponse,
 			});
 

--- a/src/infrastructure/figma/figma-service.ts
+++ b/src/infrastructure/figma/figma-service.ts
@@ -64,8 +64,7 @@ export class FigmaService {
 		url: string,
 		atlassianUserId: string,
 	): Promise<AtlassianDesign> => {
-		const { fileKey, nodeId, isPrototype } =
-			extractDataFromFigmaUrlOrThrow(url);
+		const { fileKey, nodeId } = extractDataFromFigmaUrlOrThrow(url);
 
 		const credentials = await this.getValidCredentialsOrThrow(atlassianUserId);
 
@@ -80,14 +79,12 @@ export class FigmaService {
 			return transformNodeToAtlassianDesign({
 				fileKey,
 				nodeId,
-				isPrototype,
 				fileNodesResponse,
 			});
 		} else {
 			const fileResponse = await figmaClient.getFile(fileKey, accessToken);
 			return transformFileToAtlassianDesign({
 				fileKey,
-				isPrototype,
 				fileResponse,
 			});
 		}
@@ -112,14 +109,12 @@ export class FigmaService {
 			return transformNodeToAtlassianDesign({
 				fileKey,
 				nodeId,
-				isPrototype: false,
 				fileNodesResponse,
 			});
 		} else {
 			const fileResponse = await figmaClient.getFile(fileKey, accessToken);
 			return transformFileToAtlassianDesign({
 				fileKey,
-				isPrototype: false,
 				fileResponse,
 			});
 		}

--- a/src/infrastructure/figma/figma-transformer.test.ts
+++ b/src/infrastructure/figma/figma-transformer.test.ts
@@ -19,7 +19,6 @@ import {
 	MOCK_INVALID_DESIGN_URL,
 	MOCK_NODE_ID,
 	MOCK_NODE_ID_URL,
-	MOCK_PROTOTYPE_URL,
 } from './testing';
 
 import * as configModule from '../../config';
@@ -45,26 +44,17 @@ describe('FigmaTransformer', () => {
 		jest.restoreAllMocks();
 	});
 	describe('extractDataFromFigmaUrl', () => {
-		it('should return only fileKey and isPrototype if node_id is not provided in the url', () => {
+		it('should return only fileKey if node_id is not provided in the url', () => {
 			expect(
 				extractDataFromFigmaUrl(MOCK_DESIGN_URL_WITHOUT_NODE),
 			).toStrictEqual({
 				fileKey: MOCK_FILE_KEY,
-				isPrototype: false,
 			});
 		});
-		it('should return fileKey, nodeId and isPrototype if both fileKey and nodeId are present in the url', () => {
+		it('should return fileKey and nodeId if both fileKey and nodeId are present in the url', () => {
 			expect(extractDataFromFigmaUrl(MOCK_DESIGN_URL_WITH_NODE)).toStrictEqual({
 				fileKey: MOCK_FILE_KEY,
 				nodeId: MOCK_NODE_ID,
-				isPrototype: false,
-			});
-		});
-		it('should return `isPrototype: true` if the url is for a prototype', () => {
-			expect(extractDataFromFigmaUrl(MOCK_PROTOTYPE_URL)).toStrictEqual({
-				fileKey: MOCK_FILE_KEY,
-				nodeId: MOCK_NODE_ID,
-				isPrototype: true,
 			});
 		});
 		it('should return null for an invalid url', () => {
@@ -104,19 +94,15 @@ describe('FigmaTransformer', () => {
 
 	describe('mapNodeTypeToDesignType', () => {
 		it.each([
-			[AtlassianDesignType.PROTOTYPE, 'FRAME', true],
-			[AtlassianDesignType.FILE, 'DOCUMENT', false],
-			[AtlassianDesignType.CANVAS, 'CANVAS', false],
-			[AtlassianDesignType.GROUP, 'SECTION', false],
-			[AtlassianDesignType.GROUP, 'GROUP', false],
-			[AtlassianDesignType.NODE, 'FRAME', false],
-			[AtlassianDesignType.OTHER, 'SOMETHINGELSE', false],
-		])(
-			'should return %s if Figma type is %s and isPrototype is %s',
-			(expected, type, isPrototype) => {
-				expect(mapNodeTypeToDesignType(type, isPrototype)).toEqual(expected);
-			},
-		);
+			[AtlassianDesignType.FILE, 'DOCUMENT'],
+			[AtlassianDesignType.CANVAS, 'CANVAS'],
+			[AtlassianDesignType.GROUP, 'SECTION'],
+			[AtlassianDesignType.GROUP, 'GROUP'],
+			[AtlassianDesignType.NODE, 'FRAME'],
+			[AtlassianDesignType.OTHER, 'SOMETHINGELSE'],
+		])('should return %s if Figma type is %s', (expected, type) => {
+			expect(mapNodeTypeToDesignType(type)).toEqual(expected);
+		});
 	});
 
 	describe('transformNodeToAtlassianDesign', () => {
@@ -151,7 +137,6 @@ describe('FigmaTransformer', () => {
 			const result = transformNodeToAtlassianDesign({
 				fileKey: MOCK_FILE_KEY,
 				nodeId: MOCK_NODE_ID,
-				isPrototype: false,
 				fileNodesResponse: mockApiResponse,
 			});
 
@@ -185,7 +170,6 @@ describe('FigmaTransformer', () => {
 
 			const result = transformFileToAtlassianDesign({
 				fileKey: MOCK_FILE_KEY,
-				isPrototype: false,
 				fileResponse: mockApiResponse,
 			});
 

--- a/src/infrastructure/figma/testing/mocks.ts
+++ b/src/infrastructure/figma/testing/mocks.ts
@@ -12,7 +12,6 @@ import type {
 export const MOCK_NODE_ID_URL = '1-2';
 export const MOCK_FILE_KEY = '5BnX6YnPJOvOHRdiB0seWx';
 export const MOCK_FILE_NAME = 'Test-File';
-export const MOCK_PROTOTYPE_URL = `https://www.figma.com/proto/${MOCK_FILE_KEY}/${MOCK_FILE_NAME}?node-id=${MOCK_NODE_ID_URL}`;
 export const MOCK_DESIGN_URL_WITH_NODE = `https://www.figma.com/file/${MOCK_FILE_KEY}/${MOCK_FILE_NAME}?node-id=${MOCK_NODE_ID_URL}&mode=dev`;
 export const MOCK_DESIGN_URL_WITHOUT_NODE = `https://www.figma.com/file/${MOCK_FILE_KEY}/${MOCK_FILE_NAME}?mode=dev`;
 export const MOCK_INVALID_DESIGN_URL = 'https://www.figma.com';

--- a/src/web/routes/entities/integration.test.ts
+++ b/src/web/routes/entities/integration.test.ts
@@ -285,7 +285,6 @@ describe('/entities', () => {
 					design: transformNodeToAtlassianDesign({
 						fileKey: MOCK_FILE_KEY,
 						nodeId: MOCK_NODE_ID,
-						isPrototype: false,
 						fileNodesResponse: mockFileNodesResponse,
 					}),
 				};
@@ -321,7 +320,6 @@ describe('/entities', () => {
 					design: transformNodeToAtlassianDesign({
 						fileKey: MOCK_FILE_KEY,
 						nodeId: MOCK_NODE_ID,
-						isPrototype: false,
 						fileNodesResponse: mockFileNodesResponse,
 					}),
 				};


### PR DESCRIPTION
Prototypes are simply a view mode in Figma, similar to dev mode and design mode. Therefore it does not make sense for us to store `type: PROTOTYPE` for designs fetched by the GET file or GET file nodes endpoints. Removed all code relating to prototypes.