### PR TITLE
MDTZ-1019 / MDTZ-1034 Refactor handle file update event use case

### DIFF
--- a/src/infrastructure/figma/errors.ts
+++ b/src/infrastructure/figma/errors.ts
@@ -17,12 +17,6 @@ export class FigmaWebhookServiceEventTypeValidationError extends FigmaWebhookSer
 	}
 }
 
-export class FigmaWebhookServiceAuthValidationError extends FigmaWebhookServiceValidationError {
-	constructor(webhookId: string) {
-		super(`Figma team admin auth token for webhook ${webhookId} is invalid`);
-	}
-}
-
 export class FigmaWebhookServicePasscodeValidationError extends FigmaWebhookServiceValidationError {
 	constructor(webhookId: string) {
 		super(`Received webhook event for ${webhookId} with invalid passcode`);

--- a/src/infrastructure/figma/figma-client/testing/mocks.ts
+++ b/src/infrastructure/figma/figma-client/testing/mocks.ts
@@ -114,6 +114,21 @@ export const generateGetFileResponseWithNode = ({
 	},
 });
 
+export const generateGetFileResponseWithNodes = ({
+	name = generateFigmaFileName(),
+	lastModified = new Date(),
+	nodes = [generateChildNode()],
+} = {}): FileResponse => ({
+	name,
+	lastModified: lastModified.toISOString(),
+	role: 'editor',
+	editorType: 'figma',
+	document: {
+		...MOCK_DOCUMENT,
+		children: nodes,
+	},
+});
+
 export const generateGetFileResponseWithNodeId = (
 	nodeId: string,
 ): FileResponse =>

--- a/src/infrastructure/figma/figma-service.test.ts
+++ b/src/infrastructure/figma/figma-service.test.ts
@@ -2,7 +2,7 @@ import type { AxiosResponse } from 'axios';
 import { AxiosError, HttpStatusCode } from 'axios';
 import { v4 as uuidv4 } from 'uuid';
 
-import { FigmaServiceCredentialsError } from './errors';
+import { FigmaServiceCredentialsError, FigmaServiceError } from './errors';
 import {
 	figmaAuthService,
 	NoFigmaCredentialsError,
@@ -17,8 +17,10 @@ import type {
 import { figmaClient, FigmaClientNotFoundError } from './figma-client';
 import {
 	generateChildNode,
+	generateFrameNode,
 	generateGetFileResponse,
 	generateGetFileResponseWithNode,
+	generateGetFileResponseWithNodes,
 } from './figma-client/testing';
 import {
 	buildDevResourceNameFromJiraIssue,
@@ -205,9 +207,6 @@ describe('FigmaService', () => {
 			jest
 				.spyOn(figmaService, 'getValidCredentialsOrThrow')
 				.mockResolvedValue(credentials);
-			jest
-				.spyOn(figmaAuthService, 'getCredentials')
-				.mockResolvedValue(credentials);
 			jest.spyOn(figmaClient, 'getFile').mockRejectedValue(mockError);
 
 			await expect(
@@ -220,6 +219,109 @@ describe('FigmaService', () => {
 
 			await expect(() =>
 				figmaService.fetchDesignById(designId, ATLASSIAN_USER_ID),
+			).rejects.toBeInstanceOf(FigmaServiceCredentialsError);
+		});
+	});
+
+	describe('fetchDesignsByIds', () => {
+		it('should return valid design entities for design ids with and without node ids', async () => {
+			const nodeId1 = generateFigmaNodeId();
+			const node1 = generateFrameNode({ id: nodeId1 });
+			const nodeId2 = generateFigmaNodeId();
+			const node2 = generateFrameNode({ id: nodeId2 });
+			const designIdWithoutNode = generateFigmaDesignIdentifier();
+			const designIdWithNode1 = generateFigmaDesignIdentifier({
+				fileKey: designIdWithoutNode.fileKey,
+				nodeId: nodeId1,
+			});
+			const designIdWithNode2 = generateFigmaDesignIdentifier({
+				fileKey: designIdWithoutNode.fileKey,
+				nodeId: nodeId2,
+			});
+			const credentials = generateFigmaOAuth2UserCredentials();
+			const mockResponse = generateGetFileResponseWithNodes({
+				nodes: [node1, node2],
+			});
+
+			jest
+				.spyOn(figmaService, 'getValidCredentialsOrThrow')
+				.mockResolvedValue(credentials);
+			jest
+				.spyOn(figmaAuthService, 'getCredentials')
+				.mockResolvedValue(credentials);
+			jest.spyOn(figmaClient, 'getFile').mockResolvedValue(mockResponse);
+
+			const result = await figmaService.fetchDesignsByIds(
+				[designIdWithoutNode, designIdWithNode1, designIdWithNode2],
+				ATLASSIAN_USER_ID,
+			);
+
+			const expectedResult = [
+				transformFileToAtlassianDesign({
+					fileKey: designIdWithoutNode.fileKey,
+					fileResponse: mockResponse,
+				}),
+				transformNodeToAtlassianDesign({
+					fileKey: designIdWithNode1.fileKey,
+					nodeId: designIdWithNode1.nodeId!,
+					fileResponse: mockResponse,
+				}),
+				transformNodeToAtlassianDesign({
+					fileKey: designIdWithNode2.fileKey,
+					nodeId: designIdWithNode2.nodeId!,
+					fileResponse: mockResponse,
+				}),
+			];
+
+			expect(result).toStrictEqual(expectedResult);
+		});
+
+		it('should immediately return an empty array if passed an empty design ids array', async () => {
+			jest.spyOn(figmaService, 'getValidCredentialsOrThrow');
+
+			const result = await figmaService.fetchDesignsByIds(
+				[],
+				ATLASSIAN_USER_ID,
+			);
+
+			expect(result).toStrictEqual([]);
+			expect(figmaService.getValidCredentialsOrThrow).not.toBeCalled();
+		});
+
+		it('should throw a FigmaServiceError if design ids have different file keys', async () => {
+			const designIds = [
+				generateFigmaDesignIdentifier(),
+				generateFigmaDesignIdentifier(),
+				generateFigmaDesignIdentifier(),
+			];
+			jest.spyOn(figmaService, 'getValidCredentialsOrThrow');
+
+			await expect(
+				figmaService.fetchDesignsByIds(designIds, ATLASSIAN_USER_ID),
+			).rejects.toBeInstanceOf(FigmaServiceError);
+			expect(figmaService.getValidCredentialsOrThrow).not.toBeCalled();
+		});
+
+		it('should throw when a request to a figma api fails', async () => {
+			const designId = generateFigmaDesignIdentifier();
+			const credentials = generateFigmaOAuth2UserCredentials();
+			const mockError = new Error('Figma API failed');
+
+			jest
+				.spyOn(figmaService, 'getValidCredentialsOrThrow')
+				.mockResolvedValue(credentials);
+			jest.spyOn(figmaClient, 'getFile').mockRejectedValue(mockError);
+
+			await expect(
+				figmaService.fetchDesignsByIds([designId], ATLASSIAN_USER_ID),
+			).rejects.toStrictEqual(mockError);
+		});
+
+		it('should throw if the atlassian user is not authorized', async () => {
+			const designId = generateFigmaDesignIdentifier();
+
+			await expect(() =>
+				figmaService.fetchDesignsByIds([designId], ATLASSIAN_USER_ID),
 			).rejects.toBeInstanceOf(FigmaServiceCredentialsError);
 		});
 	});

--- a/src/infrastructure/figma/figma-webhook-service.test.ts
+++ b/src/infrastructure/figma/figma-webhook-service.test.ts
@@ -1,7 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import {
-	FigmaWebhookServiceAuthValidationError,
 	FigmaWebhookServiceEventTypeValidationError,
 	FigmaWebhookServicePasscodeValidationError,
 } from './errors';
@@ -65,28 +64,5 @@ describe('FigmaWebhookService', () => {
 			),
 		).rejects.toStrictEqual(expectedError);
 		expect(figmaService.getValidCredentialsOrThrow).not.toBeCalled();
-	});
-
-	it('should throw a FigmaWebhookAuthValidationError if team admin auth is invalid', async () => {
-		const eventType: FigmaWebhookEventType = 'FILE_UPDATE';
-		const webhookId = uuidv4();
-		const figmaTeam = generateFigmaTeam({ webhookId });
-		const expectedError = new FigmaWebhookServiceAuthValidationError(webhookId);
-
-		jest
-			.spyOn(figmaTeamRepository, 'getByWebhookId')
-			.mockResolvedValue(figmaTeam);
-		jest.spyOn(figmaTeamRepository, 'updateAuthStatus').mockResolvedValue();
-		jest
-			.spyOn(figmaService, 'getValidCredentialsOrThrow')
-			.mockRejectedValue(new Error('auth error'));
-
-		await expect(
-			figmaWebhookService.validateWebhookEvent(
-				eventType,
-				webhookId,
-				figmaTeam.webhookPasscode,
-			),
-		).rejects.toStrictEqual(expectedError);
 	});
 });

--- a/src/infrastructure/figma/figma-webhook-service.ts
+++ b/src/infrastructure/figma/figma-webhook-service.ts
@@ -1,13 +1,10 @@
 import {
-	FigmaWebhookServiceAuthValidationError,
 	FigmaWebhookServiceEventTypeValidationError,
 	FigmaWebhookServicePasscodeValidationError,
 } from './errors';
-import { figmaService } from './figma-service';
 
 import {
 	type FigmaTeam,
-	FigmaTeamAuthStatus,
 	type FigmaWebhookEventType,
 } from '../../domain/entities';
 import { figmaTeamRepository } from '../repositories';
@@ -25,19 +22,6 @@ export class FigmaWebhookService {
 		const figmaTeam = await figmaTeamRepository.getByWebhookId(webhookId);
 		if (figmaTeam.webhookPasscode !== passcode) {
 			throw new FigmaWebhookServicePasscodeValidationError(webhookId);
-		}
-
-		// Ensure team admin OAuth2 credentials are still valid
-		try {
-			await figmaService.getValidCredentialsOrThrow(
-				figmaTeam.figmaAdminAtlassianUserId,
-			);
-		} catch (e: unknown) {
-			await figmaTeamRepository.updateAuthStatus(
-				figmaTeam.id,
-				FigmaTeamAuthStatus.ERROR,
-			);
-			throw new FigmaWebhookServiceAuthValidationError(webhookId);
 		}
 
 		return figmaTeam;

--- a/src/web/middleware/error-handler-middleware.ts
+++ b/src/web/middleware/error-handler-middleware.ts
@@ -7,7 +7,6 @@ import { JwtVerificationError } from './jwt-utils';
 import { SchemaValidationError } from '../../infrastructure';
 import {
 	FigmaServiceCredentialsError,
-	FigmaWebhookServiceAuthValidationError,
 	FigmaWebhookServiceEventTypeValidationError,
 	FigmaWebhookServicePasscodeValidationError,
 } from '../../infrastructure/figma';
@@ -33,10 +32,7 @@ export const errorHandlerMiddleware = (
 		res.status(HttpStatusCode.NotFound).send(err.message);
 	} else if (err instanceof FigmaServiceCredentialsError) {
 		res.status(HttpStatusCode.Forbidden).send(err.message);
-	} else if (
-		err instanceof FigmaWebhookServiceEventTypeValidationError ||
-		err instanceof FigmaWebhookServiceAuthValidationError
-	) {
+	} else if (err instanceof FigmaWebhookServiceEventTypeValidationError) {
 		res.sendStatus(HttpStatusCode.Ok);
 	} else if (
 		err instanceof FigmaWebhookServicePasscodeValidationError ||

--- a/src/web/routes/figma/integration.test.ts
+++ b/src/web/routes/figma/integration.test.ts
@@ -7,14 +7,15 @@ import { generateFigmaWebhookEventPayload } from './testing';
 import type { FigmaWebhookEventPayload } from './types';
 
 import app from '../../../app';
+import { isString } from '../../../common/stringUtils';
 import { getConfig } from '../../../config';
-import {
-	type AssociatedFigmaDesign,
-	type AtlassianDesign,
-	type ConnectInstallation,
-	type FigmaTeam,
-	FigmaTeamAuthStatus,
-	type FigmaWebhookEventType,
+import { FigmaTeamAuthStatus } from '../../../domain/entities';
+import type {
+	AtlassianDesign,
+	ConnectInstallation,
+	FigmaDesignIdentifier,
+	FigmaTeam,
+	FigmaWebhookEventType,
 } from '../../../domain/entities';
 import {
 	generateAssociatedFigmaDesignCreateParams,
@@ -59,11 +60,10 @@ const FIGMA_OAUTH_TOKEN_ENDPOINT = '/api/oauth/token';
 
 const FIGMA_WEBHOOK_EVENT_ENDPOINT = '/figma/webhook';
 
-function generateAtlassianDesignFromAssociatedFigmaDesign(
-	associatedFigmaDesign: AssociatedFigmaDesign,
+function generateAtlassianDesignFromDesignIdAndFileResponse(
+	designId: FigmaDesignIdentifier,
 	fileResponse: FileResponse,
 ) {
-	const { designId } = associatedFigmaDesign;
 	let atlassianDesign: AtlassianDesign;
 	if (!designId.nodeId) {
 		atlassianDesign = transformFileToAtlassianDesign({
@@ -135,16 +135,16 @@ describe('/figma', () => {
 						fileKey,
 						connectInstallation.id,
 					);
-				const nodeIds = associatedFigmaDesigns.flatMap(({ designId }) =>
-					designId.nodeId ? designId.nodeId : [],
-				);
+				const nodeIds = associatedFigmaDesigns
+					.map(({ designId }) => designId.nodeId!)
+					.filter(isString);
 				const fileResponse = generateGetFileResponseWithNodes({
 					nodes: nodeIds.map((nodeId) => generateChildNode({ id: nodeId })),
 				});
 				const associatedAtlassianDesigns = associatedFigmaDesigns.map(
 					(design) =>
-						generateAtlassianDesignFromAssociatedFigmaDesign(
-							design,
+						generateAtlassianDesignFromDesignIdAndFileResponse(
+							design.designId,
 							fileResponse,
 						),
 				);
@@ -189,16 +189,16 @@ describe('/figma', () => {
 						fileKey,
 						connectInstallation.id,
 					);
-				const nodeIds = associatedFigmaDesigns.flatMap(({ designId }) =>
-					designId.nodeId ? designId.nodeId : [],
-				);
+				const nodeIds = associatedFigmaDesigns
+					.map(({ designId }) => designId.nodeId!)
+					.filter(isString);
 				const fileResponse = generateGetFileResponseWithNodes({
 					nodes: nodeIds.map((nodeId) => generateChildNode({ id: nodeId })),
 				});
 				const associatedAtlassianDesigns = associatedFigmaDesigns.map(
 					(design) =>
-						generateAtlassianDesignFromAssociatedFigmaDesign(
-							design,
+						generateAtlassianDesignFromDesignIdAndFileResponse(
+							design.designId,
 							fileResponse,
 						),
 				);
@@ -276,9 +276,9 @@ describe('/figma', () => {
 						fileKey,
 						connectInstallation.id,
 					);
-				const nodeIds = associatedFigmaDesigns.flatMap(({ designId }) =>
-					designId.nodeId ? designId.nodeId : [],
-				);
+				const nodeIds = associatedFigmaDesigns
+					.map(({ designId }) => designId.nodeId!)
+					.filter(isString);
 
 				mockMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
 				mockGetTeamProjectsEndpoint({


### PR DESCRIPTION
This PR resolves two tickets for the webhook events endpoint:

**MDTZ-1019** 
Updated how we fetch design data to only make one API request, passing in a list of node IDs. Previously we were firing an API request for each `AssociatedFigmaDesign` record.

To facilitate this, the `FigmaService.fetchDesignsByIds` method was added that accepts a `FigmaDesignIdentifier[]` and parses the file response into an `AtlassianDesign[]`.

**MDTZ-1034**
Updated error handling to update FigmaTeam auth status whenever we get a FigmaServiceCredentialsError when hitting Figma APIs.