### PR TITLE
MDTZ-1007 Overwrite 'attached-design-url-v2' issue property

### DIFF
--- a/src/common/stringUtils.test.ts
+++ b/src/common/stringUtils.test.ts
@@ -17,7 +17,9 @@ describe('stringUtils', () => {
 	describe('ensureString', () => {
 		it('should throw when non-string is given', () => {
 			expect(() => ensureString(1)).toThrow(
-				'The provided value is not of the correct type. Expected string, but received: number',
+				new TypeError(
+					'The provided value is not of the correct type. Expected string, but received: number',
+				),
 			);
 		});
 	});

--- a/src/common/stringUtils.ts
+++ b/src/common/stringUtils.ts
@@ -4,7 +4,7 @@ export function isString(value: unknown): value is string {
 
 export const ensureString = (value: unknown) => {
 	if (isString(value)) return value;
-	throw new Error(
+	throw new TypeError(
 		`The provided value is not of the correct type. Expected string, but received: ${typeof value}`,
 	);
 };

--- a/src/infrastructure/ajv.test.ts
+++ b/src/infrastructure/ajv.test.ts
@@ -25,7 +25,7 @@ describe('ajv utils', () => {
 		it('should not throw when validating a valid object', () => {
 			const validObject: unknown = { value: 'test' };
 
-			assertSchema(validObject, TEST_SCHEMA);
+			expect(() => assertSchema(validObject, TEST_SCHEMA)).not.toThrow();
 		});
 
 		it('should throw when validating a non-conforming object', () => {

--- a/src/infrastructure/ajv.test.ts
+++ b/src/infrastructure/ajv.test.ts
@@ -1,0 +1,72 @@
+import {
+	assertSchema,
+	type JSONSchemaTypeWithId,
+	parseJsonOfSchema,
+	SchemaValidationError,
+} from './ajv';
+
+type TestObject = {
+	value: string;
+};
+
+const TEST_SCHEMA: JSONSchemaTypeWithId<TestObject> = {
+	$id: 'figma-for-jira:test-schema',
+	type: 'object',
+	properties: {
+		value: {
+			type: 'string',
+		},
+	},
+	required: ['value'],
+};
+
+describe('ajv utils', () => {
+	describe('assertSchema', () => {
+		it('should not throw when validating a valid object', () => {
+			const validObject: unknown = { value: 'test' };
+
+			assertSchema(validObject, TEST_SCHEMA);
+		});
+
+		it('should throw when validating a non-conforming object', () => {
+			const validObject: unknown = { value: 123 };
+
+			expect(() => {
+				assertSchema(validObject, TEST_SCHEMA);
+			}).toThrow(SchemaValidationError);
+		});
+	});
+
+	describe('parseJsonOfSchema', () => {
+		it('should not throw when parsing and validating a valid and conforming JSON string', () => {
+			const toParse = '{"value":"test"}';
+
+			const result = parseJsonOfSchema(toParse, TEST_SCHEMA);
+			expect(result.value).toEqual('test');
+		});
+
+		it('should throw SchemaValidationError when parsing a non-string value', () => {
+			const toParse = 123;
+
+			expect(() => {
+				parseJsonOfSchema(toParse, TEST_SCHEMA);
+			}).toThrow(SchemaValidationError);
+		});
+
+		it('should throw SchemaValidationError when parsing an invalid JSON string', () => {
+			const toParse = 'not JSON';
+
+			expect(() => {
+				parseJsonOfSchema(toParse, TEST_SCHEMA);
+			}).toThrow(SchemaValidationError);
+		});
+
+		it('should throw SchemaValidationError when validating a non-conforming object', () => {
+			const toParse = '{"value":123}';
+
+			expect(() => {
+				parseJsonOfSchema(toParse, TEST_SCHEMA);
+			}).toThrow(SchemaValidationError);
+		});
+	});
+});

--- a/src/infrastructure/jira/jira-client/jira-client.test.ts
+++ b/src/infrastructure/jira/jira-client/jira-client.test.ts
@@ -184,12 +184,12 @@ describe('JiraClient', () => {
 	describe('setIssueProperty', () => {
 		const issueId = 'TEST-1';
 		const propertyKey = 'property-key';
-		it("should set an issue's properties and respond with a status code", async () => {
+		it("should set an issue's properties", async () => {
 			jest.spyOn(axios, 'put').mockResolvedValue({
 				status: HttpStatusCode.Ok,
 			});
 
-			const response = await jiraClient.setIssueProperty(
+			await jiraClient.setIssueProperty(
 				issueId,
 				propertyKey,
 				'some value',
@@ -205,14 +205,13 @@ describe('JiraClient', () => {
 				'some value',
 				{ headers },
 			);
-			expect(response).toBe(HttpStatusCode.Ok);
 		});
 	});
 
 	describe('deleteIssueProperty', () => {
 		const issueId = 'TEST-1';
 		const propertyKey = 'property-key';
-		it('should delete the issue property and respond with a status code', async () => {
+		it('should delete the issue property', async () => {
 			jest.spyOn(axios, 'delete').mockResolvedValue({
 				status: HttpStatusCode.NoContent,
 			});

--- a/src/infrastructure/jira/jira-client/jira-client.ts
+++ b/src/infrastructure/jira/jira-client/jira-client.ts
@@ -160,13 +160,13 @@ class JiraClient {
 		propertyKey: string,
 		value: unknown,
 		connectInstallation: ConnectInstallation,
-	): Promise<number> => {
+	): Promise<void> => {
 		const url = new URL(
 			`/rest/api/2/issue/${issueIdOrKey}/properties/${propertyKey}`,
 			connectInstallation.baseUrl,
 		);
 
-		const response = await axios.put(url.toString(), value, {
+		await axios.put(url.toString(), value, {
 			headers: new AxiosHeaders()
 				.setAuthorization(
 					this.buildAuthorizationHeader(url, 'PUT', connectInstallation),
@@ -174,8 +174,6 @@ class JiraClient {
 				.setAccept('application/json')
 				.setContentType('application/json'),
 		});
-
-		return response.status;
 	};
 
 	/**

--- a/src/infrastructure/jira/jira-service.test.ts
+++ b/src/infrastructure/jira/jira-service.test.ts
@@ -23,6 +23,7 @@ import {
 	generateFigmaDesignIdentifier,
 	generateJiraIssue,
 	generateJiraIssueAri,
+	generateJiraIssueKey,
 } from '../../domain/entities/testing';
 import { SchemaValidationError } from '../ajv';
 
@@ -312,7 +313,7 @@ describe('JiraService', () => {
 	});
 
 	describe('updateAttachedDesignUrlV2IssueProperty', () => {
-		const issueId = 'TEST-1';
+		const issueId = generateJiraIssueKey();
 		let connectInstallation: ConnectInstallation;
 		let design: AtlassianDesign;
 
@@ -417,42 +418,67 @@ describe('JiraService', () => {
 			[{ name: 'test-no-url' }],
 			[{ url: 'test-no-name' }],
 		])(
-			'should throw a validation error if the issue property value is not in the expected shape',
+			'should overwrite the existing value if the issue property value is not in the expected shape',
 			async (value) => {
+				const expectedIssuePropertyValue = JSON.stringify(
+					JSON.stringify([
+						{
+							url: design.url,
+							name: design.displayName,
+						},
+					]),
+				);
+
 				jest.spyOn(jiraClient, 'getIssueProperty').mockResolvedValue(
 					generateGetIssuePropertyResponse({
 						key: propertyKeys.ATTACHED_DESIGN_URL_V2,
 						value: JSON.stringify(value),
 					}),
 				);
+				jest.spyOn(jiraClient, 'setIssueProperty').mockResolvedValue();
 
-				await expect(
-					jiraService.updateAttachedDesignUrlV2IssueProperty(
-						issueId,
-						design,
-						connectInstallation,
-					),
-				).rejects.toThrowError(SchemaValidationError);
-			},
-		);
-
-		it('should throw if the issue property value received from jira is not a string', async () => {
-			jest
-				.spyOn(jiraClient, 'getIssueProperty')
-				.mockResolvedValue(generateGetIssuePropertyResponse({ value: 1 }));
-			jest.spyOn(jiraClient, 'setIssueProperty').mockImplementation(jest.fn());
-
-			await expect(
-				jiraService.updateAttachedDesignUrlV2IssueProperty(
+				await jiraService.updateAttachedDesignUrlV2IssueProperty(
 					issueId,
 					design,
 					connectInstallation,
-				),
-			).rejects.toThrowError(
-				'The provided value is not of the correct type. Expected string, but received: number',
+				);
+
+				expect(jiraClient.setIssueProperty).toBeCalledWith(
+					issueId,
+					propertyKeys.ATTACHED_DESIGN_URL_V2,
+					expectedIssuePropertyValue,
+					connectInstallation,
+				);
+			},
+		);
+
+		it('should overwrite with the new value if the issue property value received from jira is not a string', async () => {
+			const expectedIssuePropertyValue = JSON.stringify(
+				JSON.stringify([
+					{
+						url: design.url,
+						name: design.displayName,
+					},
+				]),
 			);
 
-			expect(jiraClient.setIssueProperty).not.toHaveBeenCalled();
+			jest
+				.spyOn(jiraClient, 'getIssueProperty')
+				.mockResolvedValue(generateGetIssuePropertyResponse({ value: 1 }));
+			jest.spyOn(jiraClient, 'setIssueProperty').mockResolvedValue();
+
+			await jiraService.updateAttachedDesignUrlV2IssueProperty(
+				issueId,
+				design,
+				connectInstallation,
+			);
+
+			expect(jiraClient.setIssueProperty).toBeCalledWith(
+				issueId,
+				propertyKeys.ATTACHED_DESIGN_URL_V2,
+				expectedIssuePropertyValue,
+				connectInstallation,
+			);
 		});
 
 		it('should rethrow unknown errors', async () => {


### PR DESCRIPTION
When we write the `attached-design-url-v2` issue property, we check the existing value before updating, as we must include previously associated URLs in the new value. Since anyone with issue access can write any issue property, we also check that the issue property value is in the expected format.

This PR reworks how we update the `attached-design-url-v2` issue property. Instead of throwing an error when the value is in an unexpected format, we overwrite it with the new issue property value instead.