### PR TITLE
NONE Update webhook event payload schema and fix `jwt:generate` script

### DIFF
--- a/scripts/create-jwt.ts
+++ b/scripts/create-jwt.ts
@@ -15,7 +15,7 @@ const jwt = createJwtToken({
 		method,
 		pathname: url.pathname,
 	},
-	connectClientKey: INSTALLATION_CLIENT_KEY,
+	connectAppKey: INSTALLATION_CLIENT_KEY,
 	connectSharedSecret: INSTALLATION_CLIENT_SECRET,
 	expiresIn: Duration.ofMinutes(99999),
 });

--- a/src/infrastructure/webhook/webhook-service.test.ts
+++ b/src/infrastructure/webhook/webhook-service.test.ts
@@ -74,6 +74,7 @@ describe('WebhookService', () => {
 		jest
 			.spyOn(figmaTeamRepository, 'getByWebhookId')
 			.mockResolvedValue(figmaTeam);
+		jest.spyOn(figmaTeamRepository, 'updateAuthStatus').mockResolvedValue();
 		jest
 			.spyOn(figmaService, 'getValidCredentialsOrThrow')
 			.mockRejectedValue(new Error('auth error'));

--- a/src/web/routes/figma/figma-router.ts
+++ b/src/web/routes/figma/figma-router.ts
@@ -23,7 +23,10 @@ figmaRouter.post('/webhook', (req, res, next) => {
 		.then((figmaTeam) => {
 			switch (event_type) {
 				case 'FILE_UPDATE':
-					return handleFigmaFileUpdateEventUseCase.execute(figmaTeam, file_key);
+					return handleFigmaFileUpdateEventUseCase.execute(
+						figmaTeam,
+						file_key!,
+					);
 				default:
 					return Promise.resolve();
 			}

--- a/src/web/routes/figma/integration.test.ts
+++ b/src/web/routes/figma/integration.test.ts
@@ -21,6 +21,7 @@ import {
 	generateConnectInstallationCreateParams,
 	generateFigmaDesignIdentifier,
 	generateFigmaFileKey,
+	generateFigmaFileName,
 	generateFigmaTeamCreateParams,
 	generateFigmaUserCredentialsCreateParams,
 } from '../../../domain/entities/testing';
@@ -159,6 +160,7 @@ describe('/figma', () => {
 				webhookEventPayload = generateFigmaWebhookEventPayload({
 					webhook_id: figmaTeam.webhookId,
 					file_key: fileKey,
+					file_name: generateFigmaFileName(),
 					passcode: figmaTeam.webhookPasscode,
 				});
 			});
@@ -225,6 +227,7 @@ describe('/figma', () => {
 				const invalidPasscodePayload = generateFigmaWebhookEventPayload({
 					webhook_id: figmaTeam.webhookId,
 					file_key: associatedFigmaDesigns[0].designId.fileKey,
+					file_name: generateFigmaFileName(),
 					passcode: 'invalid',
 				});
 
@@ -263,6 +266,8 @@ describe('/figma', () => {
 				async (unsupportedEventType: FigmaWebhookEventType) => {
 					const webhookEventPayload = generateFigmaWebhookEventPayload({
 						event_type: unsupportedEventType,
+						file_key: generateFigmaFileKey(),
+						file_name: generateFigmaFileName(),
 					});
 
 					await request(app)

--- a/src/web/routes/figma/schemas.test.ts
+++ b/src/web/routes/figma/schemas.test.ts
@@ -1,0 +1,68 @@
+import { FIGMA_WEBHOOK_PAYLOAD_SCHEMA } from './schemas';
+import { generateFigmaWebhookEventPayload } from './testing';
+
+import {
+	generateFigmaFileKey,
+	generateFigmaFileName,
+} from '../../../domain/entities/testing';
+import { assertSchema, SchemaValidationError } from '../../../infrastructure';
+
+describe('FIGMA_WEBHOOK_PAYLOAD_SCHEMA', () => {
+	it('should validate a PING event payload with no file_key or file_name', () => {
+		const payload = generateFigmaWebhookEventPayload({ event_type: 'PING' });
+
+		expect(() =>
+			assertSchema(payload, FIGMA_WEBHOOK_PAYLOAD_SCHEMA),
+		).not.toThrow();
+	});
+
+	it('should throw an error for a FILE_UPDATE event payload with no file_key', () => {
+		const payload = generateFigmaWebhookEventPayload({
+			event_type: 'FILE_UPDATE',
+			file_name: generateFigmaFileName(),
+		});
+
+		expect(() => assertSchema(payload, FIGMA_WEBHOOK_PAYLOAD_SCHEMA)).toThrow(
+			SchemaValidationError,
+		);
+	});
+
+	it('should throw an error for a FILE_UPDATE event payload with no file_name', () => {
+		const payload = generateFigmaWebhookEventPayload({
+			event_type: 'FILE_UPDATE',
+			file_key: generateFigmaFileKey(),
+		});
+
+		expect(() => assertSchema(payload, FIGMA_WEBHOOK_PAYLOAD_SCHEMA)).toThrow(
+			SchemaValidationError,
+		);
+	});
+
+	it('should throw an error for a FILE_UPDATE event payload with a null file_key', () => {
+		const payload = {
+			...generateFigmaWebhookEventPayload({
+				event_type: 'FILE_UPDATE',
+				file_name: generateFigmaFileName(),
+			}),
+			file_key: null,
+		};
+
+		expect(() => assertSchema(payload, FIGMA_WEBHOOK_PAYLOAD_SCHEMA)).toThrow(
+			SchemaValidationError,
+		);
+	});
+
+	it('should throw an error for a FILE_UPDATE event payload with a null file_name', () => {
+		const payload = {
+			...generateFigmaWebhookEventPayload({
+				event_type: 'FILE_UPDATE',
+				file_key: generateFigmaFileName(),
+			}),
+			file_name: null,
+		};
+
+		expect(() => assertSchema(payload, FIGMA_WEBHOOK_PAYLOAD_SCHEMA)).toThrow(
+			SchemaValidationError,
+		);
+	});
+});

--- a/src/web/routes/figma/schemas.ts
+++ b/src/web/routes/figma/schemas.ts
@@ -18,14 +18,29 @@ export const FIGMA_WEBHOOK_EVENT_TYPE_SCHEMA: JSONSchemaType<FigmaWebhookEventTy
 		],
 	};
 
+/**
+ * While AJV supports optional fields in schemas, it requires these fields to
+ * also be marked as nullable. If you mark an optional field as non-nullable,
+ * the schema validation works correctly but the typechecking complains that
+ * the field is not marked nullable.
+ *
+ * This function works around the typechecking by casting the field schema to
+ * the appropriate type. This is supposed to be fixed in the next major version
+ * of AJV.
+ *
+ * @see https://github.com/ajv-validator/ajv/issues/1664#issuecomment-873613644
+ */
+const optionalNonNullable = <T>(schema: T): T & { nullable: true } =>
+	schema as T & { nullable: true };
+
 export const FIGMA_WEBHOOK_PAYLOAD_SCHEMA: JSONSchemaTypeWithId<FigmaWebhookEventPayload> =
 	{
 		$id: 'figma-rest-api:webhook:event-payload',
 		type: 'object',
 		properties: {
 			event_type: FIGMA_WEBHOOK_EVENT_TYPE_SCHEMA,
-			file_key: { type: 'string' },
-			file_name: { type: 'string' },
+			file_key: optionalNonNullable({ type: 'string' }),
+			file_name: optionalNonNullable({ type: 'string' }),
 			passcode: { type: 'string' },
 			protocol_version: { type: 'string' },
 			retries: { type: 'integer' },
@@ -43,12 +58,19 @@ export const FIGMA_WEBHOOK_PAYLOAD_SCHEMA: JSONSchemaTypeWithId<FigmaWebhookEven
 		},
 		required: [
 			'event_type',
-			'file_key',
-			'file_name',
 			'passcode',
 			'protocol_version',
 			'retries',
 			'timestamp',
 			'webhook_id',
 		],
+		if: {
+			properties: { event_type: { const: 'PING' } },
+		},
+		then: {
+			required: [],
+		},
+		else: {
+			required: ['file_key', 'file_name'],
+		},
 	};

--- a/src/web/routes/figma/testing/mocks.ts
+++ b/src/web/routes/figma/testing/mocks.ts
@@ -1,15 +1,11 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import {
-	generateFigmaFileKey,
-	generateFigmaFileName,
-} from '../../../../domain/entities/testing';
 import type { FigmaWebhookEventPayload } from '../types';
 
 export const generateFigmaWebhookEventPayload = ({
 	event_type = 'FILE_UPDATE',
-	file_key = generateFigmaFileKey(),
-	file_name = generateFigmaFileName(),
+	file_key,
+	file_name,
 	passcode = 'passcode',
 	protocol_version = '2',
 	retries = 0,

--- a/src/web/routes/figma/types.ts
+++ b/src/web/routes/figma/types.ts
@@ -2,8 +2,8 @@ import type { FigmaWebhookEventType } from '../../../domain/entities';
 
 export type FigmaWebhookEventPayload = {
 	readonly event_type: FigmaWebhookEventType;
-	readonly file_key: string;
-	readonly file_name: string;
+	readonly file_key?: string;
+	readonly file_name?: string;
 	readonly passcode: string;
 	readonly protocol_version: string;
 	readonly retries: number;


### PR DESCRIPTION
Couple of small bugfixes:

- The first is to update the webhook event payload schema to make `file_key` and `file_name` optional for `PING` events
  - When we subscribe to a webhook, some `PING` events are emitted immediately. These events don't have a `file_key` or `file_name`, so our schema validation was failing and we were returning a `400`
- The second fix is just to update the `create-jwt.ts` script to fix a renamed parameter