### PR TITLE
MDTZ-1057 Change associateEntity response to return flattened design …

### DIFF
--- a/src/web/routes/entities/entities-router.ts
+++ b/src/web/routes/entities/entities-router.ts
@@ -45,7 +45,7 @@ entitiesRouter.post(
 				atlassianUserId,
 				connectInstallation,
 			})
-			.then((design) => res.status(HttpStatusCode.Ok).send({ design }))
+			.then((design) => res.status(HttpStatusCode.Ok).send(design))
 			.catch((error) => next(error));
 	},
 );
@@ -65,7 +65,7 @@ entitiesRouter.post(
 				atlassianUserId,
 				connectInstallation,
 			})
-			.then((design) => res.status(HttpStatusCode.Ok).send({ design }))
+			.then((design) => res.status(HttpStatusCode.Ok).send(design))
 			.catch((error) => next(error));
 	},
 );

--- a/src/web/routes/entities/integration.test.ts
+++ b/src/web/routes/entities/integration.test.ts
@@ -256,7 +256,7 @@ describe('/entities', () => {
 				.set('Content-Type', 'application/json')
 				.set('User-Id', atlassianUserId)
 				.expect(HttpStatusCode.Ok)
-				.expect({ design: atlassianDesign });
+				.expect(atlassianDesign);
 			expect(await associatedFigmaDesignRepository.getAll()).toEqual([
 				{
 					id: expect.anything(),
@@ -391,7 +391,7 @@ describe('/entities', () => {
 				.set('Content-Type', 'application/json')
 				.set('User-Id', atlassianUserId)
 				.expect(HttpStatusCode.Ok)
-				.expect({ design: atlassianDesign });
+				.expect(atlassianDesign);
 			expect(await associatedFigmaDesignRepository.getAll()).toEqual([
 				{
 					id: expect.anything(),
@@ -628,7 +628,7 @@ describe('/entities', () => {
 				.set('Content-Type', 'application/json')
 				.set('User-Id', atlassianUserId)
 				.expect(HttpStatusCode.Ok)
-				.expect({ design: atlassianDesign });
+				.expect(atlassianDesign);
 			expect(await associatedFigmaDesignRepository.getAll()).toEqual([]);
 		});
 
@@ -770,7 +770,7 @@ describe('/entities', () => {
 				.set('Content-Type', 'application/json')
 				.set('User-Id', atlassianUserId)
 				.expect(HttpStatusCode.Ok)
-				.expect({ design: atlassianDesign });
+				.expect(atlassianDesign);
 			expect(await associatedFigmaDesignRepository.getAll()).toEqual([]);
 		});
 

--- a/src/web/routes/entities/types.ts
+++ b/src/web/routes/entities/types.ts
@@ -9,7 +9,7 @@ import type {
 	DisassociateEntityUseCaseParams,
 } from '../../../usecases';
 
-export type EntitiesResponseBody = AtlassianDesign | string;
+export type EntitiesResponseBody = AtlassianDesign;
 
 export type EntitiesRequestLocals = {
 	readonly connectInstallation: ConnectInstallation;

--- a/src/web/routes/entities/types.ts
+++ b/src/web/routes/entities/types.ts
@@ -9,9 +9,7 @@ import type {
 	DisassociateEntityUseCaseParams,
 } from '../../../usecases';
 
-export type EntitiesResponseBody =
-	| { readonly design: AtlassianDesign }
-	| string;
+export type EntitiesResponseBody = AtlassianDesign | string;
 
 export type EntitiesRequestLocals = {
 	readonly connectInstallation: ConnectInstallation;


### PR DESCRIPTION
Change associateEntity response to return flattened design entity.

Before:
`
{
  "design": {
    "id": ...
  }
}
`

After:
`
{
  "id": ...
}
`