### PR TITLE
NONE Remove global unused mock check to fix test flakiness

### DIFF
--- a/scripts/setup-jest.ts
+++ b/scripts/setup-jest.ts
@@ -31,18 +31,10 @@ afterEach(() => {
 });
 
 /**
- * After each test, check that we haven't overly mocked our endpoints.
+ * After each test, clean up nock mocks
  */
 afterEach(() => {
-	let unusedNockMocks: string[] = [];
-	if (!isDone()) {
-		unusedNockMocks = pendingMocks();
-	}
 	cleanAll();
-	if (unusedNockMocks.length > 0)
-		throw new Error(
-			`Endpoints mocked with nock were unused:\n${unusedNockMocks.join('\n')}`,
-		);
 });
 
 /**


### PR DESCRIPTION
This was causing flakiness in our integration tests that expect an error from a Promise.all call. If multiple endpoints inside a Promise.all call are mocked, there's no guarantee that all of the mocks will be hit if one of the Promises rejects, since Promise.all immediately halts execution on a single rejection.