### PR TITLE
NONE Handle no associated designs in webhook event handler

### DIFF
--- a/src/usecases/handle-figma-file-update-event-use-case.ts
+++ b/src/usecases/handle-figma-file-update-event-use-case.ts
@@ -39,6 +39,10 @@ export const handleFigmaFileUpdateEventUseCase = {
 			),
 		]);
 
+		if (!associatedFigmaDesigns.length) {
+			return;
+		}
+
 		try {
 			const designs = await figmaService.fetchDesignsByIds(
 				associatedFigmaDesigns.map((design) => design.designId),

--- a/src/web/routes/figma/integration.test.ts
+++ b/src/web/routes/figma/integration.test.ts
@@ -186,6 +186,30 @@ describe('/figma', () => {
 					.expect(HttpStatusCode.Ok);
 			});
 
+			it('should return a 200 if no associated designs are found for the file key', async () => {
+				const otherFileKey = generateFigmaFileKey();
+				const otherFileWebhookEventPayload = generateFigmaWebhookEventPayload({
+					webhook_id: figmaTeam.webhookId,
+					file_key: otherFileKey,
+					file_name: generateFigmaFileName(),
+					passcode: figmaTeam.webhookPasscode,
+				});
+
+				mockFigmaMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
+				mockFigmaGetTeamProjectsEndpoint({
+					baseUrl: getConfig().figma.apiBaseUrl,
+					teamId: figmaTeam.teamId,
+					response: generateGetTeamProjectsResponse({
+						name: figmaTeam.teamName,
+					}),
+				});
+
+				await request(app)
+					.post(FIGMA_WEBHOOK_EVENT_ENDPOINT)
+					.send(otherFileWebhookEventPayload)
+					.expect(HttpStatusCode.Ok);
+			});
+
 			it('should return a 200 if fetching team name from Figma fails', async () => {
 				const associatedFigmaDesigns =
 					await associatedFigmaDesignRepository.findManyByFileKeyAndConnectInstallationId(


### PR DESCRIPTION
This fixes the app fetching the Figma file and submitting an empty list to `/rest/designs/1.0/bulk` when there are no associated designs for the file key specified in the webhook event payload.