### PR TITLE
MDTZ-974 Add endpoint for removing a configured Figma team

### DIFF
--- a/src/infrastructure/repositories/figma-team-repository.ts
+++ b/src/infrastructure/repositories/figma-team-repository.ts
@@ -35,6 +35,23 @@ export class FigmaTeamRepository {
 		return this.mapToFigmaTeam(dbModel);
 	};
 
+	delete = async (id: string): Promise<FigmaTeam> => {
+		try {
+			const dbModel = await prismaClient.get().figmaTeam.delete({
+				where: { id: BigInt(id) },
+			});
+			return this.mapToFigmaTeam(dbModel);
+		} catch (e: unknown) {
+			if (
+				e instanceof PrismaClientKnownRequestError &&
+				e.code === PrismaErrorCode.RecordNotFound
+			) {
+				throw new RepositoryRecordNotFoundError(e.message);
+			}
+			throw e;
+		}
+	};
+
 	getByWebhookId = async (webhookId: string): Promise<FigmaTeam> => {
 		const dbModel = await prismaClient
 			.get()
@@ -43,6 +60,23 @@ export class FigmaTeamRepository {
 		if (dbModel === null) {
 			throw new RepositoryRecordNotFoundError(
 				`Failed to find FigmaTeam for webhookId ${webhookId}`,
+			);
+		}
+
+		return this.mapToFigmaTeam(dbModel);
+	};
+
+	getByTeamIdAndConnectInstallationId = async (
+		teamId: string,
+		connectInstallationId: string,
+	): Promise<FigmaTeam> => {
+		const dbModel = await prismaClient.get().figmaTeam.findFirst({
+			where: { teamId, connectInstallationId: BigInt(connectInstallationId) },
+		});
+
+		if (dbModel === null) {
+			throw new RepositoryRecordNotFoundError(
+				`Failed to find FigmaTeam for teamId ${teamId} and connectInstallationId ${connectInstallationId}`,
 			);
 		}
 

--- a/src/usecases/index.ts
+++ b/src/usecases/index.ts
@@ -7,5 +7,6 @@ export * from './disassociate-entity-use-case';
 export * from './handle-figma-file-update-event-use-case';
 export * from './configure-figma-teams-use-case';
 export * from './list-figma-teams-use-case';
+export * from './remove-figma-team-use-case';
 export * from './types';
 export * from './schemas';

--- a/src/usecases/remove-figma-team-use-case.test.ts
+++ b/src/usecases/remove-figma-team-use-case.test.ts
@@ -1,0 +1,61 @@
+import { removeFigmaTeamUseCase } from './remove-figma-team-use-case';
+
+import { generateFigmaTeam } from '../domain/entities/testing';
+import { getLogger } from '../infrastructure';
+import { figmaService } from '../infrastructure/figma';
+import { figmaTeamRepository } from '../infrastructure/repositories';
+
+describe('removeFigmaTeamUseCase', () => {
+	it('should delete the webhook and FigmaTeam', async () => {
+		const figmaTeam = generateFigmaTeam();
+		jest
+			.spyOn(figmaTeamRepository, 'getByTeamIdAndConnectInstallationId')
+			.mockResolvedValue(figmaTeam);
+		jest.spyOn(figmaService, 'deleteWebhook').mockResolvedValue();
+		jest.spyOn(figmaTeamRepository, 'delete').mockResolvedValue(figmaTeam);
+
+		await removeFigmaTeamUseCase.execute(
+			figmaTeam.teamId,
+			figmaTeam.connectInstallationId,
+		);
+
+		expect(
+			figmaTeamRepository.getByTeamIdAndConnectInstallationId,
+		).toBeCalledWith(figmaTeam.teamId, figmaTeam.connectInstallationId);
+		expect(figmaService.deleteWebhook).toBeCalledWith(
+			figmaTeam.webhookId,
+			figmaTeam.figmaAdminAtlassianUserId,
+		);
+		expect(figmaTeamRepository.delete).toBeCalledWith(figmaTeam.id);
+	});
+
+	it('should delete the FigmaTeam and log a warning if deleting the webhook fails', async () => {
+		const figmaTeam = generateFigmaTeam();
+		const deleteWebhookError = new Error('delete webhook error');
+		jest
+			.spyOn(figmaTeamRepository, 'getByTeamIdAndConnectInstallationId')
+			.mockResolvedValue(figmaTeam);
+		jest
+			.spyOn(figmaService, 'deleteWebhook')
+			.mockRejectedValue(deleteWebhookError);
+		jest.spyOn(figmaTeamRepository, 'delete').mockResolvedValue(figmaTeam);
+
+		await removeFigmaTeamUseCase.execute(
+			figmaTeam.teamId,
+			figmaTeam.connectInstallationId,
+		);
+
+		expect(
+			figmaTeamRepository.getByTeamIdAndConnectInstallationId,
+		).toBeCalledWith(figmaTeam.teamId, figmaTeam.connectInstallationId);
+		expect(figmaService.deleteWebhook).toBeCalledWith(
+			figmaTeam.webhookId,
+			figmaTeam.figmaAdminAtlassianUserId,
+		);
+		expect(getLogger().warn).toBeCalledWith(
+			deleteWebhookError,
+			expect.anything(),
+		);
+		expect(figmaTeamRepository.delete).toBeCalledWith(figmaTeam.id);
+	});
+});

--- a/src/usecases/remove-figma-team-use-case.ts
+++ b/src/usecases/remove-figma-team-use-case.ts
@@ -1,0 +1,24 @@
+import { getLogger } from '../infrastructure';
+import { figmaService } from '../infrastructure/figma';
+import { figmaTeamRepository } from '../infrastructure/repositories';
+
+export const removeFigmaTeamUseCase = {
+	execute: async (teamId: string, connectInstallationId: string) => {
+		const { id, webhookId, figmaAdminAtlassianUserId } =
+			await figmaTeamRepository.getByTeamIdAndConnectInstallationId(
+				teamId,
+				connectInstallationId,
+			);
+
+		try {
+			await figmaService.deleteWebhook(webhookId, figmaAdminAtlassianUserId);
+		} catch (e: unknown) {
+			getLogger().warn(
+				e,
+				`Failed to delete webhook ${webhookId} with user ${figmaAdminAtlassianUserId} when removing FigmaTeam ${id}`,
+			);
+		}
+
+		await figmaTeamRepository.delete(id);
+	},
+};

--- a/src/web/routes/teams/schemas.ts
+++ b/src/web/routes/teams/schemas.ts
@@ -1,10 +1,23 @@
-import type { ConfigureFigmaTeamRequestBody } from './types';
+import type {
+	ConfigureFigmaTeamRequestBody,
+	RemoveFigmaTeamQueryParams,
+} from './types';
 
 import type { JSONSchemaTypeWithId } from '../../../infrastructure';
 
 export const CONFIGURE_FIGMA_TEAMS_REQUEST_BODY: JSONSchemaTypeWithId<ConfigureFigmaTeamRequestBody> =
 	{
 		$id: 'figma-for-jira:configure-figma-teams-request-body',
+		type: 'object',
+		properties: {
+			teamId: { type: 'string' },
+		},
+		required: ['teamId'],
+	};
+
+export const REMOVE_FIGMA_TEAM_QUERY_PARAMS_SCHEMA: JSONSchemaTypeWithId<RemoveFigmaTeamQueryParams> =
+	{
+		$id: 'figma-for-jira:remove-figma-team-request-query-params',
 		type: 'object',
 		properties: {
 			teamId: { type: 'string' },

--- a/src/web/routes/teams/teams-router.ts
+++ b/src/web/routes/teams/teams-router.ts
@@ -2,17 +2,23 @@ import { HttpStatusCode } from 'axios';
 import type { NextFunction, Request } from 'express';
 import { Router } from 'express';
 
-import { CONFIGURE_FIGMA_TEAMS_REQUEST_BODY } from './schemas';
+import {
+	CONFIGURE_FIGMA_TEAMS_REQUEST_BODY,
+	REMOVE_FIGMA_TEAM_QUERY_PARAMS_SCHEMA,
+} from './schemas';
 import type {
 	ConfigureFigmaTeamsRequest,
 	ConfigureFigmaTeamsResponse,
 	ListFigmaTeamsResponse,
+	RemoveFigmaTeamRequest,
+	RemoveFigmaTeamResponse,
 } from './types';
 
 import { assertSchema } from '../../../infrastructure';
 import {
 	configureFigmaTeamUseCase,
 	listFigmaTeamsUseCase,
+	removeFigmaTeamUseCase,
 } from '../../../usecases';
 import {
 	authHeaderSymmetricJwtMiddleware,
@@ -38,6 +44,24 @@ teamsRouter.post(
 
 		configureFigmaTeamUseCase
 			.execute(req.body.teamId, atlassianUserId, connectInstallation)
+			.then(() => res.sendStatus(HttpStatusCode.Ok))
+			.catch(next);
+	},
+);
+
+teamsRouter.delete(
+	'/configure',
+	(
+		req: RemoveFigmaTeamRequest,
+		res: RemoveFigmaTeamResponse,
+		next: NextFunction,
+	) => {
+		assertSchema(req.query, REMOVE_FIGMA_TEAM_QUERY_PARAMS_SCHEMA);
+		const { teamId } = req.query;
+		const { connectInstallation } = res.locals;
+
+		removeFigmaTeamUseCase
+			.execute(teamId, connectInstallation.id)
 			.then(() => res.sendStatus(HttpStatusCode.Ok))
 			.catch(next);
 	},

--- a/src/web/routes/teams/types.ts
+++ b/src/web/routes/teams/types.ts
@@ -32,6 +32,24 @@ export type ConfigureFigmaTeamsResponse = Response<
 	ConfigureFigmaTeamsLocals
 >;
 
+export type RemoveFigmaTeamQueryParams = {
+	readonly teamId: string;
+};
+
+export type RemoveFigmaTeamLocals = {
+	readonly connectInstallation: ConnectInstallation;
+};
+
+export type RemoveFigmaTeamRequest = Request<
+	Record<string, never>,
+	never,
+	never,
+	RemoveFigmaTeamQueryParams,
+	RemoveFigmaTeamLocals
+>;
+
+export type RemoveFigmaTeamResponse = Response<never, RemoveFigmaTeamLocals>;
+
 export type ListFigmaTeamsLocals = {
 	readonly connectInstallation: ConnectInstallation;
 };

--- a/src/web/testing/mocks.ts
+++ b/src/web/testing/mocks.ts
@@ -3,6 +3,7 @@ import {
 	encodeAsymmetric,
 	encodeSymmetric,
 } from 'atlassian-jwt';
+import type { Params } from 'atlassian-jwt/dist/lib/jwt';
 import { AsymmetricAlgorithm } from 'atlassian-jwt/dist/lib/jwt';
 import type { Method } from 'axios';
 
@@ -76,10 +77,12 @@ export const generateInboundRequestAsymmetricJwtToken = async ({
 export const generateInboundRequestSymmetricJwtToken = ({
 	pathname,
 	method,
+	query,
 	connectInstallation: { clientKey, sharedSecret },
 }: {
 	pathname: string;
 	method: Method;
+	query?: Params;
 	connectInstallation: {
 		clientKey: string;
 		sharedSecret: string;
@@ -91,7 +94,7 @@ export const generateInboundRequestSymmetricJwtToken = ({
 			iat: nowInSeconds,
 			exp: nowInSeconds + 99999,
 			iss: clientKey,
-			qsh: createQueryStringHash({ pathname, method }),
+			qsh: createQueryStringHash({ pathname, method, query }),
 		},
 		sharedSecret,
 	);


### PR DESCRIPTION
Adds an endpoint (`DELETE /teams/configure`) for removing a configured `FigmaTeam`. The endpoint will attempt to delete the corresponding webhook, then delete the `FigmaTeam` record, regardless of whether or not deleting the webhook succeeded.

@akostevich-atlassian I will leave the refactoring updating the FigmaTeam auth status that we discussed to a separate PR, since it's not really related to these changes.