### PR TITLE
MDTZ-1017: Remove `AssociatedFigmaDesign` record on `/disassociateEntity` request

### DIFF
--- a/.runconfigs/Integration Tests.run.xml
+++ b/.runconfigs/Integration Tests.run.xml
@@ -1,0 +1,14 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Integration Tests" type="JavaScriptTestRunnerJest">
+    <config-file value="$PROJECT_DIR$/jest.config.integration.ts" />
+    <node-interpreter value="project" />
+    <jest-package value="$PROJECT_DIR$/node_modules/jest" />
+    <working-dir value="$PROJECT_DIR$" />
+    <jest-options value="--runInBand" />
+    <envs>
+      <env name="DOTENV_CONFIG_PATH" value=".env.test" />
+    </envs>
+    <scope-kind value="ALL" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.runconfigs/Unit Tests.run.xml
+++ b/.runconfigs/Unit Tests.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Unit Tests" type="JavaScriptTestRunnerJest">
+    <config-file value="$PROJECT_DIR$/jest.config.unit.ts" />
+    <node-interpreter value="project" />
+    <jest-package value="$PROJECT_DIR$/node_modules/jest" />
+    <working-dir value="$PROJECT_DIR$" />
+    <envs />
+    <scope-kind value="ALL" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/jest.config.integration.ts
+++ b/jest.config.integration.ts
@@ -3,6 +3,7 @@ import baseConfig from './jest.config';
 
 const config: Config = {
 	...baseConfig,
+	setupFilesAfterEnv: ['<rootDir>/scripts/setup-jest-integration-tests.ts'],
 	testRegex: '(\\.|/)integration\\.test.tsx?$',
 };
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,7 +8,6 @@ const config: Config = {
 	roots: ['<rootDir>/src'],
 	testRegex: '(\\.|/)(test|spec)\\.tsx?$',
 	setupFiles: ['dotenv-expand/config'],
-	setupFilesAfterEnv: ['<rootDir>/scripts/setup-jest.ts'],
 	clearMocks: true,
 };
 

--- a/prisma/migrations/20230922041702_initial/migration.sql
+++ b/prisma/migrations/20230922041702_initial/migration.sql
@@ -18,6 +18,7 @@ CREATE TABLE "associated_figma_design" (
     "id" SERIAL NOT NULL,
     "file_key" TEXT NOT NULL,
     "node_id" TEXT NOT NULL,
+    "associated-with-ari" TEXT NOT NULL,
     "connect_installation_id" INTEGER NOT NULL,
 
     CONSTRAINT "associated_figma_design_pkey" PRIMARY KEY ("id")
@@ -51,7 +52,7 @@ CREATE TABLE "figma_team" (
 CREATE UNIQUE INDEX "connect_installation_client_key_key" ON "connect_installation"("client_key");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "associated_figma_design_file_key_node_id_connect_installati_key" ON "associated_figma_design"("file_key", "node_id", "connect_installation_id");
+CREATE UNIQUE INDEX "associated_figma_design_file_key_node_id_associated-with-ar_key" ON "associated_figma_design"("file_key", "node_id", "associated-with-ari", "connect_installation_id");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "figma_oauth2_user_credentials_atlassian_user_id_key" ON "figma_oauth2_user_credentials"("atlassian_user_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,16 +21,15 @@ model ConnectInstallation {
 }
 
 model AssociatedFigmaDesign {
-  id      Int    @id @default(autoincrement())
-  fileKey String @map("file_key")
-  // Prisma does not support nullable columns with the composite indexes
-  // https://github.com/prisma/prisma/issues/3197
-  nodeId  String @map("node_id")
+  id                    Int                 @id @default(autoincrement())
+  fileKey               String              @map("file_key")
+  nodeId                String              @map("node_id") // Prisma does not support nullable columns with the composite indexes: https://github.com/prisma/prisma/issues/3197
+  associatedWithAri     String              @map("associated-with-ari")
 
   connectInstallation   ConnectInstallation @relation(fields: [connectInstallationId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   connectInstallationId Int                 @map("connect_installation_id")
 
-  @@unique([fileKey, nodeId, connectInstallationId])
+  @@unique([fileKey, nodeId, associatedWithAri, connectInstallationId])
   @@map("associated_figma_design")
 }
 
@@ -56,12 +55,11 @@ model FigmaTeam {
   webhookId                 String              @unique @map("webhook_id")
   teamId                    String              @map("team_id")
   teamName                  String              @map("team_name")
-  // Atlassian user ID of the Figma team admin that configured the webhook
-  figmaAdminAtlassianUserId String              @map("figma_admin_atlassian_user_id")
+  figmaAdminAtlassianUserId String              @map("figma_admin_atlassian_user_id") // Atlassian user ID of the Figma team admin that configured the webhook
   authStatus                FigmaTeamAuthStatus
 
-  connectInstallation   ConnectInstallation @relation(fields: [connectInstallationId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  connectInstallationId Int                 @map("connect_installation_id")
+  connectInstallation       ConnectInstallation @relation(fields: [connectInstallationId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  connectInstallationId     Int                 @map("connect_installation_id")
 
   @@unique([teamId, connectInstallationId])
   @@map("figma_team")

--- a/scripts/setup-jest-integration-tests.ts
+++ b/scripts/setup-jest-integration-tests.ts
@@ -13,6 +13,13 @@ beforeAll(() => {
 	});
 });
 
+beforeEach(async () => {
+	await prismaClient.get().associatedFigmaDesign.deleteMany({});
+	await prismaClient.get().figmaTeam.deleteMany({});
+	await prismaClient.get().figmaOAuth2UserCredentials.deleteMany({});
+	await prismaClient.get().connectInstallation.deleteMany({});
+});
+
 /**
  *  After each test, check for requests that went through
  *  without being mocked by nock.
@@ -28,13 +35,6 @@ afterEach(() => {
 		unmatchedRequests = [];
 		throw new Error(`${numberOfUnmatchedRequests} Unmatched Requests`);
 	}
-});
-
-beforeEach(async () => {
-	await prismaClient.get().associatedFigmaDesign.deleteMany({});
-	await prismaClient.get().figmaTeam.deleteMany({});
-	await prismaClient.get().figmaOAuth2UserCredentials.deleteMany({});
-	await prismaClient.get().connectInstallation.deleteMany({});
 });
 
 /**

--- a/scripts/setup-jest-integration-tests.ts
+++ b/scripts/setup-jest-integration-tests.ts
@@ -30,11 +30,11 @@ afterEach(() => {
 	}
 });
 
-beforeEach(() => {
-	prismaClient.get().associatedFigmaDesign.deleteMany({});
-	prismaClient.get().figmaTeam.deleteMany({});
-	prismaClient.get().figmaOAuth2UserCredentials.deleteMany({});
-	prismaClient.get().connectInstallation.deleteMany({});
+beforeEach(async () => {
+	await prismaClient.get().associatedFigmaDesign.deleteMany({});
+	await prismaClient.get().figmaTeam.deleteMany({});
+	await prismaClient.get().figmaOAuth2UserCredentials.deleteMany({});
+	await prismaClient.get().connectInstallation.deleteMany({});
 });
 
 /**

--- a/scripts/setup-jest.ts
+++ b/scripts/setup-jest.ts
@@ -30,6 +30,13 @@ afterEach(() => {
 	}
 });
 
+beforeEach(() => {
+	prismaClient.get().associatedFigmaDesign.deleteMany({});
+	prismaClient.get().figmaTeam.deleteMany({});
+	prismaClient.get().figmaOAuth2UserCredentials.deleteMany({});
+	prismaClient.get().connectInstallation.deleteMany({});
+});
+
 /**
  * After each test, clean up nock mocks
  */

--- a/src/domain/entities/associated-figma-design.ts
+++ b/src/domain/entities/associated-figma-design.ts
@@ -3,6 +3,10 @@ import type { FigmaDesignIdentifier } from './figma-design-identifier';
 export type AssociatedFigmaDesign = {
 	readonly id: number;
 	readonly designId: FigmaDesignIdentifier;
+	/**
+	 * An Atlassian Resource Identifier (ARI) of a target entity.
+	 */
+	readonly associatedWithAri: string;
 	readonly connectInstallationId: number;
 };
 

--- a/src/domain/entities/testing/mocks.ts
+++ b/src/domain/entities/testing/mocks.ts
@@ -63,7 +63,7 @@ export const generateFigmaDesignUrl = ({
 };
 
 export const generateFigmaOAuth2UserCredentials = ({
-	id = Date.now(),
+	id = getRandomInt(1, 10000),
 	atlassianUserId = uuidv4(),
 	accessToken = uuidv4(),
 	refreshToken = uuidv4(),
@@ -149,8 +149,9 @@ export const generateJiraIssueUrl = ({
 } = {}) => new URL(`/browse/${key}`, baseUrl).toString();
 
 export const generateJiraIssueAri = ({
+	cloudId = uuidv4(),
 	issueId = generateJiraIssueId(),
-} = {}) => `ari:cloud:jira:${uuidv4()}:issue/${issueId}`;
+} = {}) => `ari:cloud:jira:${cloudId}:issue/${issueId}`;
 
 export const generateJiraIssue = ({
 	id = generateJiraIssueId(),

--- a/src/domain/entities/testing/mocks.ts
+++ b/src/domain/entities/testing/mocks.ts
@@ -148,8 +148,9 @@ export const generateJiraIssueUrl = ({
 	key = generateJiraIssueKey(),
 } = {}) => new URL(`/browse/${key}`, baseUrl).toString();
 
-export const generateJiraIssueAri = (issueId = generateJiraIssueId()) =>
-	`ari:cloud:jira:${uuidv4()}:issue/${issueId}`;
+export const generateJiraIssueAri = ({
+	issueId = generateJiraIssueId(),
+} = {}) => `ari:cloud:jira:${uuidv4()}:issue/${issueId}`;
 
 export const generateJiraIssue = ({
 	id = generateJiraIssueId(),
@@ -167,19 +168,23 @@ export const generateJiraIssue = ({
 
 export const generateAssociatedFigmaDesignCreateParams = ({
 	designId = generateFigmaDesignIdentifier(),
+	associatedWithAri = generateJiraIssueAri(),
 	connectInstallationId = getRandomInt(1, 100000),
 }: Partial<AssociatedFigmaDesignCreateParams> = {}): AssociatedFigmaDesignCreateParams => ({
 	designId,
+	associatedWithAri,
 	connectInstallationId,
 });
 
 export const generateAssociatedFigmaDesign = ({
 	id = getRandomInt(1, 100000),
 	designId = generateFigmaDesignIdentifier(),
+	associatedWithAri = generateJiraIssueAri(),
 	connectInstallationId = getRandomInt(1, 100000),
 }: Partial<AssociatedFigmaDesign> = {}): AssociatedFigmaDesign => ({
 	id,
 	designId,
+	associatedWithAri,
 	connectInstallationId,
 });
 

--- a/src/infrastructure/figma/figma-service.ts
+++ b/src/infrastructure/figma/figma-service.ts
@@ -2,10 +2,7 @@ import { AxiosError, HttpStatusCode } from 'axios';
 
 import { FigmaServiceCredentialsError } from './errors';
 import { figmaAuthService } from './figma-auth-service';
-import type {
-	CreateDevResourcesRequest,
-	CreateDevResourcesResponse,
-} from './figma-client';
+import type { CreateDevResourcesRequest } from './figma-client';
 import { figmaClient } from './figma-client';
 import {
 	transformFileToAtlassianDesign,
@@ -96,7 +93,7 @@ export class FigmaService {
 		issueKey: string;
 		issueTitle: string;
 		atlassianUserId: string;
-	}): Promise<CreateDevResourcesResponse> => {
+	}): Promise<void> => {
 		const credentials = await this.getValidCredentialsOrThrow(atlassianUserId);
 
 		const { accessToken } = credentials;
@@ -119,8 +116,6 @@ export class FigmaService {
 				'Created dev resources with errors',
 			);
 		}
-
-		return response;
 	};
 
 	deleteDevResourceIfExists = async ({
@@ -153,7 +148,7 @@ export class FigmaService {
 			return;
 		}
 
-		return await figmaClient.deleteDevResource({
+		await figmaClient.deleteDevResource({
 			fileKey: designId.fileKey,
 			devResourceId: devResourceToDelete.id,
 			accessToken,

--- a/src/infrastructure/repositories/associated-figma-design-repository.integration.test.ts
+++ b/src/infrastructure/repositories/associated-figma-design-repository.integration.test.ts
@@ -1,0 +1,87 @@
+import { associatedFigmaDesignRepository } from './associated-figma-design-repository';
+import { connectInstallationRepository } from './connect-installation-repository';
+
+import {
+	generateAssociatedFigmaDesign,
+	generateAssociatedFigmaDesignCreateParams,
+	generateConnectInstallationCreateParams,
+} from '../../domain/entities/testing';
+
+describe('AssociatedFigmaDesignRepository', () => {
+	describe('deleteByDesignIdAndAssociatedWithAriAndConnectInstallationId', () => {
+		it('should delete target entity', async () => {
+			const connectInstallation = await connectInstallationRepository.upsert(
+				generateConnectInstallationCreateParams(),
+			);
+			const [entity1, entity2, entity3] = await Promise.all([
+				associatedFigmaDesignRepository.upsert(
+					generateAssociatedFigmaDesignCreateParams({
+						connectInstallationId: connectInstallation.id,
+					}),
+				),
+				associatedFigmaDesignRepository.upsert(
+					generateAssociatedFigmaDesignCreateParams({
+						connectInstallationId: connectInstallation.id,
+					}),
+				),
+				associatedFigmaDesignRepository.upsert(
+					generateAssociatedFigmaDesignCreateParams({
+						connectInstallationId: connectInstallation.id,
+					}),
+				),
+			]);
+
+			const result =
+				await associatedFigmaDesignRepository.deleteByDesignIdAndAssociatedWithAriAndConnectInstallationId(
+					entity1.designId,
+					entity1.associatedWithAri,
+					entity1.connectInstallationId,
+				);
+
+			expect(result).toEqual(entity1);
+			expect(
+				await associatedFigmaDesignRepository.find(entity1.id),
+			).toBeFalsy();
+			expect(
+				await associatedFigmaDesignRepository.find(entity2.id),
+			).toBeTruthy();
+			expect(
+				await associatedFigmaDesignRepository.find(entity3.id),
+			).toBeTruthy();
+		});
+
+		it('should return null if target entity does not exist', async () => {
+			const nonExistingEntity = generateAssociatedFigmaDesign();
+			const connectInstallation = await connectInstallationRepository.upsert(
+				generateConnectInstallationCreateParams(),
+			);
+			const [entity1, entity2] = await Promise.all([
+				associatedFigmaDesignRepository.upsert(
+					generateAssociatedFigmaDesignCreateParams({
+						connectInstallationId: connectInstallation.id,
+					}),
+				),
+				associatedFigmaDesignRepository.upsert(
+					generateAssociatedFigmaDesignCreateParams({
+						connectInstallationId: connectInstallation.id,
+					}),
+				),
+			]);
+
+			const result =
+				await associatedFigmaDesignRepository.deleteByDesignIdAndAssociatedWithAriAndConnectInstallationId(
+					nonExistingEntity.designId,
+					nonExistingEntity.associatedWithAri,
+					nonExistingEntity.connectInstallationId,
+				);
+
+			expect(result).toBeNull();
+			expect(
+				await associatedFigmaDesignRepository.find(entity1.id),
+			).toBeTruthy();
+			expect(
+				await associatedFigmaDesignRepository.find(entity2.id),
+			).toBeTruthy();
+		});
+	});
+});

--- a/src/infrastructure/repositories/associated-figma-design-repository.ts
+++ b/src/infrastructure/repositories/associated-figma-design-repository.ts
@@ -36,6 +36,22 @@ export class AssociatedFigmaDesignRepository {
 		return this.mapToDomainModel(record);
 	};
 
+	/**
+	 * @remarks
+	 * Required for tests only.
+	 */
+	find = async (id: number): Promise<AssociatedFigmaDesign | null> => {
+		const record = await prismaClient.get().associatedFigmaDesign.findFirst({
+			where: {
+				id,
+			},
+		});
+
+		if (record === null) return null;
+
+		return this.mapToDomainModel(record);
+	};
+
 	findManyByFileKeyAndConnectInstallationId = async (
 		fileKey: string,
 		connectInstallationId: number,
@@ -47,6 +63,10 @@ export class AssociatedFigmaDesignRepository {
 		return records.map(this.mapToDomainModel);
 	};
 
+	/**
+	 * @remarks
+	 * Required for integration tests only.
+	 */
 	findByDesignIdAndAssociatedWithAriAndConnectInstallationId = async (
 		designId: FigmaDesignIdentifier,
 		associatedWithAri: string,
@@ -70,7 +90,7 @@ export class AssociatedFigmaDesignRepository {
 		designId: FigmaDesignIdentifier,
 		associatedWithAri: string,
 		connectInstallationId: number,
-	): Promise<AssociatedFigmaDesign | undefined> => {
+	): Promise<AssociatedFigmaDesign | null> => {
 		try {
 			const record = await prismaClient.get().associatedFigmaDesign.delete({
 				where: {
@@ -89,7 +109,7 @@ export class AssociatedFigmaDesignRepository {
 				e instanceof PrismaClientKnownRequestError &&
 				e.code === PrismaErrorCode.RecordNotFound
 			) {
-				return;
+				return null;
 			}
 			throw e;
 		}

--- a/src/infrastructure/repositories/associated-figma-design-repository.ts
+++ b/src/infrastructure/repositories/associated-figma-design-repository.ts
@@ -2,7 +2,6 @@ import type { AssociatedFigmaDesign as PrismaAssociatedFigmaDesign } from '@pris
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 
 import { PrismaErrorCode } from './constants';
-import { RepositoryRecordNotFoundError } from './errors';
 import { prismaClient } from './prisma-client';
 
 import type {
@@ -50,7 +49,7 @@ export class AssociatedFigmaDesignRepository {
 	deleteByDesignIdAndConnectInstallationId = async (
 		designId: FigmaDesignIdentifier,
 		connectInstallationId: number,
-	): Promise<AssociatedFigmaDesign> => {
+	): Promise<AssociatedFigmaDesign | undefined> => {
 		try {
 			const result = await prismaClient.get().associatedFigmaDesign.delete({
 				where: {
@@ -68,7 +67,7 @@ export class AssociatedFigmaDesignRepository {
 				e instanceof PrismaClientKnownRequestError &&
 				e.code === PrismaErrorCode.RecordNotFound
 			) {
-				throw new RepositoryRecordNotFoundError(e.message);
+				return;
 			}
 			throw e;
 		}

--- a/src/usecases/associate-entity-use-case.test.ts
+++ b/src/usecases/associate-entity-use-case.test.ts
@@ -1,0 +1,115 @@
+import type { AssociateEntityUseCaseParams } from './associate-entity-use-case';
+import { associateEntityUseCase } from './associate-entity-use-case';
+import { generateAssociateEntityUseCaseParams } from './testing';
+
+import type { AssociatedFigmaDesign } from '../domain/entities';
+import {
+	AtlassianAssociation,
+	FigmaDesignIdentifier,
+} from '../domain/entities';
+import {
+	generateAtlassianDesign,
+	generateConnectInstallation,
+	generateFigmaDesignUrl,
+	generateFigmaFileKey,
+	generateJiraIssue,
+} from '../domain/entities/testing';
+import { figmaService } from '../infrastructure/figma';
+import { jiraService } from '../infrastructure/jira';
+import { associatedFigmaDesignRepository } from '../infrastructure/repositories';
+
+describe('associateEntityUseCase', () => {
+	it('should associate design to issue', async () => {
+		const connectInstallation = generateConnectInstallation();
+		const issue = generateJiraIssue();
+		const fileKey = generateFigmaFileKey();
+		const designId = new FigmaDesignIdentifier(fileKey);
+		const atlassianDesign = generateAtlassianDesign({
+			id: designId.toAtlassianDesignId(),
+		});
+		const params: AssociateEntityUseCaseParams =
+			generateAssociateEntityUseCaseParams({
+				entityUrl: generateFigmaDesignUrl({ fileKey }),
+				issueId: issue.id,
+				connectInstallation,
+			});
+		jest
+			.spyOn(figmaService, 'fetchDesignById')
+			.mockResolvedValue(atlassianDesign);
+		jest.spyOn(jiraService, 'getIssue').mockResolvedValue(issue);
+		jest.spyOn(jiraService, 'submitDesign').mockResolvedValue();
+		jest
+			.spyOn(jiraService, 'saveDesignUrlInIssueProperties')
+			.mockResolvedValue();
+		jest.spyOn(figmaService, 'createDevResource').mockResolvedValue();
+		jest
+			.spyOn(associatedFigmaDesignRepository, 'upsert')
+			.mockResolvedValue({} as AssociatedFigmaDesign);
+
+		await associateEntityUseCase.execute(params);
+
+		expect(figmaService.fetchDesignById).toHaveBeenCalledWith(
+			designId,
+			params.atlassianUserId,
+		);
+		expect(jiraService.submitDesign).toHaveBeenCalledWith(
+			{
+				design: atlassianDesign,
+				addAssociations: [
+					AtlassianAssociation.createDesignIssueAssociation(
+						params.associateWith.ari,
+					),
+				],
+			},
+			connectInstallation,
+		);
+		expect(jiraService.saveDesignUrlInIssueProperties).toHaveBeenCalledWith(
+			issue.id,
+			atlassianDesign,
+			connectInstallation,
+		);
+		expect(figmaService.createDevResource).toHaveBeenCalledWith({
+			designId,
+			issueKey: issue.key,
+			issueTitle: issue.fields.summary,
+			issueUrl: `${connectInstallation.baseUrl}/browse/${issue.key}`,
+			atlassianUserId: params.atlassianUserId,
+		});
+		expect(associatedFigmaDesignRepository.upsert).toHaveBeenCalledWith({
+			designId,
+			associatedWithAri: params.associateWith.ari,
+			connectInstallationId: connectInstallation.id,
+		});
+	});
+
+	it('should not save associated Figma design when design submission fails', async () => {
+		const connectInstallation = generateConnectInstallation();
+		const issue = generateJiraIssue();
+		const fileKey = generateFigmaFileKey();
+		const designId = new FigmaDesignIdentifier(fileKey);
+		const atlassianDesign = generateAtlassianDesign({
+			id: designId.toAtlassianDesignId(),
+		});
+		const params: AssociateEntityUseCaseParams =
+			generateAssociateEntityUseCaseParams({
+				entityUrl: generateFigmaDesignUrl({ fileKey }),
+				issueId: issue.id,
+				connectInstallation,
+			});
+		jest
+			.spyOn(figmaService, 'fetchDesignById')
+			.mockResolvedValue(atlassianDesign);
+		jest.spyOn(jiraService, 'getIssue').mockResolvedValue(issue);
+		jest.spyOn(jiraService, 'submitDesign').mockRejectedValue(new Error());
+		jest
+			.spyOn(jiraService, 'saveDesignUrlInIssueProperties')
+			.mockResolvedValue();
+		jest.spyOn(figmaService, 'createDevResource').mockResolvedValue();
+		jest.spyOn(associatedFigmaDesignRepository, 'upsert');
+
+		await expect(() =>
+			associateEntityUseCase.execute(params),
+		).rejects.toThrow();
+		expect(associatedFigmaDesignRepository.upsert).not.toHaveBeenCalled();
+	});
+});

--- a/src/usecases/associate-entity-use-case.ts
+++ b/src/usecases/associate-entity-use-case.ts
@@ -61,6 +61,7 @@ export const associateEntityUseCase = {
 
 		await associatedFigmaDesignRepository.upsert({
 			designId: figmaDesignId,
+			associatedWithAri: associateWith.ari,
 			connectInstallationId: connectInstallation.id,
 		});
 

--- a/src/usecases/disassociate-entity-use-case.test.ts
+++ b/src/usecases/disassociate-entity-use-case.test.ts
@@ -1,0 +1,113 @@
+import type { DisassociateEntityUseCaseParams } from './disassociate-entity-use-case';
+import { disassociateEntityUseCase } from './disassociate-entity-use-case';
+import { generateDisassociateEntityUseCaseParams } from './testing';
+
+import { AtlassianAssociation } from '../domain/entities';
+import {
+	generateAtlassianDesign,
+	generateConnectInstallation,
+	generateFigmaDesignIdentifier,
+	generateJiraIssue,
+} from '../domain/entities/testing';
+import { figmaService } from '../infrastructure/figma';
+import { jiraService } from '../infrastructure/jira';
+import { associatedFigmaDesignRepository } from '../infrastructure/repositories';
+
+describe('disassociateEntityUseCase', () => {
+	it('should disassociate design from issue', async () => {
+		const connectInstallation = generateConnectInstallation();
+		const issue = generateJiraIssue();
+		const designId = generateFigmaDesignIdentifier();
+		const atlassianDesign = generateAtlassianDesign({
+			id: designId.toAtlassianDesignId(),
+		});
+		const params: DisassociateEntityUseCaseParams =
+			generateDisassociateEntityUseCaseParams({
+				entityId: atlassianDesign.id,
+				issueId: issue.id,
+				connectInstallation,
+			});
+		jest
+			.spyOn(figmaService, 'fetchDesignById')
+			.mockResolvedValue(atlassianDesign);
+		jest.spyOn(jiraService, 'getIssue').mockResolvedValue(issue);
+		jest.spyOn(jiraService, 'submitDesign').mockResolvedValue();
+		jest
+			.spyOn(jiraService, 'deleteDesignUrlInIssueProperties')
+			.mockResolvedValue();
+		jest.spyOn(figmaService, 'deleteDevResourceIfExists').mockResolvedValue();
+		jest
+			.spyOn(
+				associatedFigmaDesignRepository,
+				'deleteByDesignIdAndAssociatedWithAriAndConnectInstallationId',
+			)
+			.mockResolvedValue(undefined);
+
+		await disassociateEntityUseCase.execute(params);
+
+		expect(figmaService.fetchDesignById).toHaveBeenCalledWith(
+			designId,
+			params.atlassianUserId,
+		);
+		expect(jiraService.submitDesign).toHaveBeenCalledWith(
+			{
+				design: atlassianDesign,
+				removeAssociations: [
+					AtlassianAssociation.createDesignIssueAssociation(
+						params.disassociateFrom.ari,
+					),
+				],
+			},
+			connectInstallation,
+		);
+		expect(jiraService.deleteDesignUrlInIssueProperties).toHaveBeenCalledWith(
+			issue.id,
+			atlassianDesign,
+			connectInstallation,
+		);
+		expect(figmaService.deleteDevResourceIfExists).toHaveBeenCalledWith({
+			designId: designId,
+			issueUrl: `${connectInstallation.baseUrl}/browse/${issue.key}`,
+			atlassianUserId: params.atlassianUserId,
+		});
+		expect(
+			associatedFigmaDesignRepository.deleteByDesignIdAndAssociatedWithAriAndConnectInstallationId,
+		).toHaveBeenCalledWith(
+			designId,
+			params.disassociateFrom.ari,
+			connectInstallation.id,
+		);
+	});
+
+	it('should not delete associated Figma design when design submission fails', async () => {
+		const connectInstallation = generateConnectInstallation();
+		const issue = generateJiraIssue();
+		const atlassianDesign = generateAtlassianDesign();
+		const params: DisassociateEntityUseCaseParams =
+			generateDisassociateEntityUseCaseParams({
+				entityId: atlassianDesign.id,
+				issueId: issue.id,
+				connectInstallation,
+			});
+		jest
+			.spyOn(figmaService, 'fetchDesignById')
+			.mockResolvedValue(atlassianDesign);
+		jest.spyOn(jiraService, 'getIssue').mockResolvedValue(issue);
+		jest.spyOn(jiraService, 'submitDesign').mockRejectedValue(new Error());
+		jest
+			.spyOn(jiraService, 'deleteDesignUrlInIssueProperties')
+			.mockResolvedValue();
+		jest.spyOn(figmaService, 'deleteDevResourceIfExists').mockResolvedValue();
+		jest.spyOn(
+			associatedFigmaDesignRepository,
+			'deleteByDesignIdAndAssociatedWithAriAndConnectInstallationId',
+		);
+
+		await expect(() =>
+			disassociateEntityUseCase.execute(params),
+		).rejects.toThrow();
+		expect(
+			associatedFigmaDesignRepository.deleteByDesignIdAndAssociatedWithAriAndConnectInstallationId,
+		).not.toHaveBeenCalled();
+	});
+});

--- a/src/usecases/disassociate-entity-use-case.test.ts
+++ b/src/usecases/disassociate-entity-use-case.test.ts
@@ -41,7 +41,7 @@ describe('disassociateEntityUseCase', () => {
 				associatedFigmaDesignRepository,
 				'deleteByDesignIdAndAssociatedWithAriAndConnectInstallationId',
 			)
-			.mockResolvedValue(undefined);
+			.mockResolvedValue(null);
 
 		await disassociateEntityUseCase.execute(params);
 

--- a/src/usecases/disassociate-entity-use-case.ts
+++ b/src/usecases/disassociate-entity-use-case.ts
@@ -65,8 +65,9 @@ export const disassociateEntityUseCase = {
 			}),
 		]);
 
-		await associatedFigmaDesignRepository.deleteByDesignIdAndConnectInstallationId(
+		await associatedFigmaDesignRepository.deleteByDesignIdAndAssociatedWithAriAndConnectInstallationId(
 			figmaDesignId,
+			disassociateFrom.ari,
 			connectInstallation.id,
 		);
 

--- a/src/usecases/disassociate-entity-use-case.ts
+++ b/src/usecases/disassociate-entity-use-case.ts
@@ -8,6 +8,7 @@ import {
 } from '../domain/entities';
 import { figmaService } from '../infrastructure/figma';
 import { buildIssueUrl, jiraService } from '../infrastructure/jira';
+import { associatedFigmaDesignRepository } from '../infrastructure/repositories';
 
 export type DisassociateEntityUseCaseParams = {
 	readonly entity: {
@@ -63,6 +64,11 @@ export const disassociateEntityUseCase = {
 				atlassianUserId,
 			}),
 		]);
+
+		await associatedFigmaDesignRepository.deleteByDesignIdAndConnectInstallationId(
+			figmaDesignId,
+			connectInstallation.id,
+		);
 
 		return design;
 	},

--- a/src/usecases/testing/index.ts
+++ b/src/usecases/testing/index.ts
@@ -1,0 +1,1 @@
+export * from './mocks';

--- a/src/usecases/testing/mocks.ts
+++ b/src/usecases/testing/mocks.ts
@@ -1,0 +1,49 @@
+import { v4 as uuidv4 } from 'uuid';
+
+import { JIRA_ISSUE_ATI } from '../../domain/entities';
+import {
+	generateConnectInstallation,
+	generateFigmaDesignIdentifier,
+	generateFigmaDesignUrl,
+	generateJiraIssueAri,
+	generateJiraIssueId,
+} from '../../domain/entities/testing';
+import type { AssociateEntityUseCaseParams } from '../associate-entity-use-case';
+import type { DisassociateEntityUseCaseParams } from '../disassociate-entity-use-case';
+
+export const generateAssociateEntityUseCaseParams = ({
+	entityUrl = generateFigmaDesignUrl(),
+	issueId = generateJiraIssueId(),
+	connectInstallation = generateConnectInstallation(),
+} = {}): AssociateEntityUseCaseParams => ({
+	entity: {
+		url: entityUrl,
+	},
+	associateWith: {
+		ari: generateJiraIssueAri({ issueId }),
+		ati: JIRA_ISSUE_ATI,
+		id: issueId,
+		cloudId: uuidv4(),
+	},
+	atlassianUserId: uuidv4(),
+	connectInstallation,
+});
+
+export const generateDisassociateEntityUseCaseParams = ({
+	entityId = generateFigmaDesignIdentifier().toAtlassianDesignId(),
+	issueId = generateJiraIssueId(),
+	connectInstallation = generateConnectInstallation(),
+} = {}): DisassociateEntityUseCaseParams => ({
+	entity: {
+		ari: 'NOT_USED',
+		id: entityId,
+	},
+	disassociateFrom: {
+		ari: generateJiraIssueAri({ issueId }),
+		ati: JIRA_ISSUE_ATI,
+		id: issueId,
+		cloudId: uuidv4(),
+	},
+	atlassianUserId: uuidv4(),
+	connectInstallation,
+});

--- a/src/web/routes/entities/integration.test.ts
+++ b/src/web/routes/entities/integration.test.ts
@@ -865,6 +865,7 @@ describe('/entities', () => {
 			it('should disassociate Figma file and respond with created design entity', async () => {
 				const fileName = generateFigmaFileName();
 				const fileKey = generateFigmaFileKey();
+				const designId = new FigmaDesignIdentifier(fileKey);
 				const issueId = generateJiraIssueId();
 				const issueAri = generateJiraIssueAri({ issueId });
 				const issue = generateJiraIssue({ id: issueId });
@@ -880,6 +881,11 @@ describe('/entities', () => {
 					validCredentialsParams.atlassianUserId,
 				);
 
+				await associatedFigmaDesignRepository.upsert({
+					designId,
+					associatedWithAri: issueAri,
+					connectInstallationId: MOCK_CONNECT_INSTALLATION.id,
+				});
 				mockMeEndpoint({ success: true, times: 2 });
 				mockGetFileEndpoint({
 					fileKey,
@@ -971,7 +977,7 @@ describe('/entities', () => {
 					.expect(expectedResponse);
 				expect(
 					await associatedFigmaDesignRepository.findByDesignIdAndAssociatedWithAriAndConnectInstallationId(
-						new FigmaDesignIdentifier(fileKey),
+						designId,
 						issueAri,
 						MOCK_CONNECT_INSTALLATION.id,
 					),
@@ -983,6 +989,7 @@ describe('/entities', () => {
 				const fileKey = generateFigmaFileKey();
 				const nodeId = generateFigmaNodeId();
 				const node = generateChildNode({ id: nodeId });
+				const designId = new FigmaDesignIdentifier(fileKey, nodeId);
 				const issueId = generateJiraIssueId();
 				const issueAri = generateJiraIssueAri({ issueId });
 				const issue = generateJiraIssue({ id: issueId });
@@ -1000,6 +1007,11 @@ describe('/entities', () => {
 					validCredentialsParams.atlassianUserId,
 				);
 
+				await associatedFigmaDesignRepository.upsert({
+					designId,
+					associatedWithAri: issueAri,
+					connectInstallationId: MOCK_CONNECT_INSTALLATION.id,
+				});
 				mockMeEndpoint({ success: true, times: 2 });
 				mockGetFileEndpoint({
 					fileKey,
@@ -1092,7 +1104,7 @@ describe('/entities', () => {
 					.expect(expectedResponse);
 				expect(
 					await associatedFigmaDesignRepository.findByDesignIdAndAssociatedWithAriAndConnectInstallationId(
-						new FigmaDesignIdentifier(fileKey, nodeId),
+						designId,
 						issueAri,
 						MOCK_CONNECT_INSTALLATION.id,
 					),

--- a/src/web/routes/entities/integration.test.ts
+++ b/src/web/routes/entities/integration.test.ts
@@ -11,16 +11,12 @@ import type {
 
 import app from '../../../app';
 import { getConfig } from '../../../config';
-import type {
-	ConnectInstallation,
-	FigmaUserCredentialsCreateParams,
-} from '../../../domain/entities';
 import {
 	FigmaDesignIdentifier,
 	JIRA_ISSUE_ATI,
 } from '../../../domain/entities';
 import {
-	generateConnectInstallation,
+	generateConnectInstallationCreateParams,
 	generateFigmaDesignUrl,
 	generateFigmaFileKey,
 	generateFigmaFileName,
@@ -57,11 +53,12 @@ import {
 	figmaOAuth2UserCredentialsRepository,
 } from '../../../infrastructure/repositories';
 
-const MOCK_CONNECT_INSTALLATION = generateConnectInstallation({
-	key: 'com.figma.jira-addon-dev',
-	clientKey: '4561b8be-e38b-43d4-84d9-f09e8195d117',
-	sharedSecret: '903b6b9e-b82b-48ea-a9b2-40b9e700df32',
-});
+const MOCK_CONNECT_INSTALLATION_CREATE_PARAMS =
+	generateConnectInstallationCreateParams({
+		key: 'com.figma.jira-addon-dev',
+		clientKey: '4561b8be-e38b-43d4-84d9-f09e8195d117',
+		sharedSecret: '903b6b9e-b82b-48ea-a9b2-40b9e700df32',
+	});
 const ASSOCIATE_JWT_TOKEN =
 	'JWT eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2OTM5NTcyMDUsImV4cCI6NjAwMDAwMDE2OTM5NTcxNDQsImlzcyI6IjQ1NjFiOGJlLWUzOGItNDNkNC04NGQ5LWYwOWU4MTk1ZDExNyIsInFzaCI6IjQ2ZDE3MDU4OWU0MjM2Y2U0YTQ5MTFlMGQ1YWE4YjdkOWYzZjNlODZlN2E0ZTgzMzFhM2MyNWE5NTI0MWNjMmYifQ.E71S-uGRlVmEY8-iEEj4bl3SiOcDUlJ-36XGoq8tDHE';
 const DISASSOCIATE_JWT_TOKEN =
@@ -84,18 +81,15 @@ const mockGetFileEndpoint = ({
 	fileKey,
 	accessToken,
 	query = {},
-	success = true,
+	status = HttpStatusCode.Ok,
 	response,
 }: {
 	fileKey: string;
 	accessToken: string;
 	query?: Record<string, string>;
-	success?: boolean;
+	status?: HttpStatusCode;
 	response?: Record<string, unknown>;
 }) => {
-	const statusCode = success
-		? HttpStatusCode.Ok
-		: HttpStatusCode.InternalServerError;
 	nock(FIGMA_API_BASE_URL, {
 		reqheaders: {
 			Authorization: `Bearer ${accessToken}`,
@@ -103,7 +97,7 @@ const mockGetFileEndpoint = ({
 	})
 		.get(`/v1/files/${fileKey}`)
 		.query(query)
-		.reply(statusCode, response ?? {});
+		.reply(status, response ?? {});
 };
 
 const mockGetIssueEndpoint = ({
@@ -265,1154 +259,684 @@ const generateDisassociateEntityRequest = ({
 	},
 });
 
-const setupSuccessCaseTests = async (
-	connectInstallation: ConnectInstallation,
-	validCredentialsParams: FigmaUserCredentialsCreateParams,
-) => {
-	await figmaOAuth2UserCredentialsRepository.upsert(validCredentialsParams);
-	await connectInstallationRepository.upsert(connectInstallation);
-};
-
-const cleanupSuccessCaseTests = async (
-	connectInstallation: ConnectInstallation,
-	validCredentialsParams: FigmaUserCredentialsCreateParams,
-) => {
-	await connectInstallationRepository
-		.deleteByClientKey(connectInstallation.clientKey)
-		.catch(console.log);
-	await figmaOAuth2UserCredentialsRepository
-		.delete(validCredentialsParams.atlassianUserId)
-		.catch(console.log);
-};
-
-const setupErrorCaseTests = async (
-	connectInstallation: ConnectInstallation,
-) => {
-	await connectInstallationRepository.upsert(connectInstallation);
-};
-
-const cleanupErrorCaseTests = async (
-	connectInstallation: ConnectInstallation,
-) => {
-	await connectInstallationRepository
-		.deleteByClientKey(connectInstallation.clientKey)
-		.catch(console.log);
-};
-
 describe('/entities', () => {
-	let validCredentialsParams: FigmaUserCredentialsCreateParams;
-
-	beforeEach(() => {
-		validCredentialsParams = generateFigmaUserCredentialsCreateParams();
-	});
-
 	describe('/associateEntity', () => {
-		describe('success cases', () => {
-			beforeEach(async () => {
-				await setupSuccessCaseTests(
-					MOCK_CONNECT_INSTALLATION,
-					validCredentialsParams,
-				);
+		it('should associate Figma file and respond with created design entity', async () => {
+			const atlassianUserId = uuidv4();
+			const fileName = generateFigmaFileName();
+			const fileKey = generateFigmaFileKey();
+			const issueId = generateJiraIssueId();
+			const issueAri = generateJiraIssueAri({ issueId });
+			const inputFigmaDesignUrl = generateFigmaDesignUrl({
+				fileKey,
+				fileName,
+				mode: 'dev',
+			});
+			const normalizedFigmaDesignUrl = generateFigmaDesignUrl({
+				fileKey,
+				fileName,
+			});
+			const fileResponse = generateGetFileResponse({
+				name: fileName,
 			});
 
-			afterEach(async () => {
-				await cleanupSuccessCaseTests(
-					MOCK_CONNECT_INSTALLATION,
-					validCredentialsParams,
+			const figmaUserCredentials =
+				await figmaOAuth2UserCredentialsRepository.upsert(
+					generateFigmaUserCredentialsCreateParams({ atlassianUserId }),
 				);
+			const connectInstallation = await connectInstallationRepository.upsert(
+				MOCK_CONNECT_INSTALLATION_CREATE_PARAMS,
+			);
+
+			mockMeEndpoint({ success: true, times: 2 });
+			mockGetFileEndpoint({
+				fileKey,
+				accessToken: figmaUserCredentials.accessToken,
+				query: { depth: '1' },
+				response: fileResponse,
+			});
+			mockGetIssueEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+			});
+			mockSubmitDesignsEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+			});
+			mockCreateDevResourcesEndpoint();
+
+			mockGetIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
+				status: HttpStatusCode.NotFound,
+			});
+			mockSetIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
+				value: JSON.stringify(normalizedFigmaDesignUrl),
+			});
+			mockGetIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
+				status: HttpStatusCode.NotFound,
+			});
+			mockSetIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
+				value: JSON.stringify(
+					JSON.stringify([
+						{
+							url: normalizedFigmaDesignUrl,
+							name: fileName,
+						},
+					]),
+				),
 			});
 
-			it('should associate Figma file and respond with created design entity', async () => {
-				const fileName = generateFigmaFileName();
-				const fileKey = generateFigmaFileKey();
-				const issueId = generateJiraIssueId();
-				const issueAri = generateJiraIssueAri({ issueId });
-				const inputFigmaDesignUrl = generateFigmaDesignUrl({
+			const expectedResponse = {
+				design: transformFileToAtlassianDesign({
 					fileKey,
-					fileName,
-					mode: 'dev',
-				});
-				const normalizedFigmaDesignUrl = generateFigmaDesignUrl({
-					fileKey,
-					fileName,
-				});
-				const fileResponse = generateGetFileResponse({
-					name: fileName,
-				});
-				const credentials = await figmaOAuth2UserCredentialsRepository.get(
-					validCredentialsParams.atlassianUserId,
-				);
+					fileResponse,
+				}),
+			};
 
-				mockMeEndpoint({ success: true, times: 2 });
-				mockGetFileEndpoint({
-					fileKey,
-					accessToken: credentials?.accessToken,
-					query: { depth: '1' },
-					response: fileResponse,
-				});
-				mockGetIssueEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-				});
-				mockSubmitDesignsEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-				});
-				mockCreateDevResourcesEndpoint();
-
-				mockGetIssuePropertyEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
-					status: HttpStatusCode.NotFound,
-				});
-				mockSetIssuePropertyEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
-					value: JSON.stringify(normalizedFigmaDesignUrl),
-				});
-				mockGetIssuePropertyEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-					status: HttpStatusCode.NotFound,
-				});
-				mockSetIssuePropertyEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-					value: JSON.stringify(
-						JSON.stringify([
-							{
-								url: normalizedFigmaDesignUrl,
-								name: fileName,
-							},
-						]),
-					),
-				});
-
-				const expectedResponse = {
-					design: transformFileToAtlassianDesign({
-						fileKey,
-						fileResponse,
-					}),
-				};
-
-				await request(app)
-					.post('/entities/associateEntity')
-					.send(
-						generateAssociateEntityRequest({
-							issueId,
-							issueAri,
-							figmaDesignUrl: inputFigmaDesignUrl,
-						}),
-					)
-					.set('Authorization', ASSOCIATE_JWT_TOKEN)
-					.set('Content-Type', 'application/json')
-					.set('User-Id', validCredentialsParams.atlassianUserId)
-					.expect(HttpStatusCode.Ok)
-					.expect(expectedResponse);
-				expect(
-					await associatedFigmaDesignRepository.findByDesignIdAndAssociatedWithAriAndConnectInstallationId(
-						new FigmaDesignIdentifier(fileKey),
+			await request(app)
+				.post('/entities/associateEntity')
+				.send(
+					generateAssociateEntityRequest({
+						issueId,
 						issueAri,
-						MOCK_CONNECT_INSTALLATION.id,
-					),
-				).toBeTruthy();
-			});
-
-			it('should associate Figma node and respond with created design entity', async () => {
-				const fileName = generateFigmaFileName();
-				const fileKey = generateFigmaFileKey();
-				const nodeId = generateFigmaNodeId();
-				const node = generateChildNode({ id: nodeId });
-				const issueId = generateJiraIssueId();
-				const issueAri = generateJiraIssueAri({ issueId });
-				const inputFigmaDesignUrl = generateFigmaDesignUrl({
-					fileKey,
-					fileName,
-					nodeId,
-					mode: 'dev',
-				});
-				const normalizedFigmaDesignUrl = generateFigmaDesignUrl({
-					fileKey,
-					fileName,
-					nodeId,
-				});
-				const fileResponse = generateGetFileResponseWithNode({
-					name: fileName,
-					node,
-				});
-				const credentials = await figmaOAuth2UserCredentialsRepository.get(
-					validCredentialsParams.atlassianUserId,
-				);
-
-				mockMeEndpoint({ success: true, times: 2 });
-				mockGetFileEndpoint({
-					fileKey,
-					accessToken: credentials?.accessToken,
-					query: {
-						ids: nodeId,
-						node_last_modified: 'true',
-					},
-					response: fileResponse,
-				});
-				mockGetIssueEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-				});
-				mockSubmitDesignsEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-				});
-				mockCreateDevResourcesEndpoint();
-
-				mockGetIssuePropertyEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
-					status: HttpStatusCode.NotFound,
-				});
-				mockSetIssuePropertyEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
-					value: JSON.stringify(normalizedFigmaDesignUrl),
-				});
-				mockGetIssuePropertyEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-					status: HttpStatusCode.NotFound,
-				});
-				mockSetIssuePropertyEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-					value: JSON.stringify(
-						JSON.stringify([
-							{
-								url: normalizedFigmaDesignUrl,
-								name: node.name,
-							},
-						]),
-					),
-				});
-
-				const expectedResponse = {
-					design: transformNodeToAtlassianDesign({
-						fileKey,
-						nodeId,
-						fileResponse,
+						figmaDesignUrl: inputFigmaDesignUrl,
 					}),
-				};
-
-				await request(app)
-					.post('/entities/associateEntity')
-					.send(
-						generateAssociateEntityRequest({
-							issueId,
-							issueAri,
-							figmaDesignUrl: inputFigmaDesignUrl,
-						}),
-					)
-					.set('Authorization', ASSOCIATE_JWT_TOKEN)
-					.set('Content-Type', 'application/json')
-					.set('User-Id', validCredentialsParams.atlassianUserId)
-					.expect(HttpStatusCode.Ok)
-					.expect(expectedResponse);
-				expect(
-					await associatedFigmaDesignRepository.findByDesignIdAndAssociatedWithAriAndConnectInstallationId(
-						new FigmaDesignIdentifier(fileKey, nodeId),
-						issueAri,
-						MOCK_CONNECT_INSTALLATION.id,
-					),
-				).toBeTruthy();
-			});
+				)
+				.set('Authorization', ASSOCIATE_JWT_TOKEN)
+				.set('Content-Type', 'application/json')
+				.set('User-Id', atlassianUserId)
+				.expect(HttpStatusCode.Ok)
+				.expect(expectedResponse);
+			expect(
+				await associatedFigmaDesignRepository.findByDesignIdAndAssociatedWithAriAndConnectInstallationId(
+					new FigmaDesignIdentifier(fileKey),
+					issueAri,
+					connectInstallation.id,
+				),
+			).toBeTruthy();
 		});
 
-		describe('error cases', () => {
-			beforeEach(async () => {
-				await setupErrorCaseTests(MOCK_CONNECT_INSTALLATION);
+		it('should associate Figma node and respond with created design entity', async () => {
+			const atlassianUserId = uuidv4();
+			const fileName = generateFigmaFileName();
+			const fileKey = generateFigmaFileKey();
+			const nodeId = generateFigmaNodeId();
+			const node = generateChildNode({ id: nodeId });
+			const issueId = generateJiraIssueId();
+			const issueAri = generateJiraIssueAri({ issueId });
+			const inputFigmaDesignUrl = generateFigmaDesignUrl({
+				fileKey,
+				fileName,
+				nodeId,
+				mode: 'dev',
+			});
+			const normalizedFigmaDesignUrl = generateFigmaDesignUrl({
+				fileKey,
+				fileName,
+				nodeId,
+			});
+			const fileResponse = generateGetFileResponseWithNode({
+				name: fileName,
+				node,
 			});
 
-			afterEach(async () => {
-				await cleanupErrorCaseTests(MOCK_CONNECT_INSTALLATION);
+			const figmaUserCredentials =
+				await figmaOAuth2UserCredentialsRepository.upsert(
+					generateFigmaUserCredentialsCreateParams({ atlassianUserId }),
+				);
+			const connectInstallation = await connectInstallationRepository.upsert(
+				MOCK_CONNECT_INSTALLATION_CREATE_PARAMS,
+			);
+
+			mockMeEndpoint({ success: true, times: 2 });
+			mockGetFileEndpoint({
+				fileKey,
+				accessToken: figmaUserCredentials.accessToken,
+				query: {
+					ids: nodeId,
+					node_last_modified: 'true',
+				},
+				response: fileResponse,
+			});
+			mockGetIssueEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+			});
+			mockSubmitDesignsEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+			});
+			mockCreateDevResourcesEndpoint();
+
+			mockGetIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
+				status: HttpStatusCode.NotFound,
+			});
+			mockSetIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
+				value: JSON.stringify(normalizedFigmaDesignUrl),
+			});
+			mockGetIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
+				status: HttpStatusCode.NotFound,
+			});
+			mockSetIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
+				value: JSON.stringify(
+					JSON.stringify([
+						{
+							url: normalizedFigmaDesignUrl,
+							name: node.name,
+						},
+					]),
+				),
 			});
 
-			it('should respond with 401 "User-Id" header is not set', () => {
-				return request(app)
-					.post('/entities/associateEntity')
-					.send(generateAssociateEntityRequest())
-					.set('Authorization', ASSOCIATE_JWT_TOKEN)
-					.set('Content-Type', 'application/json')
-					.expect(HttpStatusCode.Unauthorized);
+			const expectedResponse = {
+				design: transformNodeToAtlassianDesign({
+					fileKey,
+					nodeId,
+					fileResponse,
+				}),
+			};
+
+			await request(app)
+				.post('/entities/associateEntity')
+				.send(
+					generateAssociateEntityRequest({
+						issueId,
+						issueAri,
+						figmaDesignUrl: inputFigmaDesignUrl,
+					}),
+				)
+				.set('Authorization', ASSOCIATE_JWT_TOKEN)
+				.set('Content-Type', 'application/json')
+				.set('User-Id', atlassianUserId)
+				.expect(HttpStatusCode.Ok)
+				.expect(expectedResponse);
+			expect(
+				await associatedFigmaDesignRepository.findByDesignIdAndAssociatedWithAriAndConnectInstallationId(
+					new FigmaDesignIdentifier(fileKey, nodeId),
+					issueAri,
+					connectInstallation.id,
+				),
+			).toBeTruthy();
+		});
+
+		it('should respond with 401 "User-Id" header is not set', () => {
+			return request(app)
+				.post('/entities/associateEntity')
+				.send(generateAssociateEntityRequest())
+				.set('Authorization', ASSOCIATE_JWT_TOKEN)
+				.set('Content-Type', 'application/json')
+				.expect(HttpStatusCode.Unauthorized);
+		});
+
+		it('should respond with 403 if credentials are not found', async () => {
+			const issueId = generateJiraIssueId();
+			const connectInstallation = await connectInstallationRepository.upsert(
+				MOCK_CONNECT_INSTALLATION_CREATE_PARAMS,
+			);
+			mockGetIssueEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
 			});
 
-			it('should respond with 403 if credentials are not found', () => {
-				const issueId = generateJiraIssueId();
-				mockGetIssueEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-				});
+			return request(app)
+				.post('/entities/associateEntity')
+				.send(generateAssociateEntityRequest({ issueId }))
+				.set('Authorization', ASSOCIATE_JWT_TOKEN)
+				.set('Content-Type', 'application/json')
+				.set('User-Id', uuidv4())
+				.expect(HttpStatusCode.Forbidden);
+		});
 
-				return request(app)
-					.post('/entities/associateEntity')
-					.send(generateAssociateEntityRequest({ issueId }))
-					.set('Authorization', ASSOCIATE_JWT_TOKEN)
-					.set('Content-Type', 'application/json')
-					.set('User-Id', validCredentialsParams.atlassianUserId)
-					.expect(HttpStatusCode.Forbidden);
+		it('should respond with 500 if design fetching fails', async () => {
+			const atlassianUserId = uuidv4();
+			const fileKey = generateFigmaFileKey();
+			const issueId = generateJiraIssueId();
+			const issueAri = generateJiraIssueAri({ issueId });
+			const inputFigmaDesignUrl = generateFigmaDesignUrl({
+				fileKey,
+				fileName: generateFigmaFileName(),
+				mode: 'dev',
 			});
 
-			describe('with valid auth and upstream errors', () => {
-				beforeEach(async () => {
-					await figmaOAuth2UserCredentialsRepository.upsert(
-						validCredentialsParams,
-					);
-				});
+			const figmaUserCredentials =
+				await figmaOAuth2UserCredentialsRepository.upsert(
+					generateFigmaUserCredentialsCreateParams({ atlassianUserId }),
+				);
+			const connectInstallation = await connectInstallationRepository.upsert(
+				MOCK_CONNECT_INSTALLATION_CREATE_PARAMS,
+			);
 
-				afterEach(async () => {
-					await figmaOAuth2UserCredentialsRepository
-						.delete(validCredentialsParams.atlassianUserId)
-						.catch(console.log);
-				});
-
-				it('should respond with 500 if fetching design details fails', async () => {
-					const fileKey = generateFigmaFileKey();
-					const issueId = generateJiraIssueId();
-					const figmaDesignUrl = generateFigmaDesignUrl({
-						fileKey,
-					});
-					const credentials = await figmaOAuth2UserCredentialsRepository.get(
-						validCredentialsParams.atlassianUserId,
-					);
-
-					mockMeEndpoint({ success: true });
-					mockGetIssueEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-					});
-					mockGetFileEndpoint({
-						fileKey,
-						accessToken: credentials?.accessToken,
-						query: { depth: '1' },
-						success: false,
-					});
-
-					return request(app)
-						.post('/entities/associateEntity')
-						.send(
-							generateAssociateEntityRequest({
-								issueId,
-								figmaDesignUrl,
-							}),
-						)
-						.set('Authorization', ASSOCIATE_JWT_TOKEN)
-						.set('Content-Type', 'application/json')
-						.set('User-Id', validCredentialsParams.atlassianUserId)
-						.expect(HttpStatusCode.InternalServerError);
-				});
-
-				it('should respond with 500 if fetching issue details fails', async () => {
-					const fileKey = generateFigmaFileKey();
-					const issueId = generateJiraIssueId();
-					const figmaDesignUrl = generateFigmaDesignUrl({ fileKey });
-					const credentials = await figmaOAuth2UserCredentialsRepository.get(
-						validCredentialsParams.atlassianUserId,
-					);
-
-					mockGetFileEndpoint({
-						fileKey,
-						accessToken: credentials?.accessToken,
-						query: { depth: '1' },
-					});
-					mockMeEndpoint();
-					mockGetIssueEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						status: HttpStatusCode.InternalServerError,
-					});
-
-					return request(app)
-						.post('/entities/associateEntity')
-						.send(
-							generateAssociateEntityRequest({
-								issueId,
-								figmaDesignUrl,
-							}),
-						)
-						.set('Authorization', ASSOCIATE_JWT_TOKEN)
-						.set('Content-Type', 'application/json')
-						.set('User-Id', validCredentialsParams.atlassianUserId)
-						.expect(HttpStatusCode.InternalServerError);
-				});
-
-				it('should respond with 500 if design ingestion fails', async () => {
-					const fileName = generateFigmaFileName();
-					const fileKey = generateFigmaFileKey();
-					const issueId = generateJiraIssueId();
-					const figmaDesignUrl = generateFigmaDesignUrl({ fileKey, fileName });
-					const fileResponse = generateGetFileResponse({ name: fileName });
-					const credentials = await figmaOAuth2UserCredentialsRepository.get(
-						validCredentialsParams.atlassianUserId,
-					);
-
-					mockMeEndpoint({ success: true, times: 2 });
-					mockGetFileEndpoint({
-						fileKey,
-						accessToken: credentials?.accessToken,
-						query: { depth: '1' },
-						response: fileResponse,
-					});
-					mockGetIssueEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-					});
-					mockGetIssuePropertyEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
-					});
-					mockGetIssuePropertyEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-						response: generateGetIssuePropertyResponse({
-							key: propertyKeys.ATTACHED_DESIGN_URL_V2,
-							value: JSON.stringify([]),
-						}),
-					});
-					mockSetIssuePropertyEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-						value: JSON.stringify(
-							JSON.stringify([
-								{ url: figmaDesignUrl, name: fileResponse.name },
-							]),
-						),
-					});
-					mockCreateDevResourcesEndpoint();
-					mockSubmitDesignsEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						status: HttpStatusCode.InternalServerError,
-					});
-
-					return request(app)
-						.post('/entities/associateEntity')
-						.send(
-							generateAssociateEntityRequest({
-								issueId,
-								figmaDesignUrl,
-							}),
-						)
-						.set('Authorization', ASSOCIATE_JWT_TOKEN)
-						.set('Content-Type', 'application/json')
-						.set('User-Id', validCredentialsParams.atlassianUserId)
-						.expect(HttpStatusCode.InternalServerError);
-				});
-
-				it('should respond with 500 if createDevResource request fails', async () => {
-					const fileName = generateFigmaFileName();
-					const fileKey = generateFigmaFileKey();
-					const issueId = generateJiraIssueId();
-					const figmaDesignUrl = generateFigmaDesignUrl({ fileKey, fileName });
-					const fileResponse = generateGetFileResponse({ name: fileName });
-					const credentials = await figmaOAuth2UserCredentialsRepository.get(
-						validCredentialsParams.atlassianUserId,
-					);
-
-					mockMeEndpoint({ success: true, times: 2 });
-					mockGetFileEndpoint({
-						fileKey,
-						accessToken: credentials?.accessToken,
-						query: { depth: '1' },
-						response: fileResponse,
-					});
-					mockGetIssueEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-					});
-					mockGetIssuePropertyEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
-					});
-					mockGetIssuePropertyEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-						response: generateGetIssuePropertyResponse({
-							key: propertyKeys.ATTACHED_DESIGN_URL_V2,
-							value: JSON.stringify([]),
-						}),
-					});
-					mockSetIssuePropertyEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-						value: JSON.stringify(
-							JSON.stringify([
-								{ url: figmaDesignUrl, name: fileResponse.name },
-							]),
-						),
-					});
-					mockSubmitDesignsEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					});
-					mockCreateDevResourcesEndpoint({
-						status: HttpStatusCode.InternalServerError,
-					});
-
-					return request(app)
-						.post('/entities/associateEntity')
-						.send(
-							generateAssociateEntityRequest({
-								issueId,
-								figmaDesignUrl,
-							}),
-						)
-						.set('Authorization', ASSOCIATE_JWT_TOKEN)
-						.set('Content-Type', 'application/json')
-						.set('User-Id', validCredentialsParams.atlassianUserId)
-						.expect(HttpStatusCode.InternalServerError);
-				});
-
-				it('should respond with 500 if setting any attached-design-url property fails', async () => {
-					const fileName = generateFigmaFileName();
-					const fileKey = generateFigmaFileKey();
-					const issueId = generateJiraIssueId();
-					const figmaDesignUrl = generateFigmaDesignUrl({ fileKey, fileName });
-					const fileResponse = generateGetFileResponse({ name: fileName });
-					const credentials = await figmaOAuth2UserCredentialsRepository.get(
-						validCredentialsParams.atlassianUserId,
-					);
-
-					mockMeEndpoint({ success: true, times: 2 });
-					mockGetFileEndpoint({
-						fileKey,
-						accessToken: credentials?.accessToken,
-						query: { depth: '1' },
-						response: fileResponse,
-					});
-					mockGetIssueEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-					});
-					mockGetIssuePropertyEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
-						status: HttpStatusCode.InternalServerError,
-					});
-					mockGetIssuePropertyEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-						response: generateGetIssuePropertyResponse({
-							key: propertyKeys.ATTACHED_DESIGN_URL_V2,
-							value: JSON.stringify([]),
-						}),
-					});
-					mockSetIssuePropertyEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-						value: JSON.stringify(
-							JSON.stringify([
-								{ url: figmaDesignUrl, name: fileResponse.name },
-							]),
-						),
-					});
-					mockSubmitDesignsEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					});
-					mockCreateDevResourcesEndpoint();
-
-					return request(app)
-						.post('/entities/associateEntity')
-						.send(
-							generateAssociateEntityRequest({
-								issueId,
-								figmaDesignUrl,
-							}),
-						)
-						.set('Authorization', ASSOCIATE_JWT_TOKEN)
-						.set('Content-Type', 'application/json')
-						.set('User-Id', validCredentialsParams.atlassianUserId)
-						.expect(HttpStatusCode.InternalServerError);
-				});
+			mockMeEndpoint({ success: true, times: 2 });
+			mockGetIssueEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
 			});
+			mockGetFileEndpoint({
+				fileKey,
+				accessToken: figmaUserCredentials.accessToken,
+				query: { depth: '1' },
+				status: HttpStatusCode.InternalServerError,
+			});
+
+			await request(app)
+				.post('/entities/associateEntity')
+				.send(
+					generateAssociateEntityRequest({
+						issueId,
+						issueAri,
+						figmaDesignUrl: inputFigmaDesignUrl,
+					}),
+				)
+				.set('Authorization', ASSOCIATE_JWT_TOKEN)
+				.set('Content-Type', 'application/json')
+				.set('User-Id', atlassianUserId);
 		});
 	});
 
 	describe('/disassociateEntity', () => {
-		describe('success cases', () => {
-			beforeEach(async () => {
-				await setupSuccessCaseTests(
-					MOCK_CONNECT_INSTALLATION,
-					validCredentialsParams,
-				);
+		it('should disassociate Figma file and respond with created design entity', async () => {
+			const atlassianUserId = uuidv4();
+			const fileName = generateFigmaFileName();
+			const fileKey = generateFigmaFileKey();
+			const designId = new FigmaDesignIdentifier(fileKey);
+			const issueId = generateJiraIssueId();
+			const issueAri = generateJiraIssueAri({ issueId });
+			const issue = generateJiraIssue({ id: issueId });
+			const devResourceId = uuidv4();
+			const figmaDesignUrl = generateFigmaDesignUrl({
+				fileKey,
+				fileName,
+			});
+			const fileResponse = generateGetFileResponse({
+				name: fileName,
 			});
 
-			afterEach(async () => {
-				await cleanupSuccessCaseTests(
-					MOCK_CONNECT_INSTALLATION,
-					validCredentialsParams,
+			const figmaUserCredentials =
+				await figmaOAuth2UserCredentialsRepository.upsert(
+					generateFigmaUserCredentialsCreateParams({ atlassianUserId }),
 				);
+			const connectInstallation = await connectInstallationRepository.upsert(
+				MOCK_CONNECT_INSTALLATION_CREATE_PARAMS,
+			);
+
+			await associatedFigmaDesignRepository.upsert({
+				designId,
+				associatedWithAri: issueAri,
+				connectInstallationId: connectInstallation.id,
+			});
+			mockMeEndpoint({ success: true, times: 2 });
+			mockGetFileEndpoint({
+				fileKey,
+				accessToken: figmaUserCredentials.accessToken,
+				query: { depth: '1' },
+				response: fileResponse,
+			});
+			mockGetIssueEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				response: issue,
+			});
+			mockSubmitDesignsEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+			});
+			mockGetDevResourcesEndpoint({
+				fileKey,
+				nodeId: '0:0',
+				response: generateGetDevResourcesResponse({
+					id: devResourceId,
+					url: generateJiraIssueUrl({
+						baseUrl: connectInstallation.baseUrl,
+						key: issue.key,
+					}),
+				}),
+			});
+			mockDeleteDevResourcesEndpoint({ fileKey, devResourceId });
+			mockGetIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
+				response: generateGetIssuePropertyResponse({
+					key: propertyKeys.ATTACHED_DESIGN_URL,
+					value: figmaDesignUrl,
+				}),
+			});
+			mockDeleteIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
 			});
 
-			it('should disassociate Figma file and respond with created design entity', async () => {
-				const fileName = generateFigmaFileName();
-				const fileKey = generateFigmaFileKey();
-				const designId = new FigmaDesignIdentifier(fileKey);
-				const issueId = generateJiraIssueId();
-				const issueAri = generateJiraIssueAri({ issueId });
-				const issue = generateJiraIssue({ id: issueId });
-				const devResourceId = uuidv4();
-				const figmaDesignUrl = generateFigmaDesignUrl({
+			const expectedDesignUrlV2Value: AttachedDesignUrlV2IssuePropertyValue = {
+				url: 'https://should-not-be-deleted.com',
+				name: 'should not be deleted',
+			};
+			const attachedDesignUrlV2Values: AttachedDesignUrlV2IssuePropertyValue[] =
+				[
+					{ url: figmaDesignUrl, name: fileResponse.name },
+					expectedDesignUrlV2Value,
+				];
+			mockGetIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
+				response: generateGetIssuePropertyResponse({
+					key: propertyKeys.ATTACHED_DESIGN_URL_V2,
+					value: JSON.stringify(attachedDesignUrlV2Values),
+				}),
+			});
+			mockSetIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
+				value: JSON.stringify(JSON.stringify([expectedDesignUrlV2Value])),
+			});
+
+			const expectedResponse = {
+				design: transformFileToAtlassianDesign({
 					fileKey,
-					fileName,
-				});
-				const fileResponse = generateGetFileResponse({
-					name: fileName,
-				});
-				const credentials = await figmaOAuth2UserCredentialsRepository.get(
-					validCredentialsParams.atlassianUserId,
-				);
+					fileResponse,
+				}),
+			};
 
-				await associatedFigmaDesignRepository.upsert({
-					designId,
-					associatedWithAri: issueAri,
-					connectInstallationId: MOCK_CONNECT_INSTALLATION.id,
-				});
-				mockMeEndpoint({ success: true, times: 2 });
-				mockGetFileEndpoint({
-					fileKey,
-					accessToken: credentials?.accessToken,
-					query: { depth: '1' },
-					response: fileResponse,
-				});
-				mockGetIssueEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					response: issue,
-				});
-				mockSubmitDesignsEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-				});
-				mockGetDevResourcesEndpoint({
-					fileKey,
-					nodeId: '0:0',
-					response: generateGetDevResourcesResponse({
-						id: devResourceId,
-						url: generateJiraIssueUrl({
-							baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-							key: issue.key,
-						}),
-					}),
-				});
-				mockDeleteDevResourcesEndpoint({ fileKey, devResourceId });
-				mockGetIssuePropertyEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
-					response: generateGetIssuePropertyResponse({
-						key: propertyKeys.ATTACHED_DESIGN_URL,
-						value: figmaDesignUrl,
-					}),
-				});
-				mockDeleteIssuePropertyEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
-				});
-
-				const expectedDesignUrlV2Value: AttachedDesignUrlV2IssuePropertyValue =
-					{
-						url: 'https://should-not-be-deleted.com',
-						name: 'should not be deleted',
-					};
-				const attachedDesignUrlV2Values: AttachedDesignUrlV2IssuePropertyValue[] =
-					[
-						{ url: figmaDesignUrl, name: fileResponse.name },
-						expectedDesignUrlV2Value,
-					];
-				mockGetIssuePropertyEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-					response: generateGetIssuePropertyResponse({
-						key: propertyKeys.ATTACHED_DESIGN_URL_V2,
-						value: JSON.stringify(attachedDesignUrlV2Values),
-					}),
-				});
-				mockSetIssuePropertyEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-					value: JSON.stringify(JSON.stringify([expectedDesignUrlV2Value])),
-				});
-
-				const expectedResponse = {
-					design: transformFileToAtlassianDesign({
-						fileKey,
-						fileResponse,
-					}),
-				};
-
-				await request(app)
-					.post('/entities/disassociateEntity')
-					.send(
-						generateDisassociateEntityRequest({
-							issueId,
-							issueAri,
-							entityId: fileKey,
-						}),
-					)
-					.set('Authorization', DISASSOCIATE_JWT_TOKEN)
-					.set('Content-Type', 'application/json')
-					.set('User-Id', validCredentialsParams.atlassianUserId)
-					.expect(HttpStatusCode.Ok)
-					.expect(expectedResponse);
-				expect(
-					await associatedFigmaDesignRepository.findByDesignIdAndAssociatedWithAriAndConnectInstallationId(
-						designId,
+			await request(app)
+				.post('/entities/disassociateEntity')
+				.send(
+					generateDisassociateEntityRequest({
+						issueId,
 						issueAri,
-						MOCK_CONNECT_INSTALLATION.id,
-					),
-				).toBeNull();
-			});
-
-			it('should disassociate Figma node and respond with created design entity', async () => {
-				const fileName = generateFigmaFileName();
-				const fileKey = generateFigmaFileKey();
-				const nodeId = generateFigmaNodeId();
-				const node = generateChildNode({ id: nodeId });
-				const designId = new FigmaDesignIdentifier(fileKey, nodeId);
-				const issueId = generateJiraIssueId();
-				const issueAri = generateJiraIssueAri({ issueId });
-				const issue = generateJiraIssue({ id: issueId });
-				const devResourceId = uuidv4();
-				const figmaDesignUrl = generateFigmaDesignUrl({
-					fileKey,
-					fileName,
-					nodeId,
-				});
-				const fileResponse = generateGetFileResponseWithNode({
-					name: fileName,
-					node,
-				});
-				const credentials = await figmaOAuth2UserCredentialsRepository.get(
-					validCredentialsParams.atlassianUserId,
-				);
-
-				await associatedFigmaDesignRepository.upsert({
+						entityId: fileKey,
+					}),
+				)
+				.set('Authorization', DISASSOCIATE_JWT_TOKEN)
+				.set('Content-Type', 'application/json')
+				.set('User-Id', atlassianUserId)
+				.expect(HttpStatusCode.Ok)
+				.expect(expectedResponse);
+			expect(
+				await associatedFigmaDesignRepository.findByDesignIdAndAssociatedWithAriAndConnectInstallationId(
 					designId,
-					associatedWithAri: issueAri,
-					connectInstallationId: MOCK_CONNECT_INSTALLATION.id,
-				});
-				mockMeEndpoint({ success: true, times: 2 });
-				mockGetFileEndpoint({
-					fileKey,
-					accessToken: credentials?.accessToken,
-					query: { ids: nodeId, node_last_modified: 'true' },
-					response: fileResponse,
-				});
-				mockGetIssueEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					response: issue,
-				});
-				mockSubmitDesignsEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-				});
-				mockGetDevResourcesEndpoint({
-					fileKey,
-					nodeId,
-					response: generateGetDevResourcesResponse({
-						id: devResourceId,
-						url: generateJiraIssueUrl({
-							baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-							key: issue.key,
-						}),
-					}),
-				});
-				mockDeleteDevResourcesEndpoint({ fileKey, devResourceId });
-				mockGetIssuePropertyEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
-					response: generateGetIssuePropertyResponse({
-						key: propertyKeys.ATTACHED_DESIGN_URL,
-						value: figmaDesignUrl,
-					}),
-				});
-				mockDeleteIssuePropertyEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
-				});
-
-				const expectedDesignUrlV2Value: AttachedDesignUrlV2IssuePropertyValue =
-					{
-						url: 'https://should-not-be-deleted.com',
-						name: 'should not be deleted',
-					};
-				const attachedDesignUrlV2Values: AttachedDesignUrlV2IssuePropertyValue[] =
-					[
-						{ url: figmaDesignUrl, name: fileResponse.name },
-						expectedDesignUrlV2Value,
-					];
-				mockGetIssuePropertyEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-					response: generateGetIssuePropertyResponse({
-						key: propertyKeys.ATTACHED_DESIGN_URL_V2,
-						value: JSON.stringify(attachedDesignUrlV2Values),
-					}),
-				});
-				mockSetIssuePropertyEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-					propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-					value: JSON.stringify(JSON.stringify([expectedDesignUrlV2Value])),
-				});
-
-				const expectedResponse = {
-					design: transformNodeToAtlassianDesign({
-						fileKey,
-						nodeId,
-						fileResponse,
-					}),
-				};
-
-				await request(app)
-					.post('/entities/disassociateEntity')
-					.send(
-						generateDisassociateEntityRequest({
-							issueId,
-							issueAri,
-							entityId: `${fileKey}/${nodeId}`,
-						}),
-					)
-					.set('Authorization', DISASSOCIATE_JWT_TOKEN)
-					.set('Content-Type', 'application/json')
-					.set('User-Id', validCredentialsParams.atlassianUserId)
-					.expect(HttpStatusCode.Ok)
-					.expect(expectedResponse);
-				expect(
-					await associatedFigmaDesignRepository.findByDesignIdAndAssociatedWithAriAndConnectInstallationId(
-						designId,
-						issueAri,
-						MOCK_CONNECT_INSTALLATION.id,
-					),
-				).toBeNull();
-			});
+					issueAri,
+					connectInstallation.id,
+				),
+			).toBeNull();
 		});
 
-		describe('error cases', () => {
-			beforeEach(async () => {
-				await setupErrorCaseTests(MOCK_CONNECT_INSTALLATION);
+		it('should disassociate Figma node and respond with created design entity', async () => {
+			const atlassianUserId = uuidv4();
+			const fileName = generateFigmaFileName();
+			const fileKey = generateFigmaFileKey();
+			const nodeId = generateFigmaNodeId();
+			const node = generateChildNode({ id: nodeId });
+			const designId = new FigmaDesignIdentifier(fileKey, nodeId);
+			const issueId = generateJiraIssueId();
+			const issueAri = generateJiraIssueAri({ issueId });
+			const issue = generateJiraIssue({ id: issueId });
+			const devResourceId = uuidv4();
+			const figmaDesignUrl = generateFigmaDesignUrl({
+				fileKey,
+				fileName,
+				nodeId,
+			});
+			const fileResponse = generateGetFileResponseWithNode({
+				name: fileName,
+				node,
 			});
 
-			afterEach(async () => {
-				await cleanupErrorCaseTests(MOCK_CONNECT_INSTALLATION);
+			const figmaUserCredentials =
+				await figmaOAuth2UserCredentialsRepository.upsert(
+					generateFigmaUserCredentialsCreateParams({ atlassianUserId }),
+				);
+			const connectInstallation = await connectInstallationRepository.upsert(
+				MOCK_CONNECT_INSTALLATION_CREATE_PARAMS,
+			);
+
+			await associatedFigmaDesignRepository.upsert({
+				designId,
+				associatedWithAri: issueAri,
+				connectInstallationId: connectInstallation.id,
+			});
+			mockMeEndpoint({ success: true, times: 2 });
+			mockGetFileEndpoint({
+				fileKey,
+				accessToken: figmaUserCredentials.accessToken,
+				query: { ids: nodeId, node_last_modified: 'true' },
+				response: fileResponse,
+			});
+			mockGetIssueEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				response: issue,
+			});
+			mockSubmitDesignsEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+			});
+			mockGetDevResourcesEndpoint({
+				fileKey,
+				nodeId,
+				response: generateGetDevResourcesResponse({
+					id: devResourceId,
+					url: generateJiraIssueUrl({
+						baseUrl: connectInstallation.baseUrl,
+						key: issue.key,
+					}),
+				}),
+			});
+			mockDeleteDevResourcesEndpoint({ fileKey, devResourceId });
+			mockGetIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
+				response: generateGetIssuePropertyResponse({
+					key: propertyKeys.ATTACHED_DESIGN_URL,
+					value: figmaDesignUrl,
+				}),
+			});
+			mockDeleteIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
 			});
 
-			it('should respond with 401 "User-Id" header is not set', () => {
-				return request(app)
-					.post('/entities/disassociateEntity')
-					.send(generateDisassociateEntityRequest())
-					.set('Authorization', DISASSOCIATE_JWT_TOKEN)
-					.set('Content-Type', 'application/json')
-					.expect(HttpStatusCode.Unauthorized);
+			const expectedDesignUrlV2Value: AttachedDesignUrlV2IssuePropertyValue = {
+				url: 'https://should-not-be-deleted.com',
+				name: 'should not be deleted',
+			};
+			const attachedDesignUrlV2Values: AttachedDesignUrlV2IssuePropertyValue[] =
+				[
+					{ url: figmaDesignUrl, name: fileResponse.name },
+					expectedDesignUrlV2Value,
+				];
+			mockGetIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
+				response: generateGetIssuePropertyResponse({
+					key: propertyKeys.ATTACHED_DESIGN_URL_V2,
+					value: JSON.stringify(attachedDesignUrlV2Values),
+				}),
+			});
+			mockSetIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
+				value: JSON.stringify(JSON.stringify([expectedDesignUrlV2Value])),
 			});
 
-			it('should respond with 403 if credentials are not found', () => {
-				const issueId = generateJiraIssueId();
-				mockGetIssueEndpoint({
-					baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					issueId,
-				});
+			const expectedResponse = {
+				design: transformNodeToAtlassianDesign({
+					fileKey,
+					nodeId,
+					fileResponse,
+				}),
+			};
 
-				return request(app)
-					.post('/entities/disassociateEntity')
-					.send(generateDisassociateEntityRequest({ issueId }))
-					.set('Authorization', DISASSOCIATE_JWT_TOKEN)
-					.set('Content-Type', 'application/json')
-					.set('User-Id', validCredentialsParams.atlassianUserId)
-					.expect(HttpStatusCode.Forbidden);
+			await request(app)
+				.post('/entities/disassociateEntity')
+				.send(
+					generateDisassociateEntityRequest({
+						issueId,
+						issueAri,
+						entityId: `${fileKey}/${nodeId}`,
+					}),
+				)
+				.set('Authorization', DISASSOCIATE_JWT_TOKEN)
+				.set('Content-Type', 'application/json')
+				.set('User-Id', atlassianUserId)
+				.expect(HttpStatusCode.Ok)
+				.expect(expectedResponse);
+			expect(
+				await associatedFigmaDesignRepository.findByDesignIdAndAssociatedWithAriAndConnectInstallationId(
+					designId,
+					issueAri,
+					connectInstallation.id,
+				),
+			).toBeNull();
+		});
+
+		it('should respond with 200 if getDevResource returns no resources', async () => {
+			const atlassianUserId = uuidv4();
+			const fileName = generateFigmaFileName();
+			const fileKey = generateFigmaFileKey();
+			const issueId = generateJiraIssueId();
+			const issue = generateJiraIssue({ id: issueId });
+			const fileResponse = generateGetFileResponse({ name: fileName });
+
+			const figmaUserCredentials =
+				await figmaOAuth2UserCredentialsRepository.upsert(
+					generateFigmaUserCredentialsCreateParams({ atlassianUserId }),
+				);
+			const connectInstallation = await connectInstallationRepository.upsert(
+				MOCK_CONNECT_INSTALLATION_CREATE_PARAMS,
+			);
+
+			mockMeEndpoint({ success: true, times: 2 });
+			mockGetFileEndpoint({
+				fileKey,
+				accessToken: figmaUserCredentials.accessToken,
+				query: { depth: '1' },
+				response: fileResponse,
+			});
+			mockGetIssueEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				response: issue,
+			});
+			mockSubmitDesignsEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+			});
+			mockGetIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
+				status: HttpStatusCode.NotFound,
+			});
+			mockGetIssuePropertyEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
+				status: HttpStatusCode.NotFound,
+			});
+			mockGetDevResourcesEndpoint({
+				fileKey,
+				nodeId: '0:0',
+				response: generateEmptyDevResourcesResponse(),
 			});
 
-			describe('with valid auth and upstream errors', () => {
-				beforeEach(async () => {
-					await figmaOAuth2UserCredentialsRepository.upsert(
-						validCredentialsParams,
-					);
-				});
-
-				afterEach(async () => {
-					await figmaOAuth2UserCredentialsRepository
-						.delete(validCredentialsParams.atlassianUserId)
-						.catch(console.log);
-				});
-
-				it('should respond with 500 if fetching design details fails', async () => {
-					const fileKey = generateFigmaFileKey();
-					const issueId = generateJiraIssueId();
-					const issue = generateJiraIssue({ id: issueId });
-					const credentials = await figmaOAuth2UserCredentialsRepository.get(
-						validCredentialsParams.atlassianUserId,
-					);
-
-					mockMeEndpoint({ success: true });
-					mockGetIssueEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
+			return request(app)
+				.post('/entities/disassociateEntity')
+				.send(
+					generateDisassociateEntityRequest({
 						issueId,
-						response: issue,
-					});
-					mockGetFileEndpoint({
-						fileKey,
-						accessToken: credentials?.accessToken,
-						query: { depth: '1' },
-						success: false,
-					});
+						entityId: fileKey,
+					}),
+				)
+				.set('Authorization', DISASSOCIATE_JWT_TOKEN)
+				.set('Content-Type', 'application/json')
+				.set('User-Id', atlassianUserId)
+				.expect(HttpStatusCode.Ok);
+		});
 
-					return request(app)
-						.post('/entities/disassociateEntity')
-						.send(
-							generateDisassociateEntityRequest({
-								issueId,
-								entityId: fileKey,
-							}),
-						)
-						.set('Authorization', DISASSOCIATE_JWT_TOKEN)
-						.set('Content-Type', 'application/json')
-						.set('User-Id', validCredentialsParams.atlassianUserId)
-						.expect(HttpStatusCode.InternalServerError);
-				});
+		it('should respond with 401 "User-Id" header is not set', () => {
+			return request(app)
+				.post('/entities/disassociateEntity')
+				.send(generateDisassociateEntityRequest())
+				.set('Authorization', DISASSOCIATE_JWT_TOKEN)
+				.set('Content-Type', 'application/json')
+				.expect(HttpStatusCode.Unauthorized);
+		});
 
-				it('should respond with 500 if fetching issue details fails', async () => {
-					const fileName = generateFigmaFileName();
-					const fileKey = generateFigmaFileKey();
-					const issueId = generateJiraIssueId();
-					const fileResponse = generateGetFileResponse({ name: fileName });
-					const credentials = await figmaOAuth2UserCredentialsRepository.get(
-						validCredentialsParams.atlassianUserId,
-					);
-					mockGetFileEndpoint({
-						fileKey,
-						accessToken: credentials?.accessToken,
-						query: { depth: '1' },
-						response: fileResponse,
-					});
-					mockMeEndpoint();
-					mockGetIssueEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						status: HttpStatusCode.InternalServerError,
-					});
-
-					return request(app)
-						.post('/entities/disassociateEntity')
-						.send(
-							generateDisassociateEntityRequest({
-								issueId,
-								entityId: fileKey,
-							}),
-						)
-						.set('Authorization', DISASSOCIATE_JWT_TOKEN)
-						.set('Content-Type', 'application/json')
-						.set('User-Id', validCredentialsParams.atlassianUserId)
-						.expect(HttpStatusCode.InternalServerError);
-				});
-
-				it('should respond with 500 if design ingestion fails', async () => {
-					const fileName = generateFigmaFileName();
-					const fileKey = generateFigmaFileKey();
-					const issueId = generateJiraIssueId();
-					const issue = generateJiraIssue({ id: issueId });
-					const fileResponse = generateGetFileResponse({ name: fileName });
-					const credentials = await figmaOAuth2UserCredentialsRepository.get(
-						validCredentialsParams.atlassianUserId,
-					);
-
-					mockMeEndpoint({ success: true, times: 2 });
-					mockGetFileEndpoint({
-						fileKey,
-						accessToken: credentials?.accessToken,
-						query: { depth: '1' },
-						response: fileResponse,
-					});
-					mockGetIssueEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						response: issue,
-					});
-					mockGetDevResourcesEndpoint({
-						fileKey,
-						nodeId: '0:0',
-						response: generateEmptyDevResourcesResponse(),
-					});
-					mockGetIssuePropertyEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
-						status: HttpStatusCode.NotFound,
-					});
-					mockGetIssuePropertyEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-						status: HttpStatusCode.NotFound,
-					});
-					mockSubmitDesignsEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						status: HttpStatusCode.InternalServerError,
-					});
-
-					return request(app)
-						.post('/entities/disassociateEntity')
-						.send(
-							generateDisassociateEntityRequest({
-								issueId,
-								entityId: fileKey,
-							}),
-						)
-						.set('Authorization', DISASSOCIATE_JWT_TOKEN)
-						.set('Content-Type', 'application/json')
-						.set('User-Id', validCredentialsParams.atlassianUserId)
-						.expect(HttpStatusCode.InternalServerError);
-				});
-
-				it('should respond with 200 if getDevResource returns no resources', async () => {
-					const fileName = generateFigmaFileName();
-					const fileKey = generateFigmaFileKey();
-					const issueId = generateJiraIssueId();
-					const issue = generateJiraIssue({ id: issueId });
-					const fileResponse = generateGetFileResponse({ name: fileName });
-					const credentials = await figmaOAuth2UserCredentialsRepository.get(
-						validCredentialsParams.atlassianUserId,
-					);
-
-					mockMeEndpoint({ success: true, times: 2 });
-					mockGetFileEndpoint({
-						fileKey,
-						accessToken: credentials?.accessToken,
-						query: { depth: '1' },
-						response: fileResponse,
-					});
-					mockGetIssueEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						response: issue,
-					});
-					mockSubmitDesignsEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					});
-					mockGetIssuePropertyEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
-						status: HttpStatusCode.NotFound,
-					});
-					mockGetIssuePropertyEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-						status: HttpStatusCode.NotFound,
-					});
-					mockGetDevResourcesEndpoint({
-						fileKey,
-						nodeId: '0:0',
-						response: generateEmptyDevResourcesResponse(),
-					});
-
-					return request(app)
-						.post('/entities/disassociateEntity')
-						.send(
-							generateDisassociateEntityRequest({
-								issueId,
-								entityId: fileKey,
-							}),
-						)
-						.set('Authorization', DISASSOCIATE_JWT_TOKEN)
-						.set('Content-Type', 'application/json')
-						.set('User-Id', validCredentialsParams.atlassianUserId)
-						.expect(HttpStatusCode.Ok);
-				});
-
-				it('should respond with 500 if deleteDevResource request fails', async () => {
-					const fileName = generateFigmaFileName();
-					const fileKey = generateFigmaFileKey();
-					const issueId = generateJiraIssueId();
-					const issue = generateJiraIssue({ id: issueId });
-					const fileResponse = generateGetFileResponse({ name: fileName });
-					const devResourceId = uuidv4();
-					const credentials = await figmaOAuth2UserCredentialsRepository.get(
-						validCredentialsParams.atlassianUserId,
-					);
-
-					mockMeEndpoint({ success: true, times: 2 });
-					mockGetFileEndpoint({
-						fileKey,
-						accessToken: credentials?.accessToken,
-						query: { depth: '1' },
-						response: fileResponse,
-					});
-					mockGetIssueEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						response: issue,
-					});
-					mockSubmitDesignsEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-					});
-					mockGetDevResourcesEndpoint({
-						fileKey,
-						nodeId: '0:0',
-						response: generateGetDevResourcesResponse({
-							id: devResourceId,
-							url: generateJiraIssueUrl({
-								baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-								key: issue.key,
-							}),
-						}),
-					});
-					mockGetIssuePropertyEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
-						status: HttpStatusCode.NotFound,
-					});
-					mockGetIssuePropertyEndpoint({
-						baseUrl: MOCK_CONNECT_INSTALLATION.baseUrl,
-						issueId,
-						propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
-						status: HttpStatusCode.NotFound,
-					});
-					mockDeleteDevResourcesEndpoint({
-						fileKey,
-						devResourceId,
-						status: HttpStatusCode.InternalServerError,
-					});
-
-					return request(app)
-						.post('/entities/disassociateEntity')
-						.send(
-							generateDisassociateEntityRequest({
-								issueId,
-								entityId: fileKey,
-							}),
-						)
-						.set('Authorization', DISASSOCIATE_JWT_TOKEN)
-						.set('Content-Type', 'application/json')
-						.set('User-Id', validCredentialsParams.atlassianUserId)
-						.expect(HttpStatusCode.InternalServerError);
-				});
+		it('should respond with 403 if credentials are not found', async () => {
+			const issueId = generateJiraIssueId();
+			const connectInstallation = await connectInstallationRepository.upsert(
+				MOCK_CONNECT_INSTALLATION_CREATE_PARAMS,
+			);
+			mockGetIssueEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
 			});
+
+			return request(app)
+				.post('/entities/disassociateEntity')
+				.send(generateDisassociateEntityRequest({ issueId }))
+				.set('Authorization', DISASSOCIATE_JWT_TOKEN)
+				.set('Content-Type', 'application/json')
+				.set('User-Id', uuidv4())
+				.expect(HttpStatusCode.Forbidden);
+		});
+
+		it('should respond with 500 if design fetching fails', async () => {
+			const atlassianUserId = uuidv4();
+			const fileKey = generateFigmaFileKey();
+			const issueId = generateJiraIssueId();
+
+			const figmaUserCredentials =
+				await figmaOAuth2UserCredentialsRepository.upsert(
+					generateFigmaUserCredentialsCreateParams({ atlassianUserId }),
+				);
+			const connectInstallation = await connectInstallationRepository.upsert(
+				MOCK_CONNECT_INSTALLATION_CREATE_PARAMS,
+			);
+
+			mockMeEndpoint({ success: true, times: 2 });
+			mockGetIssueEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				issueId,
+			});
+			mockGetFileEndpoint({
+				fileKey,
+				accessToken: figmaUserCredentials.accessToken,
+				query: { depth: '1' },
+				status: HttpStatusCode.InternalServerError,
+			});
+
+			return request(app)
+				.post('/entities/disassociateEntity')
+				.send(generateDisassociateEntityRequest({ entityId: fileKey, issueId }))
+				.set('Authorization', DISASSOCIATE_JWT_TOKEN)
+				.set('Content-Type', 'application/json')
+				.set('User-Id', atlassianUserId)
+				.expect(HttpStatusCode.InternalServerError);
 		});
 	});
 });

--- a/src/web/routes/figma/integration.test.ts
+++ b/src/web/routes/figma/integration.test.ts
@@ -1,4 +1,3 @@
-import type { FigmaTeam } from '@prisma/client';
 import { HttpStatusCode } from 'axios';
 import nock from 'nock';
 import request from 'supertest';
@@ -9,6 +8,7 @@ import { getConfig } from '../../../config';
 import type {
 	AssociatedFigmaDesign,
 	ConnectInstallation,
+	FigmaTeam,
 } from '../../../domain/entities';
 import { FigmaTeamAuthStatus } from '../../../domain/entities';
 import {


### PR DESCRIPTION
## Changes

- **[Feature]:** Add `AssociatedFigmaDesign.associatedWithAri` field to track which Atlassian entity (e.g., Issue) a design is associated with. This knowledge is used to find and delete only a target `AssociatedFigmaDesign` record on a `/disassociateEntity` request.
- **[Feature]:** Update `/disassociateEntity` flow to delete `AssociatedFigmaDesign`.
- **[Improvement]:** Do not set up nock and Prisma for unit tests but only for integration tests.
- **[Improvement]:** Clean the database before each integration test.
- **[Improvement]:** Remove excessive integration tests for `/associateEntity` and `/disassociateEntity`.
- **[Improvement]:** Add unit test for `/associateEntity` and `/disassociateEntity`.
