### PR TITLE
NONE: Refactor integration tests

### DIFF
--- a/src/infrastructure/figma/figma-client/testing/mocks.ts
+++ b/src/infrastructure/figma/figma-client/testing/mocks.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import type {
+	CreateDevResourcesRequest,
 	FileResponse,
 	GetDevResourcesResponse,
 	GetOAuth2TokenResponse,
@@ -129,12 +130,22 @@ export const generateGetFileResponseWithNodes = ({
 	},
 });
 
-export const generateGetFileResponseWithNodeId = (
-	nodeId: string,
-): FileResponse =>
-	generateGetFileResponseWithNode({
-		node: generateChildNode({ id: nodeId }),
-	});
+export const generateCreateDevResourcesRequest = ({
+	name = 'Mock dev resource',
+	url = generateJiraIssueUrl(),
+	fileKey = generateFigmaFileKey(),
+	nodeId = generateFigmaNodeId(),
+}: {
+	name?: string;
+	url?: string;
+	fileKey?: string;
+	nodeId?: string;
+} = {}): CreateDevResourcesRequest => ({
+	name,
+	url,
+	file_key: fileKey,
+	node_id: nodeId,
+});
 
 export const generateGetDevResourcesResponse = ({
 	id = uuidv4(),

--- a/src/infrastructure/figma/figma-client/testing/mocks.ts
+++ b/src/infrastructure/figma/figma-client/testing/mocks.ts
@@ -2,13 +2,17 @@ import { v4 as uuidv4 } from 'uuid';
 
 import type {
 	CreateDevResourcesRequest,
+	CreateWebhookRequest,
+	CreateWebhookResponse,
 	FileResponse,
 	GetDevResourcesResponse,
 	GetOAuth2TokenResponse,
+	GetTeamProjectsResponse,
 	Node,
 	RefreshOAuth2TokenResponse,
 } from '..';
 import { Duration } from '../../../../common/duration';
+import type { FigmaWebhookEventType } from '../../../../domain/entities';
 import {
 	generateFigmaFileKey,
 	generateFigmaFileName,
@@ -167,3 +171,46 @@ export const generateEmptyDevResourcesResponse =
 	(): GetDevResourcesResponse => ({
 		dev_resources: [],
 	});
+
+export const generateCreateWebhookRequest = ({
+	teamId = uuidv4(),
+	eventType = 'FILE_UPDATE' as FigmaWebhookEventType,
+	endpoint = `https://figma-for-jira.atlassian.com/figma/webhooks`,
+	passcode = uuidv4(),
+	description = 'Figma for Jira',
+} = {}): CreateWebhookRequest => ({
+	team_id: teamId,
+	event_type: eventType,
+	endpoint,
+	passcode,
+	description,
+});
+
+export const generateCreateWebhookResponse = ({
+	id = uuidv4(),
+	teamId = uuidv4(),
+	eventType = 'FILE_UPDATE',
+	clientId = uuidv4(),
+	endpoint = `https://figma-for-jira.atlassian.com/figma/webhooks`,
+	passcode = uuidv4(),
+	status = 'ACTIVE',
+	description = 'Figma for Jira',
+	protocolVersion = '2',
+} = {}): CreateWebhookResponse => ({
+	id: id,
+	team_id: teamId,
+	event_type: eventType,
+	client_id: clientId,
+	endpoint,
+	passcode,
+	status,
+	description,
+	protocol_version: protocolVersion,
+});
+
+export const generateGetTeamProjectsResponse = ({
+	name = `Team ${uuidv4()}`,
+} = {}): GetTeamProjectsResponse => ({
+	name,
+	projects: [],
+});

--- a/src/infrastructure/figma/figma-service.test.ts
+++ b/src/infrastructure/figma/figma-service.test.ts
@@ -22,10 +22,7 @@ import {
 	generateGetFileResponseWithNode,
 	generateGetFileResponseWithNodes,
 } from './figma-client/testing';
-import {
-	buildDevResourceNameFromJiraIssue,
-	figmaService,
-} from './figma-service';
+import { figmaService } from './figma-service';
 import {
 	transformFileToAtlassianDesign,
 	transformNodeToAtlassianDesign,
@@ -364,7 +361,7 @@ describe('FigmaService', () => {
 			});
 
 			const expectedDevResource: CreateDevResourcesRequest = {
-				name: buildDevResourceNameFromJiraIssue(issueKey, issueTitle),
+				name: `[${issueKey}] ${issueTitle}`,
 				url: issueUrl,
 				file_key: designId.fileKey,
 				node_id: '0:0',
@@ -397,7 +394,7 @@ describe('FigmaService', () => {
 			});
 
 			const expectedDevResource: CreateDevResourcesRequest = {
-				name: buildDevResourceNameFromJiraIssue(issueKey, issueTitle),
+				name: `[${issueKey}] ${issueTitle}`,
 				url: issueUrl,
 				file_key: designId.fileKey,
 				node_id: designId.nodeId!,

--- a/src/infrastructure/figma/figma-service.ts
+++ b/src/infrastructure/figma/figma-service.ts
@@ -22,7 +22,7 @@ import type {
 } from '../../domain/entities';
 import { getLogger } from '../logger';
 
-export const buildDevResourceNameFromJiraIssue = (
+const buildDevResourceNameFromJiraIssue = (
 	issueKey: string,
 	issueSummary: string,
 ) => `[${issueKey}] ${issueSummary}`;

--- a/src/infrastructure/jira/jira-client/testing/mocks.ts
+++ b/src/infrastructure/jira/jira-client/testing/mocks.ts
@@ -2,12 +2,14 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { Duration } from '../../../../common/duration';
 import {
+	generateFigmaFileKey,
 	generateJiraIssueId,
 	generateJiraIssueKey,
 	generateJiraIssueUrl,
 } from '../../../../domain/entities/testing';
 import type { JwtTokenParams } from '../jwt-utils';
 import type {
+	Association,
 	GetIssuePropertyResponse,
 	GetIssueResponse,
 	SubmitDesignsRequest,
@@ -30,16 +32,29 @@ export const MOCK_JWT_TOKEN_PARAMS: JwtTokenParams = {
 export const MOCK_JWT_TOKEN = 'test-jwt-token';
 
 export const generateSubmitDesignsRequest = ({
-	id = uuidv4(),
+	id = generateFigmaFileKey(),
 	displayName = `Design ${uuidv4()}`,
-	url = `https://www.figma.com/file/UcmoEBi9SyNOX3SNhXqShY/${displayName}?type=design&node-id=0-1&mode=design`,
-	liveEmbedUrl = `https://www.figma.com/file/UcmoEBi9SyNOX3SNhXqShY/${displayName}?type=design&node-id=0-1&mode=design`,
+	url = `https://www.figma.com/file/${id}/${displayName}?type=design&mode=design`,
+	liveEmbedUrl = `https://www.figma.com/file/${id}/${displayName}?type=design&mode=design`,
+	inspectUrl = `https://www.figma.com/file/${id}/${displayName}?mode=dev",`,
 	status = 'UNKNOWN',
 	type = 'FILE',
 	lastUpdated = new Date().toISOString(),
 	updateSequenceNumber = Date.now(),
-	addAssociations = [],
-	removeAssociations = [],
+	addAssociations = null,
+	removeAssociations = null,
+}: {
+	id?: string;
+	displayName?: string;
+	url?: string;
+	liveEmbedUrl?: string;
+	inspectUrl?: string;
+	status?: string;
+	type?: string;
+	lastUpdated?: string;
+	updateSequenceNumber?: number;
+	addAssociations?: Association[] | null;
+	removeAssociations?: Association[] | null;
 } = {}): SubmitDesignsRequest => ({
 	designs: [
 		{
@@ -47,6 +62,7 @@ export const generateSubmitDesignsRequest = ({
 			displayName,
 			url,
 			liveEmbedUrl,
+			inspectUrl,
 			status,
 			type,
 			lastUpdated,

--- a/src/web/routes/entities/integration.test.ts
+++ b/src/web/routes/entities/integration.test.ts
@@ -46,16 +46,16 @@ import {
 } from '../../../infrastructure/repositories';
 import {
 	generateInboundRequestSymmetricJwtToken,
-	mockCreateDevResourcesEndpoint,
-	mockDeleteDevResourcesEndpoint,
-	mockDeleteIssuePropertyEndpoint,
-	mockGetDevResourcesEndpoint,
-	mockGetFileEndpoint,
-	mockGetIssueEndpoint,
-	mockGetIssuePropertyEndpoint,
-	mockMeEndpoint,
-	mockSetIssuePropertyEndpoint,
-	mockSubmitDesignsEndpoint,
+	mockFigmaCreateDevResourcesEndpoint,
+	mockFigmaDeleteDevResourcesEndpoint,
+	mockFigmaGetDevResourcesEndpoint,
+	mockFigmaGetFileEndpoint,
+	mockFigmaMeEndpoint,
+	mockJiraDeleteIssuePropertyEndpoint,
+	mockJiraGetIssueEndpoint,
+	mockJiraGetIssuePropertyEndpoint,
+	mockJiraSetIssuePropertyEndpoint,
+	mockJiraSubmitDesignsEndpoint,
 } from '../../testing';
 
 const MOCK_CONNECT_INSTALLATION_CREATE_PARAMS =
@@ -153,44 +153,46 @@ describe('/entities', () => {
 					}),
 				);
 
-			mockMeEndpoint({
+			mockFigmaMeEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 			});
-			mockGetFileEndpoint({
+			mockFigmaGetFileEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				fileKey,
 				accessToken: figmaUserCredentials.accessToken,
 				query: { depth: '1' },
 				response: fileResponse,
 			});
-			mockGetIssueEndpoint({
+			mockJiraGetIssueEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 			});
-			mockSubmitDesignsEndpoint({
+			mockJiraSubmitDesignsEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 			});
-			mockCreateDevResourcesEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
+			mockFigmaCreateDevResourcesEndpoint({
+				baseUrl: getConfig().figma.apiBaseUrl,
+			});
 
-			mockGetIssuePropertyEndpoint({
+			mockJiraGetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
 				status: HttpStatusCode.NotFound,
 			});
-			mockSetIssuePropertyEndpoint({
+			mockJiraSetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
 				value: JSON.stringify(normalizedFigmaDesignUrl),
 			});
-			mockGetIssuePropertyEndpoint({
+			mockJiraGetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
 				status: HttpStatusCode.NotFound,
 			});
-			mockSetIssuePropertyEndpoint({
+			mockJiraSetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
@@ -267,10 +269,10 @@ describe('/entities', () => {
 					}),
 				);
 
-			mockMeEndpoint({
+			mockFigmaMeEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 			});
-			mockGetFileEndpoint({
+			mockFigmaGetFileEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				fileKey,
 				accessToken: figmaUserCredentials.accessToken,
@@ -280,34 +282,36 @@ describe('/entities', () => {
 				},
 				response: fileResponse,
 			});
-			mockGetIssueEndpoint({
+			mockJiraGetIssueEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 			});
-			mockSubmitDesignsEndpoint({
+			mockJiraSubmitDesignsEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 			});
-			mockCreateDevResourcesEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
+			mockFigmaCreateDevResourcesEndpoint({
+				baseUrl: getConfig().figma.apiBaseUrl,
+			});
 
-			mockGetIssuePropertyEndpoint({
+			mockJiraGetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
 				status: HttpStatusCode.NotFound,
 			});
-			mockSetIssuePropertyEndpoint({
+			mockJiraSetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
 				value: JSON.stringify(normalizedFigmaDesignUrl),
 			});
-			mockGetIssuePropertyEndpoint({
+			mockJiraGetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
 				status: HttpStatusCode.NotFound,
 			});
-			mockSetIssuePropertyEndpoint({
+			mockJiraSetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
@@ -359,7 +363,7 @@ describe('/entities', () => {
 			const connectInstallation = await connectInstallationRepository.upsert(
 				MOCK_CONNECT_INSTALLATION_CREATE_PARAMS,
 			);
-			mockGetIssueEndpoint({
+			mockJiraGetIssueEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 			});
@@ -395,14 +399,14 @@ describe('/entities', () => {
 					}),
 				);
 
-			mockMeEndpoint({
+			mockFigmaMeEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 			});
-			mockGetIssueEndpoint({
+			mockJiraGetIssueEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 			});
-			mockGetFileEndpoint({
+			mockFigmaGetFileEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				fileKey,
 				accessToken: figmaUserCredentials.accessToken,
@@ -462,25 +466,25 @@ describe('/entities', () => {
 				associatedWithAri: issueAri,
 				connectInstallationId: connectInstallation.id,
 			});
-			mockMeEndpoint({
+			mockFigmaMeEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 			});
-			mockGetFileEndpoint({
+			mockFigmaGetFileEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				fileKey,
 				accessToken: figmaUserCredentials.accessToken,
 				query: { depth: '1' },
 				response: fileResponse,
 			});
-			mockGetIssueEndpoint({
+			mockJiraGetIssueEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				response: issue,
 			});
-			mockSubmitDesignsEndpoint({
+			mockJiraSubmitDesignsEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 			});
-			mockGetDevResourcesEndpoint({
+			mockFigmaGetDevResourcesEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				fileKey,
 				nodeId: '0:0',
@@ -492,12 +496,12 @@ describe('/entities', () => {
 					}),
 				}),
 			});
-			mockDeleteDevResourcesEndpoint({
+			mockFigmaDeleteDevResourcesEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				fileKey,
 				devResourceId,
 			});
-			mockGetIssuePropertyEndpoint({
+			mockJiraGetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
@@ -506,7 +510,7 @@ describe('/entities', () => {
 					value: figmaDesignUrl,
 				}),
 			});
-			mockDeleteIssuePropertyEndpoint({
+			mockJiraDeleteIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
@@ -521,7 +525,7 @@ describe('/entities', () => {
 					{ url: figmaDesignUrl, name: fileResponse.name },
 					expectedDesignUrlV2Value,
 				];
-			mockGetIssuePropertyEndpoint({
+			mockJiraGetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
@@ -530,7 +534,7 @@ describe('/entities', () => {
 					value: JSON.stringify(attachedDesignUrlV2Values),
 				}),
 			});
-			mockSetIssuePropertyEndpoint({
+			mockJiraSetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
@@ -595,25 +599,25 @@ describe('/entities', () => {
 				connectInstallationId: connectInstallation.id,
 			});
 
-			mockMeEndpoint({
+			mockFigmaMeEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 			});
-			mockGetFileEndpoint({
+			mockFigmaGetFileEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				fileKey,
 				accessToken: figmaUserCredentials.accessToken,
 				query: { ids: nodeId, node_last_modified: 'true' },
 				response: fileResponse,
 			});
-			mockGetIssueEndpoint({
+			mockJiraGetIssueEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				response: issue,
 			});
-			mockSubmitDesignsEndpoint({
+			mockJiraSubmitDesignsEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 			});
-			mockGetDevResourcesEndpoint({
+			mockFigmaGetDevResourcesEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				fileKey,
 				nodeId,
@@ -625,12 +629,12 @@ describe('/entities', () => {
 					}),
 				}),
 			});
-			mockDeleteDevResourcesEndpoint({
+			mockFigmaDeleteDevResourcesEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				fileKey,
 				devResourceId,
 			});
-			mockGetIssuePropertyEndpoint({
+			mockJiraGetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
@@ -639,7 +643,7 @@ describe('/entities', () => {
 					value: figmaDesignUrl,
 				}),
 			});
-			mockDeleteIssuePropertyEndpoint({
+			mockJiraDeleteIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
@@ -654,7 +658,7 @@ describe('/entities', () => {
 					{ url: figmaDesignUrl, name: fileResponse.name },
 					expectedDesignUrlV2Value,
 				];
-			mockGetIssuePropertyEndpoint({
+			mockJiraGetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
@@ -663,7 +667,7 @@ describe('/entities', () => {
 					value: JSON.stringify(attachedDesignUrlV2Values),
 				}),
 			});
-			mockSetIssuePropertyEndpoint({
+			mockJiraSetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
@@ -705,37 +709,37 @@ describe('/entities', () => {
 					}),
 				);
 
-			mockMeEndpoint({
+			mockFigmaMeEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 			});
-			mockGetFileEndpoint({
+			mockFigmaGetFileEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				fileKey,
 				accessToken: figmaUserCredentials.accessToken,
 				query: { depth: '1' },
 				response: fileResponse,
 			});
-			mockGetIssueEndpoint({
+			mockJiraGetIssueEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				response: issue,
 			});
-			mockSubmitDesignsEndpoint({
+			mockJiraSubmitDesignsEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 			});
-			mockGetIssuePropertyEndpoint({
+			mockJiraGetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL,
 				status: HttpStatusCode.NotFound,
 			});
-			mockGetIssuePropertyEndpoint({
+			mockJiraGetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 				propertyKey: propertyKeys.ATTACHED_DESIGN_URL_V2,
 				status: HttpStatusCode.NotFound,
 			});
-			mockGetDevResourcesEndpoint({
+			mockFigmaGetDevResourcesEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				fileKey,
 				nodeId: '0:0',
@@ -770,7 +774,7 @@ describe('/entities', () => {
 			const connectInstallation = await connectInstallationRepository.upsert(
 				MOCK_CONNECT_INSTALLATION_CREATE_PARAMS,
 			);
-			mockGetIssueEndpoint({
+			mockJiraGetIssueEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 			});
@@ -800,14 +804,14 @@ describe('/entities', () => {
 					}),
 				);
 
-			mockMeEndpoint({
+			mockFigmaMeEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 			});
-			mockGetIssueEndpoint({
+			mockJiraGetIssueEndpoint({
 				baseUrl: connectInstallation.baseUrl,
 				issueId,
 			});
-			mockGetFileEndpoint({
+			mockFigmaGetFileEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				fileKey,
 				accessToken: figmaUserCredentials.accessToken,

--- a/src/web/routes/entities/integration.test.ts
+++ b/src/web/routes/entities/integration.test.ts
@@ -179,7 +179,9 @@ describe('/entities', () => {
 				request: generateSubmitDesignsRequest({
 					...atlassianDesign,
 					addAssociations: [
-						AtlassianAssociation.createDesignIssueAssociation(issueAri),
+						// Nock does not correctly match a request body when provide an instance of a class
+						// (e.g., as `AtlassianAssociation`). Therefore, pass an object instead.
+						{ ...AtlassianAssociation.createDesignIssueAssociation(issueAri) },
 					],
 					removeAssociations: null,
 				}),
@@ -312,7 +314,7 @@ describe('/entities', () => {
 				request: generateSubmitDesignsRequest({
 					...atlassianDesign,
 					addAssociations: [
-						AtlassianAssociation.createDesignIssueAssociation(issueAri),
+						{ ...AtlassianAssociation.createDesignIssueAssociation(issueAri) },
 					],
 					removeAssociations: null,
 				}),
@@ -519,7 +521,7 @@ describe('/entities', () => {
 					...atlassianDesign,
 					addAssociations: null,
 					removeAssociations: [
-						AtlassianAssociation.createDesignIssueAssociation(issueAri),
+						{ ...AtlassianAssociation.createDesignIssueAssociation(issueAri) },
 					],
 				}),
 			});
@@ -658,7 +660,7 @@ describe('/entities', () => {
 					...atlassianDesign,
 					addAssociations: null,
 					removeAssociations: [
-						AtlassianAssociation.createDesignIssueAssociation(issueAri),
+						{ ...AtlassianAssociation.createDesignIssueAssociation(issueAri) },
 					],
 				}),
 			});

--- a/src/web/routes/figma/integration.test.ts
+++ b/src/web/routes/figma/integration.test.ts
@@ -9,7 +9,6 @@ import type { FigmaWebhookEventPayload } from './types';
 import app from '../../../app';
 import { isString } from '../../../common/stringUtils';
 import { getConfig } from '../../../config';
-import { FigmaTeamAuthStatus } from '../../../domain/entities';
 import type {
 	AtlassianDesign,
 	ConnectInstallation,
@@ -17,6 +16,7 @@ import type {
 	FigmaTeam,
 	FigmaWebhookEventType,
 } from '../../../domain/entities';
+import { FigmaTeamAuthStatus } from '../../../domain/entities';
 import {
 	generateAssociatedFigmaDesignCreateParams,
 	generateConnectInstallation,
@@ -48,10 +48,10 @@ import {
 	figmaTeamRepository,
 } from '../../../infrastructure/repositories';
 import {
-	mockGetFileWithNodesEndpoint,
-	mockGetTeamProjectsEndpoint,
-	mockMeEndpoint,
-	mockSubmitDesignsEndpoint,
+	mockFigmaGetFileWithNodesEndpoint,
+	mockFigmaGetTeamProjectsEndpoint,
+	mockFigmaMeEndpoint,
+	mockJiraSubmitDesignsEndpoint,
 } from '../../testing';
 
 const FIGMA_OAUTH_API_BASE_URL = getConfig().figma.oauthApiBaseUrl;
@@ -149,19 +149,19 @@ describe('/figma', () => {
 						),
 				);
 
-				mockMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
-				mockGetTeamProjectsEndpoint({
+				mockFigmaMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
+				mockFigmaGetTeamProjectsEndpoint({
 					baseUrl: getConfig().figma.apiBaseUrl,
 					teamId: figmaTeam.teamId,
 					teamName: figmaTeam.teamName,
 				});
-				mockGetFileWithNodesEndpoint({
+				mockFigmaGetFileWithNodesEndpoint({
 					baseUrl: getConfig().figma.apiBaseUrl,
 					fileKey: fileKey,
 					nodeIds,
 					response: fileResponse,
 				});
-				mockSubmitDesignsEndpoint({
+				mockJiraSubmitDesignsEndpoint({
 					baseUrl: connectInstallation.baseUrl,
 					request: {
 						designs: associatedAtlassianDesigns.map((atlassianDesign) => ({
@@ -202,20 +202,20 @@ describe('/figma', () => {
 							fileResponse,
 						),
 				);
-				mockMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
-				mockGetTeamProjectsEndpoint({
+				mockFigmaMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
+				mockFigmaGetTeamProjectsEndpoint({
 					baseUrl: getConfig().figma.apiBaseUrl,
 					teamId: figmaTeam.teamId,
 					teamName: figmaTeam.teamName,
-					success: false,
+					status: HttpStatusCode.InternalServerError,
 				});
-				mockGetFileWithNodesEndpoint({
+				mockFigmaGetFileWithNodesEndpoint({
 					baseUrl: getConfig().figma.apiBaseUrl,
 					fileKey: fileKey,
 					nodeIds,
 					response: fileResponse,
 				});
-				mockSubmitDesignsEndpoint({
+				mockJiraSubmitDesignsEndpoint({
 					baseUrl: connectInstallation.baseUrl,
 					request: {
 						designs: associatedAtlassianDesigns.map((atlassianDesign) => ({
@@ -238,9 +238,9 @@ describe('/figma', () => {
 			});
 
 			it("should set the FigmaTeam status to 'ERROR' and return a 200 if we can't get valid OAuth2 credentials", async () => {
-				mockMeEndpoint({
+				mockFigmaMeEndpoint({
 					baseUrl: getConfig().figma.apiBaseUrl,
-					success: false,
+					status: HttpStatusCode.Forbidden,
 				});
 
 				await request(app)
@@ -280,17 +280,17 @@ describe('/figma', () => {
 					.map(({ designId }) => designId.nodeId!)
 					.filter(isString);
 
-				mockMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
-				mockGetTeamProjectsEndpoint({
+				mockFigmaMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
+				mockFigmaGetTeamProjectsEndpoint({
 					baseUrl: getConfig().figma.apiBaseUrl,
 					teamId: figmaTeam.teamId,
 					teamName: figmaTeam.teamName,
 				});
-				mockGetFileWithNodesEndpoint({
+				mockFigmaGetFileWithNodesEndpoint({
 					baseUrl: getConfig().figma.apiBaseUrl,
 					fileKey: fileKey,
 					nodeIds,
-					success: false,
+					status: HttpStatusCode.InternalServerError,
 				});
 
 				await request(app)

--- a/src/web/routes/figma/integration.test.ts
+++ b/src/web/routes/figma/integration.test.ts
@@ -35,6 +35,7 @@ import {
 	generateGetFileResponseWithNodes,
 	generateGetOAuth2TokenQueryParams,
 	generateGetOAuth2TokenResponse,
+	generateGetTeamProjectsResponse,
 } from '../../../infrastructure/figma/figma-client/testing';
 import {
 	transformFileToAtlassianDesign,
@@ -153,7 +154,9 @@ describe('/figma', () => {
 				mockFigmaGetTeamProjectsEndpoint({
 					baseUrl: getConfig().figma.apiBaseUrl,
 					teamId: figmaTeam.teamId,
-					teamName: figmaTeam.teamName,
+					response: generateGetTeamProjectsResponse({
+						name: figmaTeam.teamName,
+					}),
 				});
 				mockFigmaGetFileWithNodesEndpoint({
 					baseUrl: getConfig().figma.apiBaseUrl,
@@ -206,7 +209,6 @@ describe('/figma', () => {
 				mockFigmaGetTeamProjectsEndpoint({
 					baseUrl: getConfig().figma.apiBaseUrl,
 					teamId: figmaTeam.teamId,
-					teamName: figmaTeam.teamName,
 					status: HttpStatusCode.InternalServerError,
 				});
 				mockFigmaGetFileWithNodesEndpoint({
@@ -284,7 +286,9 @@ describe('/figma', () => {
 				mockFigmaGetTeamProjectsEndpoint({
 					baseUrl: getConfig().figma.apiBaseUrl,
 					teamId: figmaTeam.teamId,
-					teamName: figmaTeam.teamName,
+					response: generateGetTeamProjectsResponse({
+						name: figmaTeam.teamName,
+					}),
 				});
 				mockFigmaGetFileWithNodesEndpoint({
 					baseUrl: getConfig().figma.apiBaseUrl,

--- a/src/web/routes/lifecycle-events/integration.test.ts
+++ b/src/web/routes/lifecycle-events/integration.test.ts
@@ -20,9 +20,9 @@ import {
 } from '../../../infrastructure/repositories';
 import {
 	generateInboundRequestAsymmetricJwtToken,
-	mockConnectKeyEndpoint,
+	mockConnectGetKeyEndpoint,
 	mockFigmaDeleteWebhookEndpoint,
-	mockMeEndpoint,
+	mockFigmaMeEndpoint,
 } from '../../testing';
 
 describe('/lifecycleEvents', () => {
@@ -42,10 +42,10 @@ describe('/lifecycleEvents', () => {
 					},
 				});
 
-			mockConnectKeyEndpoint({
+			mockConnectGetKeyEndpoint({
 				baseUrl: getConfig().jira.connectKeyServerUrl,
 				keyId,
-				publicKey,
+				response: publicKey,
 				status: HttpStatusCode.Ok,
 			});
 
@@ -79,10 +79,10 @@ describe('/lifecycleEvents', () => {
 					},
 				});
 
-			mockConnectKeyEndpoint({
+			mockConnectGetKeyEndpoint({
 				baseUrl: getConfig().jira.connectKeyServerUrl,
 				keyId,
-				publicKey,
+				response: publicKey,
 				status: HttpStatusCode.Ok,
 			});
 
@@ -181,13 +181,13 @@ describe('/lifecycleEvents', () => {
 					},
 				});
 
-			mockConnectKeyEndpoint({
+			mockConnectGetKeyEndpoint({
 				baseUrl: getConfig().jira.connectKeyServerUrl,
 				keyId,
-				publicKey,
+				response: publicKey,
 				status: HttpStatusCode.Ok,
 			});
-			mockMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
+			mockFigmaMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
 			mockFigmaDeleteWebhookEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				webhookId: targetFigmaTeam1.webhookId,
@@ -236,10 +236,10 @@ describe('/lifecycleEvents', () => {
 					},
 				});
 
-			mockConnectKeyEndpoint({
+			mockConnectGetKeyEndpoint({
 				baseUrl: getConfig().jira.connectKeyServerUrl,
 				keyId,
-				publicKey,
+				response: publicKey,
 				status: HttpStatusCode.Ok,
 			});
 

--- a/src/web/routes/teams/integration.test.ts
+++ b/src/web/routes/teams/integration.test.ts
@@ -25,10 +25,10 @@ import {
 } from '../../../infrastructure/repositories';
 import {
 	generateInboundRequestSymmetricJwtToken,
-	mockCreateWebhookEndpoint,
+	mockFigmaCreateWebhookEndpoint,
 	mockFigmaDeleteWebhookEndpoint,
-	mockGetTeamProjectsEndpoint,
-	mockMeEndpoint,
+	mockFigmaGetTeamProjectsEndpoint,
+	mockFigmaMeEndpoint,
 } from '../../testing';
 
 const figmaTeamSummaryComparer = (a: FigmaTeamSummary, b: FigmaTeamSummary) =>
@@ -64,13 +64,13 @@ describe('/teams', () => {
 				connectInstallation,
 			});
 
-			mockMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
-			mockGetTeamProjectsEndpoint({
+			mockFigmaMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
+			mockFigmaGetTeamProjectsEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				teamId,
 				teamName,
 			});
-			mockCreateWebhookEndpoint({
+			mockFigmaCreateWebhookEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				webhookId,
 				teamId,
@@ -106,17 +106,17 @@ describe('/teams', () => {
 				connectInstallation,
 			});
 
-			mockMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
-			mockGetTeamProjectsEndpoint({
+			mockFigmaMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
+			mockFigmaGetTeamProjectsEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				teamId,
 				teamName,
 			});
-			mockCreateWebhookEndpoint({
+			mockFigmaCreateWebhookEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				webhookId,
 				teamId,
-				success: false,
+				status: HttpStatusCode.InternalServerError,
 			});
 
 			await request(app)
@@ -165,7 +165,7 @@ describe('/teams', () => {
 				connectInstallation,
 			});
 
-			mockMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
+			mockFigmaMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
 			mockFigmaDeleteWebhookEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				webhookId: figmaTeam.webhookId,
@@ -204,7 +204,7 @@ describe('/teams', () => {
 				connectInstallation,
 			});
 
-			mockMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
+			mockFigmaMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
 			mockFigmaDeleteWebhookEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				webhookId: figmaTeam.webhookId,
@@ -270,7 +270,7 @@ describe('/teams', () => {
 				connectInstallation: targetConnectInstallation,
 			});
 
-			mockMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
+			mockFigmaMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
 
 			const response = await request(app)
 				.get(TEAMS_LIST_ENDPOINT)
@@ -307,7 +307,7 @@ describe('/teams', () => {
 				connectInstallation: targetConnectInstallation,
 			});
 
-			mockMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
+			mockFigmaMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
 
 			const response = await request(app)
 				.get(TEAMS_LIST_ENDPOINT)

--- a/src/web/routes/teams/integration.test.ts
+++ b/src/web/routes/teams/integration.test.ts
@@ -18,6 +18,10 @@ import {
 } from '../../../domain/entities/testing';
 import { figmaClient } from '../../../infrastructure/figma/figma-client';
 import {
+	generateCreateWebhookResponse,
+	generateGetTeamProjectsResponse,
+} from '../../../infrastructure/figma/figma-client/testing';
+import {
 	connectInstallationRepository,
 	figmaOAuth2UserCredentialsRepository,
 	figmaTeamRepository,
@@ -68,12 +72,21 @@ describe('/teams', () => {
 			mockFigmaGetTeamProjectsEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				teamId,
-				teamName,
+				response: generateGetTeamProjectsResponse({ name: teamName }),
 			});
 			mockFigmaCreateWebhookEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
-				webhookId,
-				teamId,
+				request: {
+					event_type: 'FILE_UPDATE',
+					team_id: teamId,
+					endpoint: `${getConfig().app.baseUrl}/figma/webhook`,
+					passcode: /.+/i,
+					description: /.+/i,
+				},
+				response: generateCreateWebhookResponse({
+					id: webhookId,
+					teamId,
+				}),
 			});
 
 			await request(app)
@@ -110,12 +123,10 @@ describe('/teams', () => {
 			mockFigmaGetTeamProjectsEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
 				teamId,
-				teamName,
+				response: generateGetTeamProjectsResponse({ name: teamName }),
 			});
 			mockFigmaCreateWebhookEndpoint({
 				baseUrl: getConfig().figma.apiBaseUrl,
-				webhookId,
-				teamId,
 				status: HttpStatusCode.InternalServerError,
 			});
 

--- a/src/web/testing/connect-api-mock.ts
+++ b/src/web/testing/connect-api-mock.ts
@@ -12,7 +12,7 @@ export const mockConnectGetKeyEndpoint = ({
 }: {
 	baseUrl: string;
 	keyId: string;
-	response: string;
+	response?: string;
 	status: HttpStatusCode;
 }) => {
 	nock(baseUrl).get(`/${keyId}`).reply(status, response);

--- a/src/web/testing/connect-api-mock.ts
+++ b/src/web/testing/connect-api-mock.ts
@@ -4,16 +4,16 @@ import nock from 'nock';
 /**
  * @see https://developer.atlassian.com/cloud/jira/platform/security-for-connect-apps/#validating-installation-lifecycle-requests
  */
-export const mockConnectKeyEndpoint = ({
+export const mockConnectGetKeyEndpoint = ({
 	baseUrl,
 	keyId,
-	publicKey,
 	status = HttpStatusCode.Ok,
+	response,
 }: {
 	baseUrl: string;
 	keyId: string;
-	publicKey: string;
+	response: string;
 	status: HttpStatusCode;
 }) => {
-	nock(baseUrl).get(`/${keyId}`).reply(status, publicKey);
+	nock(baseUrl).get(`/${keyId}`).reply(status, response);
 };

--- a/src/web/testing/figma-api-mocks.ts
+++ b/src/web/testing/figma-api-mocks.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { getConfig } from '../../config';
 import type {
+	CreateDevResourcesRequest,
 	FileResponse,
 	GetDevResourcesResponse,
 } from '../../infrastructure/figma/figma-client';
@@ -71,12 +72,14 @@ export const mockFigmaGetFileWithNodesEndpoint = ({
 
 export const mockFigmaCreateDevResourcesEndpoint = ({
 	baseUrl,
+	request,
 	status = HttpStatusCode.Ok,
 }: {
 	baseUrl: string;
+	request?: CreateDevResourcesRequest;
 	status?: HttpStatusCode;
 }) => {
-	nock(baseUrl).post('/v1/dev_resources').reply(status);
+	nock(baseUrl).post('/v1/dev_resources').reply(status, request);
 };
 
 export const mockFigmaGetDevResourcesEndpoint = ({

--- a/src/web/testing/figma-api-mocks.ts
+++ b/src/web/testing/figma-api-mocks.ts
@@ -13,18 +13,17 @@ import {
 	generateGetFileResponseWithNodes,
 } from '../../infrastructure/figma/figma-client/testing';
 
-export const mockMeEndpoint = ({
+export const mockFigmaMeEndpoint = ({
 	baseUrl,
-	success = true,
+	status = HttpStatusCode.Ok,
 }: {
 	baseUrl: string;
-	success?: boolean;
+	status?: HttpStatusCode;
 }) => {
-	const statusCode = success ? HttpStatusCode.Ok : HttpStatusCode.Forbidden;
-	nock(baseUrl).get('/v1/me').reply(statusCode).persist();
+	nock(baseUrl).get('/v1/me').reply(status).persist();
 };
 
-export const mockGetFileEndpoint = ({
+export const mockFigmaGetFileEndpoint = ({
 	baseUrl,
 	fileKey,
 	accessToken,
@@ -49,99 +48,28 @@ export const mockGetFileEndpoint = ({
 		.reply(status, response ?? {});
 };
 
-export const mockGetFileWithNodesEndpoint = ({
+export const mockFigmaGetFileWithNodesEndpoint = ({
 	baseUrl,
 	fileKey = uuidv4(),
 	nodeIds,
+	status = HttpStatusCode.Ok,
 	response = generateGetFileResponseWithNodes({
 		nodes: nodeIds.map((nodeId) => generateChildNode({ id: nodeId })),
 	}),
-	success = true,
 }: {
 	baseUrl: string;
 	fileKey?: string;
 	nodeIds: string[];
+	status?: HttpStatusCode;
 	response?: FileResponse;
-	success?: boolean;
 }) => {
 	nock(baseUrl)
 		.get(`/v1/files/${fileKey}`)
 		.query({ ids: nodeIds.join(','), node_last_modified: true })
-		.reply(
-			success ? HttpStatusCode.Ok : HttpStatusCode.InternalServerError,
-			response,
-		);
+		.reply(status, response);
 };
 
-export const mockCreateWebhookEndpoint = ({
-	baseUrl,
-	webhookId = uuidv4(),
-	teamId = uuidv4(),
-	success = true,
-}: {
-	baseUrl: string;
-	webhookId?: string;
-	teamId?: string;
-	success?: boolean;
-}) => {
-	const statusCode = success
-		? HttpStatusCode.Ok
-		: HttpStatusCode.InternalServerError;
-	nock(baseUrl)
-		.post('/v2/webhooks')
-		.reply(statusCode, {
-			id: webhookId,
-			team_id: teamId,
-			event_type: 'FILE_UPDATE',
-			client_id: getConfig().figma.clientId,
-			endpoint: `${getConfig().app.baseUrl}/figma/webhooks`,
-			passcode: 'NOT_USED',
-			status: 'ACTIVE',
-			description: 'Figma for Jira',
-			protocol_version: '2',
-		});
-};
-
-export const mockGetTeamProjectsEndpoint = ({
-	baseUrl,
-	teamId = uuidv4(),
-	teamName = uuidv4(),
-	success = true,
-}: {
-	baseUrl: string;
-	teamId?: string;
-	teamName?: string;
-	success?: boolean;
-}) => {
-	const statusCode = success
-		? HttpStatusCode.Ok
-		: HttpStatusCode.InternalServerError;
-	nock(baseUrl)
-		.get(`/v1/teams/${teamId}/projects`)
-		.reply(statusCode, { name: teamName, projects: [] });
-};
-
-export const mockFigmaDeleteWebhookEndpoint = ({
-	baseUrl,
-	webhookId,
-	accessToken,
-	status = HttpStatusCode.Ok,
-}: {
-	baseUrl: string;
-	webhookId: string;
-	accessToken: string;
-	status: HttpStatusCode;
-}) => {
-	nock(baseUrl, {
-		reqheaders: {
-			Authorization: `Bearer ${accessToken}`,
-		},
-	})
-		.delete(`/v2/webhooks/${webhookId}`)
-		.reply(status);
-};
-
-export const mockCreateDevResourcesEndpoint = ({
+export const mockFigmaCreateDevResourcesEndpoint = ({
 	baseUrl,
 	status = HttpStatusCode.Ok,
 }: {
@@ -151,24 +79,26 @@ export const mockCreateDevResourcesEndpoint = ({
 	nock(baseUrl).post('/v1/dev_resources').reply(status);
 };
 
-export const mockGetDevResourcesEndpoint = ({
+export const mockFigmaGetDevResourcesEndpoint = ({
 	baseUrl,
 	fileKey,
 	nodeId,
+	status = HttpStatusCode.Ok,
 	response = generateGetDevResourcesResponse(),
 }: {
 	baseUrl: string;
 	fileKey: string;
 	nodeId: string;
+	status?: HttpStatusCode;
 	response?: GetDevResourcesResponse;
 }) => {
 	nock(baseUrl)
 		.get(`/v1/files/${fileKey}/dev_resources`)
 		.query({ node_ids: nodeId })
-		.reply(HttpStatusCode.Ok, response);
+		.reply(status, response);
 };
 
-export const mockDeleteDevResourcesEndpoint = ({
+export const mockFigmaDeleteDevResourcesEndpoint = ({
 	baseUrl,
 	fileKey,
 	devResourceId,
@@ -182,4 +112,66 @@ export const mockDeleteDevResourcesEndpoint = ({
 	nock(baseUrl)
 		.delete(`/v1/files/${fileKey}/dev_resources/${devResourceId}`)
 		.reply(status);
+};
+
+export const mockFigmaCreateWebhookEndpoint = ({
+	baseUrl,
+	webhookId = uuidv4(),
+	teamId = uuidv4(),
+	status = HttpStatusCode.Ok,
+}: {
+	baseUrl: string;
+	webhookId?: string;
+	teamId?: string;
+	status?: HttpStatusCode;
+}) => {
+	nock(baseUrl)
+		.post('/v2/webhooks')
+		.reply(status, {
+			id: webhookId,
+			team_id: teamId,
+			event_type: 'FILE_UPDATE',
+			client_id: getConfig().figma.clientId,
+			endpoint: `${getConfig().app.baseUrl}/figma/webhooks`,
+			passcode: 'NOT_USED',
+			status: 'ACTIVE',
+			description: 'Figma for Jira',
+			protocol_version: '2',
+		});
+};
+
+export const mockFigmaDeleteWebhookEndpoint = ({
+	baseUrl,
+	webhookId,
+	accessToken,
+	status = HttpStatusCode.Ok,
+}: {
+	baseUrl: string;
+	webhookId: string;
+	accessToken: string;
+	status?: HttpStatusCode;
+}) => {
+	nock(baseUrl, {
+		reqheaders: {
+			Authorization: `Bearer ${accessToken}`,
+		},
+	})
+		.delete(`/v2/webhooks/${webhookId}`)
+		.reply(status);
+};
+
+export const mockFigmaGetTeamProjectsEndpoint = ({
+	baseUrl,
+	teamId = uuidv4(),
+	teamName = uuidv4(),
+	status = HttpStatusCode.Ok,
+}: {
+	baseUrl: string;
+	teamId?: string;
+	teamName?: string;
+	status?: HttpStatusCode;
+}) => {
+	nock(baseUrl)
+		.get(`/v1/teams/${teamId}/projects`)
+		.reply(status, { name: teamName, projects: [] });
 };

--- a/src/web/testing/jira-api-mocks.ts
+++ b/src/web/testing/jira-api-mocks.ts
@@ -21,7 +21,7 @@ export const mockJiraSubmitDesignsEndpoint = ({
 	status = HttpStatusCode.Ok,
 }: {
 	baseUrl: string;
-	request?: SubmitDesignsRequest;
+	request?: SubmitDesignsRequest | RequestBodyMatcher;
 	response?: SubmitDesignsResponse;
 	status?: HttpStatusCode;
 }) => {

--- a/src/web/testing/jira-api-mocks.ts
+++ b/src/web/testing/jira-api-mocks.ts
@@ -25,9 +25,7 @@ export const mockJiraSubmitDesignsEndpoint = ({
 	response?: SubmitDesignsResponse;
 	status?: HttpStatusCode;
 }) => {
-	nock(baseUrl)
-		.post('/rest/designs/1.0/bulk', JSON.stringify(request))
-		.reply(status, response);
+	nock(baseUrl).post('/rest/designs/1.0/bulk', request).reply(status, response);
 };
 
 export const mockJiraGetIssueEndpoint = ({

--- a/src/web/testing/jira-api-mocks.ts
+++ b/src/web/testing/jira-api-mocks.ts
@@ -25,7 +25,9 @@ export const mockJiraSubmitDesignsEndpoint = ({
 	response?: SubmitDesignsResponse;
 	status?: HttpStatusCode;
 }) => {
-	nock(baseUrl).post('/rest/designs/1.0/bulk', request).reply(status, response);
+	nock(baseUrl)
+		.post('/rest/designs/1.0/bulk', JSON.stringify(request))
+		.reply(status, response);
 };
 
 export const mockJiraGetIssueEndpoint = ({
@@ -64,17 +66,17 @@ export const mockJiraSetIssuePropertyEndpoint = ({
 	baseUrl,
 	issueId,
 	propertyKey,
-	value,
+	request,
 	status = HttpStatusCode.Ok,
 }: {
 	baseUrl: string;
 	issueId: string;
 	propertyKey: string;
-	value: RequestBodyMatcher;
+	request: RequestBodyMatcher;
 	status?: HttpStatusCode;
 }) => {
 	nock(baseUrl)
-		.put(`/rest/api/2/issue/${issueId}/properties/${propertyKey}`, value)
+		.put(`/rest/api/2/issue/${issueId}/properties/${propertyKey}`, request)
 		.reply(status);
 };
 

--- a/src/web/testing/jira-api-mocks.ts
+++ b/src/web/testing/jira-api-mocks.ts
@@ -14,26 +14,21 @@ import {
 	generateSuccessfulSubmitDesignsResponse,
 } from '../../infrastructure/jira/jira-client/testing';
 
-export const mockSubmitDesignsEndpoint = ({
+export const mockJiraSubmitDesignsEndpoint = ({
 	baseUrl,
 	request,
 	response = generateSuccessfulSubmitDesignsResponse(),
-	success = true,
+	status = HttpStatusCode.Ok,
 }: {
 	baseUrl: string;
 	request?: SubmitDesignsRequest;
 	response?: SubmitDesignsResponse;
-	success?: boolean;
+	status?: HttpStatusCode;
 }) => {
-	nock(baseUrl)
-		.post('/rest/designs/1.0/bulk', request)
-		.reply(
-			success ? HttpStatusCode.Ok : HttpStatusCode.InternalServerError,
-			response,
-		);
+	nock(baseUrl).post('/rest/designs/1.0/bulk', request).reply(status, response);
 };
 
-export const mockGetIssueEndpoint = ({
+export const mockJiraGetIssueEndpoint = ({
 	baseUrl,
 	issueId,
 	status = HttpStatusCode.Ok,
@@ -47,7 +42,7 @@ export const mockGetIssueEndpoint = ({
 	nock(baseUrl).get(`/rest/agile/1.0/issue/${issueId}`).reply(status, response);
 };
 
-export const mockGetIssuePropertyEndpoint = ({
+export const mockJiraGetIssuePropertyEndpoint = ({
 	baseUrl,
 	issueId = generateJiraIssueId(),
 	propertyKey = '',
@@ -65,7 +60,7 @@ export const mockGetIssuePropertyEndpoint = ({
 		.reply(status, status === HttpStatusCode.Ok ? response : undefined);
 };
 
-export const mockSetIssuePropertyEndpoint = ({
+export const mockJiraSetIssuePropertyEndpoint = ({
 	baseUrl,
 	issueId,
 	propertyKey,
@@ -83,16 +78,18 @@ export const mockSetIssuePropertyEndpoint = ({
 		.reply(status);
 };
 
-export const mockDeleteIssuePropertyEndpoint = ({
+export const mockJiraDeleteIssuePropertyEndpoint = ({
 	baseUrl,
 	issueId,
 	propertyKey,
+	status = HttpStatusCode.Ok,
 }: {
 	baseUrl: string;
 	issueId: string;
 	propertyKey?: string;
+	status?: HttpStatusCode;
 }) => {
 	nock(baseUrl)
 		.delete(`/rest/api/2/issue/${issueId}/properties/${propertyKey}`)
-		.reply(200);
+		.reply(status);
 };


### PR DESCRIPTION
## Changes

- **[Improvement]:** Updates test utilities for mocking endpoints (with Nock) to provide consistent contact.
  ```ts
  export const mockXxxEndpoint = ({
	baseUrl,
	param1,
	param2,
	request,
	response = generateXxxResponse(),
	status = HttpStatusCode.Ok,
  }: {
    // ...
  }) => {
    // ...
  }
  ```
- **[Improvement]:** Updates some integration tests to assert requests to external services.
- **[Improvement]:** Applies minor refactoring to tests.