### PR TITLE
NONE: Fix "Uninstalled" event handling

### DIFF
--- a/scripts/create-jwt.ts
+++ b/scripts/create-jwt.ts
@@ -14,6 +14,7 @@ const jwt = createJwtToken({
 	request: {
 		method,
 		pathname: url.pathname,
+		query: Object.fromEntries(url.searchParams),
 	},
 	connectAppKey: INSTALLATION_CLIENT_KEY,
 	connectSharedSecret: INSTALLATION_CLIENT_SECRET,

--- a/src/web/routes/lifecycle-events/integration.test.ts
+++ b/src/web/routes/lifecycle-events/integration.test.ts
@@ -2,7 +2,10 @@ import { HttpStatusCode } from 'axios';
 import request from 'supertest';
 import { v4 as uuidv4 } from 'uuid';
 
-import { generateConnectLifecycleRequest } from './testing';
+import {
+	generateInstalledConnectLifecycleEventRequest,
+	generateUninstalledConnectLifecycleEventRequest,
+} from './testing';
 
 import app from '../../../app';
 import { getConfig } from '../../../config';
@@ -29,7 +32,9 @@ describe('/lifecycleEvents', () => {
 	describe('/installed', () => {
 		it('should create a connect installation record', async () => {
 			const clientKey = uuidv4();
-			const installedRequest = generateConnectLifecycleRequest({ clientKey });
+			const installedRequest = generateInstalledConnectLifecycleEventRequest({
+				clientKey,
+			});
 			const keyId = uuidv4();
 			const { jwtToken, publicKey } =
 				await generateInboundRequestAsymmetricJwtToken({
@@ -89,14 +94,14 @@ describe('/lifecycleEvents', () => {
 			return request(app)
 				.post('/lifecycleEvents/installed')
 				.set('Authorization', `JWT ${jwtToken}`)
-				.send(generateConnectLifecycleRequest())
+				.send(generateInstalledConnectLifecycleEventRequest())
 				.expect(HttpStatusCode.Unauthorized);
 		});
 
 		it('should respond 401 when JWT token is missing', () => {
 			return request(app)
 				.post('/lifecycleEvents/installed')
-				.send(generateConnectLifecycleRequest())
+				.send(generateInstalledConnectLifecycleEventRequest())
 				.expect(HttpStatusCode.Unauthorized);
 		});
 	});
@@ -205,7 +210,7 @@ describe('/lifecycleEvents', () => {
 				.post('/lifecycleEvents/uninstalled')
 				.set('Authorization', `JWT ${jwtToken}`)
 				.send(
-					generateConnectLifecycleRequest({
+					generateUninstalledConnectLifecycleEventRequest({
 						key: getConfig().app.key,
 						clientKey: targetConnectInstallation.clientKey,
 					}),
@@ -246,14 +251,14 @@ describe('/lifecycleEvents', () => {
 			return request(app)
 				.post('/lifecycleEvents/uninstalled')
 				.set('Authorization', `JWT ${jwtToken}`)
-				.send(generateConnectLifecycleRequest())
+				.send(generateUninstalledConnectLifecycleEventRequest())
 				.expect(HttpStatusCode.Unauthorized);
 		});
 
 		it('should respond 401 when JWT token is missing', () => {
 			return request(app)
 				.post('/lifecycleEvents/uninstalled')
-				.send(generateConnectLifecycleRequest())
+				.send(generateUninstalledConnectLifecycleEventRequest())
 				.expect(HttpStatusCode.Unauthorized);
 		});
 	});

--- a/src/web/routes/lifecycle-events/lifecycle-events-router.ts
+++ b/src/web/routes/lifecycle-events/lifecycle-events-router.ts
@@ -2,10 +2,14 @@ import { HttpStatusCode } from 'axios';
 import type { NextFunction } from 'express';
 import { Router } from 'express';
 
-import { CONNECT_LIFECYCLE_EVENT_REQUEST_BODY_SCHEMA } from './schemas';
+import {
+	INSTALLED_CONNECT_LIFECYCLE_EVENT_REQUEST_BODY_SCHEMA,
+	UNINSTALLED_CONNECT_LIFECYCLE_EVENT_REQUEST_BODY_SCHEMA,
+} from './schemas';
 import type {
-	ConnectLifecycleEventRequest,
 	ConnectLifecycleEventResponse,
+	InstalledConnectLifecycleEventRequest,
+	UninstalledConnectLifecycleEventRequest,
 } from './types';
 
 import type { ConnectInstallationCreateParams } from '../../../domain/entities';
@@ -24,11 +28,14 @@ lifecycleEventsRouter.post(
 	'/installed',
 	authHeaderAsymmetricJwtMiddleware,
 	(
-		req: ConnectLifecycleEventRequest,
+		req: InstalledConnectLifecycleEventRequest,
 		res: ConnectLifecycleEventResponse,
 		next: NextFunction,
 	) => {
-		assertSchema(req.body, CONNECT_LIFECYCLE_EVENT_REQUEST_BODY_SCHEMA);
+		assertSchema(
+			req.body,
+			INSTALLED_CONNECT_LIFECYCLE_EVENT_REQUEST_BODY_SCHEMA,
+		);
 		const installation: ConnectInstallationCreateParams = {
 			key: req.body.key,
 			clientKey: req.body.clientKey,
@@ -72,11 +79,14 @@ lifecycleEventsRouter.post(
 	'/uninstalled',
 	authHeaderAsymmetricJwtMiddleware,
 	(
-		req: ConnectLifecycleEventRequest,
+		req: UninstalledConnectLifecycleEventRequest,
 		res: ConnectLifecycleEventResponse,
 		next: NextFunction,
 	) => {
-		assertSchema(req.body, CONNECT_LIFECYCLE_EVENT_REQUEST_BODY_SCHEMA);
+		assertSchema(
+			req.body,
+			UNINSTALLED_CONNECT_LIFECYCLE_EVENT_REQUEST_BODY_SCHEMA,
+		);
 		const { clientKey } = req.body;
 		uninstalledUseCase
 			.execute(clientKey)

--- a/src/web/routes/lifecycle-events/schemas.ts
+++ b/src/web/routes/lifecycle-events/schemas.ts
@@ -1,10 +1,13 @@
-import type { ConnectLifecycleEventRequestBody } from './types';
+import type {
+	InstalledConnectLifecycleEventRequestBody,
+	UninstalledConnectLifecycleEventRequestBody,
+} from './types';
 
-import type { JSONSchemaTypeWithId } from '../../../infrastructure/ajv';
+import type { JSONSchemaTypeWithId } from '../../../infrastructure';
 
-export const CONNECT_LIFECYCLE_EVENT_REQUEST_BODY_SCHEMA: JSONSchemaTypeWithId<ConnectLifecycleEventRequestBody> =
+export const INSTALLED_CONNECT_LIFECYCLE_EVENT_REQUEST_BODY_SCHEMA: JSONSchemaTypeWithId<InstalledConnectLifecycleEventRequestBody> =
 	{
-		$id: 'jira-software-connect:lifecycle-event-request-body',
+		$id: 'jira-software-connect:installed-lifecycle-event-request-body',
 		type: 'object',
 		properties: {
 			key: { type: 'string' },
@@ -14,4 +17,17 @@ export const CONNECT_LIFECYCLE_EVENT_REQUEST_BODY_SCHEMA: JSONSchemaTypeWithId<C
 			displayUrl: { type: 'string', nullable: true },
 		},
 		required: ['key', 'clientKey', 'sharedSecret', 'baseUrl'],
+	};
+
+export const UNINSTALLED_CONNECT_LIFECYCLE_EVENT_REQUEST_BODY_SCHEMA: JSONSchemaTypeWithId<UninstalledConnectLifecycleEventRequestBody> =
+	{
+		$id: 'jira-software-connect:uninstalled-lifecycle-event-request-body',
+		type: 'object',
+		properties: {
+			key: { type: 'string' },
+			clientKey: { type: 'string' },
+			baseUrl: { type: 'string' },
+			displayUrl: { type: 'string', nullable: true },
+		},
+		required: ['key', 'clientKey', 'baseUrl'],
 	};

--- a/src/web/routes/lifecycle-events/testing/mocks.ts
+++ b/src/web/routes/lifecycle-events/testing/mocks.ts
@@ -1,17 +1,32 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import type { ConnectLifecycleEventRequestBody } from '../types';
+import type {
+	InstalledConnectLifecycleEventRequestBody,
+	UninstalledConnectLifecycleEventRequestBody,
+} from '../types';
 
-export const generateConnectLifecycleRequest = ({
+export const generateInstalledConnectLifecycleEventRequest = ({
 	key = uuidv4(),
 	clientKey = uuidv4(),
 	sharedSecret = uuidv4(),
 	baseUrl = `https://${uuidv4()}.atlassian.com`,
 	displayUrl = `https://${uuidv4()}.atlassian.com`,
-} = {}): ConnectLifecycleEventRequestBody => ({
+} = {}): InstalledConnectLifecycleEventRequestBody => ({
 	key,
 	clientKey,
 	sharedSecret,
+	baseUrl,
+	displayUrl,
+});
+
+export const generateUninstalledConnectLifecycleEventRequest = ({
+	key = uuidv4(),
+	clientKey = uuidv4(),
+	baseUrl = `https://${uuidv4()}.atlassian.com`,
+	displayUrl = `https://${uuidv4()}.atlassian.com`,
+} = {}): UninstalledConnectLifecycleEventRequestBody => ({
+	key,
+	clientKey,
 	baseUrl,
 	displayUrl,
 });

--- a/src/web/routes/lifecycle-events/types.ts
+++ b/src/web/routes/lifecycle-events/types.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from 'express';
 
-export type ConnectLifecycleEventRequestBody = {
+export type InstalledConnectLifecycleEventRequestBody = {
 	readonly key: string;
 	readonly clientKey: string;
 	readonly sharedSecret: string;
@@ -8,10 +8,25 @@ export type ConnectLifecycleEventRequestBody = {
 	readonly displayUrl?: string;
 };
 
-export type ConnectLifecycleEventRequest = Request<
+export type InstalledConnectLifecycleEventRequest = Request<
 	Record<string, never>,
 	never,
-	ConnectLifecycleEventRequestBody,
+	InstalledConnectLifecycleEventRequestBody,
+	Record<string, never>,
+	Record<string, never>
+>;
+
+export type UninstalledConnectLifecycleEventRequestBody = {
+	readonly key: string;
+	readonly clientKey: string;
+	readonly baseUrl: string;
+	readonly displayUrl?: string;
+};
+
+export type UninstalledConnectLifecycleEventRequest = Request<
+	Record<string, never>,
+	never,
+	UninstalledConnectLifecycleEventRequestBody,
 	Record<string, never>,
 	Record<string, never>
 >;


### PR DESCRIPTION
## Changes

- **[Fix]:** Fixes the issue with the "Uninstalled" event schema requiring `sharedSecret`. Jira does not send `sharedSecret` on the "Uninstalled" event (see more detail [here](https://developer.atlassian.com/cloud/jira/platform/connect-app-descriptor/#lifecycle)) -- therefore, `/lifecycleEvents/uninstalled` always returned an error. For extra safety and extensibility, the PR separates the types and schemas for lifecycle events due to minor differences among them.
- **[Improvement]:** Updates `createJwtToken` development utility to handle query parameters. This change allows to generate a token for an `auth/checkAuth` request:
  ```sh
  npm run jwt:generate \
    GET "${BASE_URL}/auth/checkAuth?userId=${ATLASSIAN_USER_ID}"
  ```