### PR TITLE
NONE: Add context-qsh as a valid qsh for JWT verification

### DIFF
--- a/src/infrastructure/jira/inbound-auth/jira-jwt-utils.test.ts
+++ b/src/infrastructure/jira/inbound-auth/jira-jwt-utils.test.ts
@@ -1,0 +1,54 @@
+import { createQueryStringHash } from 'atlassian-jwt';
+
+import { verifyQshClaimBoundToUrl } from './jira-jwt-utils';
+
+import { UnauthorizedError } from '../../../web/middleware/errors';
+
+const NOW = Date.now();
+
+describe('verifyQshClaimBoundToUrl', () => {
+	beforeEach(() => {
+		jest.useFakeTimers().setSystemTime(NOW);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('throws on invalid qsh claims', () => {
+		expect(() =>
+			verifyQshClaimBoundToUrl(
+				{ qsh: 'invalid-qsh' },
+				{
+					method: 'GET',
+					pathname: '/foo',
+					query: {},
+				},
+			),
+		).toThrowError(UnauthorizedError);
+	});
+
+	it('passes on valid qsh claims', () => {
+		const request = {
+			method: 'GET',
+			pathname: '/foo',
+			query: {},
+		};
+
+		const qsh = createQueryStringHash(request, false);
+		expect(() => verifyQshClaimBoundToUrl({ qsh }, request)).not.toThrowError();
+	});
+
+	it('passes when the qsh is context-qsh', () => {
+		expect(() =>
+			verifyQshClaimBoundToUrl(
+				{ qsh: 'context-qsh' },
+				{
+					method: 'GET',
+					pathname: '/foo',
+					query: {},
+				},
+			),
+		).not.toThrowError(UnauthorizedError);
+	});
+});

--- a/src/infrastructure/jira/inbound-auth/jira-jwt-utils.ts
+++ b/src/infrastructure/jira/inbound-auth/jira-jwt-utils.ts
@@ -17,7 +17,7 @@ export const verifyQshClaimBoundToUrl = (
 		query?: Record<string, unknown>;
 	},
 ) => {
-	if (qsh !== createQueryStringHash(request, false)) {
+	if (qsh !== createQueryStringHash(request, false) && qsh !== 'context-qsh') {
 		throw new UnauthorizedError('The token contains an invalid `qsh` claim.');
 	}
 };


### PR DESCRIPTION
Saw that the JWT token was failing when I tried to use the one I got via `AP.context.getToken()`. After reading through the docs, I believe this is okay and expected that the `qsh` in this case will always be `context-qsh`. So added it as an acceptable value

**Changes:**
- **fix:** Fixes the JWT token failing verification when accessed from the configure page

**Test Plan**
- jest