### PR TITLE
NONE: Add `FigmaTeam.adminInfo` to simplify `FigmaTeam` consumer code

### DIFF
--- a/src/domain/entities/figma-team.ts
+++ b/src/domain/entities/figma-team.ts
@@ -7,17 +7,34 @@ export enum FigmaTeamAuthStatus {
 
 export class FigmaTeam {
 	private readonly _adminInfo: ConnectUserInfo;
+	readonly id: string;
+	readonly webhookId: string;
+	readonly webhookPasscode: string;
+	readonly teamId: string;
+	readonly teamName: string;
+	readonly figmaAdminAtlassianUserId: string;
+	readonly authStatus: FigmaTeamAuthStatus;
+	readonly connectInstallationId: string;
 
-	constructor(
-		readonly id: string,
-		readonly webhookId: string,
-		readonly webhookPasscode: string,
-		readonly teamId: string,
-		readonly teamName: string,
-		readonly figmaAdminAtlassianUserId: string,
-		readonly authStatus: FigmaTeamAuthStatus,
-		readonly connectInstallationId: string,
-	) {
+	constructor(params: {
+		id: string;
+		webhookId: string;
+		webhookPasscode: string;
+		teamId: string;
+		teamName: string;
+		figmaAdminAtlassianUserId: string;
+		authStatus: FigmaTeamAuthStatus;
+		connectInstallationId: string;
+	}) {
+		this.id = params.id;
+		this.webhookId = params.webhookId;
+		this.webhookPasscode = params.webhookPasscode;
+		this.teamId = params.teamId;
+		this.teamName = params.teamName;
+		this.figmaAdminAtlassianUserId = params.figmaAdminAtlassianUserId;
+		this.authStatus = params.authStatus;
+		this.connectInstallationId = params.connectInstallationId;
+
 		this._adminInfo = {
 			atlassianUserId: this.figmaAdminAtlassianUserId,
 			connectInstallationId: this.connectInstallationId,
@@ -29,7 +46,15 @@ export class FigmaTeam {
 	}
 }
 
-export type FigmaTeamCreateParams = Omit<FigmaTeam, 'id' | 'adminInfo'>;
+export type FigmaTeamCreateParams = {
+	readonly webhookId: string;
+	readonly webhookPasscode: string;
+	readonly teamId: string;
+	readonly teamName: string;
+	readonly figmaAdminAtlassianUserId: string;
+	readonly authStatus: FigmaTeamAuthStatus;
+	readonly connectInstallationId: string;
+};
 
 export type FigmaTeamSummary = Pick<
 	FigmaTeam,

--- a/src/domain/entities/figma-team.ts
+++ b/src/domain/entities/figma-team.ts
@@ -1,20 +1,35 @@
+import type { ConnectUserInfo } from './connect-user-info';
+
 export enum FigmaTeamAuthStatus {
 	OK = 'OK',
 	ERROR = 'ERROR',
 }
 
-export type FigmaTeam = {
-	readonly id: string;
-	readonly webhookId: string;
-	readonly webhookPasscode: string;
-	readonly teamId: string;
-	readonly teamName: string;
-	readonly figmaAdminAtlassianUserId: string;
-	readonly authStatus: FigmaTeamAuthStatus;
-	readonly connectInstallationId: string;
-};
+export class FigmaTeam {
+	private readonly _adminInfo: ConnectUserInfo;
 
-export type FigmaTeamCreateParams = Omit<FigmaTeam, 'id'>;
+	constructor(
+		readonly id: string,
+		readonly webhookId: string,
+		readonly webhookPasscode: string,
+		readonly teamId: string,
+		readonly teamName: string,
+		readonly figmaAdminAtlassianUserId: string,
+		readonly authStatus: FigmaTeamAuthStatus,
+		readonly connectInstallationId: string,
+	) {
+		this._adminInfo = {
+			atlassianUserId: this.figmaAdminAtlassianUserId,
+			connectInstallationId: this.connectInstallationId,
+		};
+	}
+
+	get adminInfo() {
+		return this._adminInfo;
+	}
+}
+
+export type FigmaTeamCreateParams = Omit<FigmaTeam, 'id' | 'adminInfo'>;
 
 export type FigmaTeamSummary = Pick<
 	FigmaTeam,

--- a/src/domain/entities/testing/mocks.ts
+++ b/src/domain/entities/testing/mocks.ts
@@ -244,7 +244,7 @@ export const generateFigmaTeam = ({
 	authStatus = FigmaTeamAuthStatus.OK,
 	connectInstallationId = generateNumericStringId(),
 }: Partial<FigmaTeam> = {}): FigmaTeam =>
-	new FigmaTeam(
+	new FigmaTeam({
 		id,
 		webhookId,
 		webhookPasscode,
@@ -253,7 +253,7 @@ export const generateFigmaTeam = ({
 		figmaAdminAtlassianUserId,
 		authStatus,
 		connectInstallationId,
-	);
+	});
 
 export const generateFigmaTeamSummary = ({
 	teamId = uuidv4(),

--- a/src/domain/entities/testing/mocks.ts
+++ b/src/domain/entities/testing/mocks.ts
@@ -8,7 +8,6 @@ import type {
 	ConnectInstallationCreateParams,
 	ConnectUserInfo,
 	FigmaOAuth2UserCredentialsCreateParams,
-	FigmaTeam,
 	FigmaTeamCreateParams,
 	FigmaTeamSummary,
 	JiraIssue,
@@ -18,6 +17,7 @@ import {
 	AtlassianDesignType,
 	FigmaDesignIdentifier,
 	FigmaOAuth2UserCredentials,
+	FigmaTeam,
 	FigmaTeamAuthStatus,
 } from '..';
 import { Duration } from '../../../common/duration';
@@ -241,18 +241,19 @@ export const generateFigmaTeam = ({
 	teamId = uuidv4(),
 	teamName = uuidv4(),
 	figmaAdminAtlassianUserId = uuidv4(),
-	authStatus: status = FigmaTeamAuthStatus.OK,
+	authStatus = FigmaTeamAuthStatus.OK,
 	connectInstallationId = generateNumericStringId(),
-}: Partial<FigmaTeam> = {}): FigmaTeam => ({
-	id,
-	webhookId,
-	webhookPasscode,
-	teamId,
-	teamName,
-	figmaAdminAtlassianUserId,
-	authStatus: status,
-	connectInstallationId,
-});
+}: Partial<FigmaTeam> = {}): FigmaTeam =>
+	new FigmaTeam(
+		id,
+		webhookId,
+		webhookPasscode,
+		teamId,
+		teamName,
+		figmaAdminAtlassianUserId,
+		authStatus,
+		connectInstallationId,
+	);
 
 export const generateFigmaTeamSummary = ({
 	teamId = uuidv4(),

--- a/src/infrastructure/repositories/figma-team-repository.ts
+++ b/src/infrastructure/repositories/figma-team-repository.ts
@@ -6,11 +6,10 @@ import { RepositoryRecordNotFoundError } from './errors';
 import { prismaClient } from './prisma-client';
 
 import type {
-	FigmaTeam,
 	FigmaTeamCreateParams,
 	FigmaTeamSummary,
 } from '../../domain/entities';
-import { FigmaTeamAuthStatus } from '../../domain/entities';
+import { FigmaTeam, FigmaTeamAuthStatus } from '../../domain/entities';
 
 type PrismaFigmaTeamCreateParams = Omit<PrismaFigmaTeam, 'id'>;
 type PrismaFigmaTeamSummary = Pick<
@@ -176,16 +175,17 @@ export class FigmaTeamRepository {
 		figmaAdminAtlassianUserId,
 		authStatus,
 		connectInstallationId,
-	}: PrismaFigmaTeam): FigmaTeam => ({
-		id: id.toString(),
-		webhookId,
-		webhookPasscode,
-		teamId,
-		teamName,
-		figmaAdminAtlassianUserId,
-		authStatus: FigmaTeamAuthStatus[authStatus],
-		connectInstallationId: connectInstallationId.toString(),
-	});
+	}: PrismaFigmaTeam): FigmaTeam =>
+		new FigmaTeam(
+			id.toString(),
+			webhookId,
+			webhookPasscode,
+			teamId,
+			teamName,
+			figmaAdminAtlassianUserId,
+			FigmaTeamAuthStatus[authStatus],
+			connectInstallationId.toString(),
+		);
 
 	private mapToFigmaTeamSummary = ({
 		teamId,

--- a/src/infrastructure/repositories/figma-team-repository.ts
+++ b/src/infrastructure/repositories/figma-team-repository.ts
@@ -176,16 +176,16 @@ export class FigmaTeamRepository {
 		authStatus,
 		connectInstallationId,
 	}: PrismaFigmaTeam): FigmaTeam =>
-		new FigmaTeam(
-			id.toString(),
+		new FigmaTeam({
+			id: id.toString(),
 			webhookId,
 			webhookPasscode,
 			teamId,
 			teamName,
 			figmaAdminAtlassianUserId,
-			FigmaTeamAuthStatus[authStatus],
-			connectInstallationId.toString(),
-		);
+			authStatus: FigmaTeamAuthStatus[authStatus],
+			connectInstallationId: connectInstallationId.toString(),
+		});
 
 	private mapToFigmaTeamSummary = ({
 		teamId,

--- a/src/usecases/handle-figma-file-update-event-use-case.ts
+++ b/src/usecases/handle-figma-file-update-event-use-case.ts
@@ -14,10 +14,10 @@ import {
 export const handleFigmaFileUpdateEventUseCase = {
 	execute: async (figmaTeam: FigmaTeam, fileKey: string): Promise<void> => {
 		try {
-			const teamName = await figmaService.getTeamName(figmaTeam.teamId, {
-				atlassianUserId: figmaTeam.figmaAdminAtlassianUserId,
-				connectInstallationId: figmaTeam.connectInstallationId,
-			});
+			const teamName = await figmaService.getTeamName(
+				figmaTeam.teamId,
+				figmaTeam.adminInfo,
+			);
 			await figmaTeamRepository.updateTeamName(figmaTeam.id, teamName);
 		} catch (e: unknown) {
 			if (e instanceof FigmaServiceCredentialsError) {
@@ -42,10 +42,7 @@ export const handleFigmaFileUpdateEventUseCase = {
 		try {
 			const designs = await figmaService.fetchDesignsByIds(
 				associatedFigmaDesigns.map((design) => design.designId),
-				{
-					atlassianUserId: figmaTeam.figmaAdminAtlassianUserId,
-					connectInstallationId: figmaTeam.connectInstallationId,
-				},
+				figmaTeam.adminInfo,
 			);
 
 			await jiraService.submitDesigns(

--- a/src/usecases/remove-figma-team-use-case.test.ts
+++ b/src/usecases/remove-figma-team-use-case.test.ts
@@ -21,10 +21,10 @@ describe('removeFigmaTeamUseCase', () => {
 		expect(
 			figmaTeamRepository.getByTeamIdAndConnectInstallationId,
 		).toBeCalledWith(figmaTeam.teamId, figmaTeam.connectInstallationId);
-		expect(figmaService.tryDeleteWebhook).toBeCalledWith(figmaTeam.webhookId, {
-			atlassianUserId: figmaTeam.figmaAdminAtlassianUserId,
-			connectInstallationId: figmaTeam.connectInstallationId,
-		});
+		expect(figmaService.tryDeleteWebhook).toBeCalledWith(
+			figmaTeam.webhookId,
+			figmaTeam.adminInfo,
+		);
 		expect(figmaTeamRepository.delete).toBeCalledWith(figmaTeam.id);
 	});
 });

--- a/src/usecases/remove-figma-team-use-case.ts
+++ b/src/usecases/remove-figma-team-use-case.ts
@@ -3,17 +3,17 @@ import { figmaTeamRepository } from '../infrastructure/repositories';
 
 export const removeFigmaTeamUseCase = {
 	execute: async (teamId: string, connectInstallationId: string) => {
-		const { id, webhookId, figmaAdminAtlassianUserId } =
+		const figmaTeam =
 			await figmaTeamRepository.getByTeamIdAndConnectInstallationId(
 				teamId,
 				connectInstallationId,
 			);
 
-		await figmaService.tryDeleteWebhook(webhookId, {
-			atlassianUserId: figmaAdminAtlassianUserId,
-			connectInstallationId,
-		});
+		await figmaService.tryDeleteWebhook(
+			figmaTeam.webhookId,
+			figmaTeam.adminInfo,
+		);
 
-		await figmaTeamRepository.delete(id);
+		await figmaTeamRepository.delete(figmaTeam.id);
 	},
 };

--- a/src/usecases/uninstalled-use-case.test.ts
+++ b/src/usecases/uninstalled-use-case.test.ts
@@ -37,17 +37,11 @@ describe('uninstalledUseCase', () => {
 		expect(figmaService.tryDeleteWebhook).toHaveBeenCalledTimes(2);
 		expect(figmaService.tryDeleteWebhook).toHaveBeenCalledWith(
 			figmaTeam1.webhookId,
-			{
-				atlassianUserId: figmaTeam1.figmaAdminAtlassianUserId,
-				connectInstallationId: connectInstallation.id,
-			},
+			figmaTeam1.adminInfo,
 		);
 		expect(figmaService.tryDeleteWebhook).toHaveBeenCalledWith(
 			figmaTeam2.webhookId,
-			{
-				atlassianUserId: figmaTeam2.figmaAdminAtlassianUserId,
-				connectInstallationId: connectInstallation.id,
-			},
+			figmaTeam2.adminInfo,
 		);
 		expect(
 			connectInstallationRepository.deleteByClientKey,

--- a/src/usecases/uninstalled-use-case.ts
+++ b/src/usecases/uninstalled-use-case.ts
@@ -24,10 +24,7 @@ export const uninstalledUseCase = {
 
 		await Promise.allSettled(
 			figmaTeams.map((figmaTeam) =>
-				figmaService.tryDeleteWebhook(figmaTeam.webhookId, {
-					atlassianUserId: figmaTeam.figmaAdminAtlassianUserId,
-					connectInstallationId: figmaTeam.connectInstallationId,
-				}),
+				figmaService.tryDeleteWebhook(figmaTeam.webhookId, figmaTeam.adminInfo),
 			),
 		);
 		// The `ConnectInstallation` deletion causes cascading deletion of all the related records.

--- a/src/web/routes/teams/integration.test.ts
+++ b/src/web/routes/teams/integration.test.ts
@@ -84,16 +84,17 @@ describe('/teams', () => {
 				.expect(HttpStatusCode.Ok);
 
 			const figmaTeam = await figmaTeamRepository.getByWebhookId(webhookId);
-			expect(figmaTeam).toEqual({
-				id: expect.anything(),
-				webhookId,
-				webhookPasscode: figmaTeam.webhookPasscode,
-				teamId,
-				teamName,
-				figmaAdminAtlassianUserId: figmaOAuth2UserCredentials.atlassianUserId,
-				authStatus: FigmaTeamAuthStatus.OK,
-				connectInstallationId: connectInstallation.id,
-			});
+			expect(figmaTeam).toEqual(
+				expect.objectContaining({
+					webhookId,
+					webhookPasscode: figmaTeam.webhookPasscode,
+					teamId,
+					teamName,
+					figmaAdminAtlassianUserId: figmaOAuth2UserCredentials.atlassianUserId,
+					authStatus: FigmaTeamAuthStatus.OK,
+					connectInstallationId: connectInstallation.id,
+				}),
+			);
 		});
 
 		it('should return a 500 and not create a FigmaTeam when creating the webhook fails', async () => {


### PR DESCRIPTION
The PR addresses https://github.com/atlassian-labs/figma-for-jira/pull/83#discussion_r1340880224 from another PR.

## Changes

- **[Improvement]:** Adds a `FigmaTeam.adminInfo` property.
- **[Improvement]:** Update the `FigmaTeam` consumer code to leverage a new property instead of a manual construction of `ConnectUserInfo` object.