### PR TITLE
NONE: Add `/admin/auth/checkAuth` endpoint. Group admin endpoints under `/admin`.

### DIFF
--- a/admin/vite.config.ts
+++ b/admin/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 // https://vitejs.dev/config/
 export default () => {
 	return defineConfig({
-		base: '/admin',
+		base: '/static/admin',
 		plugins: [react()],
 	});
 };

--- a/src/atlassian-connect.ts
+++ b/src/atlassian-connect.ts
@@ -98,7 +98,7 @@ export const connectAppDescriptor = {
 					value: 'Configure',
 				},
 				location: 'admin_plugins_menu/figma-addon-admin-section',
-				url: '/admin',
+				url: '/static/admin',
 				conditions: [{ condition: 'user_is_admin' }],
 			},
 		],

--- a/src/web/routes/admin/admin-router.ts
+++ b/src/web/routes/admin/admin-router.ts
@@ -1,7 +1,13 @@
-import { Router, static as Static } from 'express';
+import { Router } from 'express';
 
-import path from 'path';
+import { authRouter } from './auth';
+import { teamsRouter } from './teams';
+
+import { jiraContextSymmetricJwtAuthMiddleware } from '../../middleware/jira';
 
 export const adminRouter = Router();
 
-adminRouter.use('/', Static(path.join(process.cwd(), 'admin/dist')));
+adminRouter.use(jiraContextSymmetricJwtAuthMiddleware);
+
+adminRouter.use('/auth', authRouter);
+adminRouter.use('/teams', teamsRouter);

--- a/src/web/routes/admin/auth/auth-router.ts
+++ b/src/web/routes/admin/auth/auth-router.ts
@@ -1,0 +1,40 @@
+import type { NextFunction } from 'express';
+import { Router } from 'express';
+
+import type { CheckAuthRequest, CheckAuthResponse } from './types';
+
+import { figmaAuthService } from '../../../../infrastructure/figma';
+import { checkUserFigmaAuthUseCase } from '../../../../usecases';
+
+export const authRouter = Router();
+
+/**
+ * Checks whether the given Atlassian admin is authorized to call Figma API.
+ */
+authRouter.get(
+	['/checkAuth'],
+	function (req: CheckAuthRequest, res: CheckAuthResponse, next: NextFunction) {
+		const { connectInstallation, atlassianUserId } = res.locals;
+
+		checkUserFigmaAuthUseCase
+			.execute(atlassianUserId, connectInstallation)
+			.then((authorized) => {
+				if (authorized) {
+					return res.send({ authorized });
+				}
+
+				const authorizationEndpoint =
+					figmaAuthService.createOAuth2AuthorizationRequest({
+						atlassianUserId,
+						connectInstallation,
+						redirectEndpoint: `figma/oauth/callback`,
+					});
+
+				return res.send({
+					authorized,
+					grant: { authorizationEndpoint },
+				});
+			})
+			.catch((error) => next(error));
+	},
+);

--- a/src/web/routes/admin/auth/index.ts
+++ b/src/web/routes/admin/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './auth-router';

--- a/src/web/routes/admin/auth/integration.test.ts
+++ b/src/web/routes/admin/auth/integration.test.ts
@@ -1,0 +1,219 @@
+import { HttpStatusCode } from 'axios';
+import nock from 'nock';
+import request from 'supertest';
+import { v4 as uuidv4 } from 'uuid';
+
+import app from '../../../../app';
+import { getConfig } from '../../../../config';
+import {
+	generateConnectInstallationCreateParams,
+	generateExpiredFigmaOAuth2UserCredentialCreateParams,
+	generateFigmaOAuth2UserCredentialCreateParams,
+} from '../../../../domain/entities/testing';
+import { figmaAuthService } from '../../../../infrastructure/figma';
+import {
+	generateRefreshOAuth2TokenQueryParams,
+	generateRefreshOAuth2TokenResponse,
+} from '../../../../infrastructure/figma/figma-client/testing';
+import {
+	connectInstallationRepository,
+	figmaOAuth2UserCredentialsRepository,
+} from '../../../../infrastructure/repositories';
+import { generateJiraContextSymmetricJwtToken } from '../../../testing';
+
+const FIGMA_API_BASE_URL = getConfig().figma.apiBaseUrl;
+const FIGMA_OAUTH_API_BASE_URL =
+	getConfig().figma.oauth2.authorizationServerBaseUrl;
+
+const FIGMA_OAUTH_REFRESH_TOKEN_ENDPOINT = '/api/oauth/refresh';
+const FIGMA_ME_ENDPOINT = '/v1/me';
+const CHECK_AUTH_ENDPOINT = '/admin/auth/checkAuth';
+
+describe('/admin/auth', () => {
+	describe('/checkAuth', () => {
+		describe('with valid OAuth credentials stored', () => {
+			it('should return a response indicating that user is authorized if /me endpoint responds with a non-error response code', async () => {
+				const connectInstallation = await connectInstallationRepository.upsert(
+					generateConnectInstallationCreateParams(),
+				);
+				const atlassianUserId = uuidv4();
+				await figmaOAuth2UserCredentialsRepository.upsert(
+					generateFigmaOAuth2UserCredentialCreateParams({
+						atlassianUserId,
+						connectInstallationId: connectInstallation.id,
+					}),
+				);
+				const jwt = generateJiraContextSymmetricJwtToken({
+					connectInstallation,
+					atlassianUserId,
+				});
+
+				nock(FIGMA_API_BASE_URL)
+					.get(FIGMA_ME_ENDPOINT)
+					.reply(HttpStatusCode.Ok);
+
+				return request(app)
+					.get(CHECK_AUTH_ENDPOINT)
+					.set('Authorization', `JWT ${jwt}`)
+					.expect(HttpStatusCode.Ok)
+					.expect({ authorized: true });
+			});
+
+			it('should return a response indicating that user is not authorized if the /me endpoint responds with a 403', async () => {
+				const connectInstallation = await connectInstallationRepository.upsert(
+					generateConnectInstallationCreateParams(),
+				);
+				const atlassianUserId = uuidv4();
+				await figmaOAuth2UserCredentialsRepository.upsert(
+					generateFigmaOAuth2UserCredentialCreateParams({
+						atlassianUserId,
+						connectInstallationId: connectInstallation.id,
+					}),
+				);
+				const jwt = generateJiraContextSymmetricJwtToken({
+					connectInstallation,
+					atlassianUserId,
+				});
+
+				nock(FIGMA_API_BASE_URL)
+					.get(FIGMA_ME_ENDPOINT)
+					.reply(HttpStatusCode.Forbidden);
+
+				return request(app)
+					.get(CHECK_AUTH_ENDPOINT)
+					.set('Authorization', `JWT ${jwt}`)
+					.expect(HttpStatusCode.Ok)
+					.expect({
+						authorized: false,
+						grant: {
+							authorizationEndpoint:
+								figmaAuthService.createOAuth2AuthorizationRequest({
+									atlassianUserId,
+									connectInstallation,
+									redirectEndpoint: 'figma/oauth/callback',
+								}),
+						},
+					});
+			});
+		});
+
+		describe('with expired OAuth credentials stored', () => {
+			const REFRESH_TOKEN = uuidv4();
+			const REFRESH_TOKEN_QUERY_PARAMS = generateRefreshOAuth2TokenQueryParams({
+				client_id: getConfig().figma.oauth2.clientId,
+				client_secret: getConfig().figma.oauth2.clientSecret,
+				refresh_token: REFRESH_TOKEN,
+			});
+
+			it('should return a response indicating that user is authorized if credentials were refreshed', async () => {
+				const connectInstallation = await connectInstallationRepository.upsert(
+					generateConnectInstallationCreateParams(),
+				);
+				const atlassianUserId = uuidv4();
+				await figmaOAuth2UserCredentialsRepository.upsert(
+					generateExpiredFigmaOAuth2UserCredentialCreateParams({
+						refreshToken: REFRESH_TOKEN,
+						atlassianUserId,
+						connectInstallationId: connectInstallation.id,
+					}),
+				);
+				const refreshTokenResponse = generateRefreshOAuth2TokenResponse();
+				const jwt = generateJiraContextSymmetricJwtToken({
+					connectInstallation,
+					atlassianUserId,
+				});
+
+				nock(FIGMA_OAUTH_API_BASE_URL)
+					.post(FIGMA_OAUTH_REFRESH_TOKEN_ENDPOINT)
+					.query(REFRESH_TOKEN_QUERY_PARAMS)
+					.reply(HttpStatusCode.Ok, refreshTokenResponse);
+				nock(FIGMA_API_BASE_URL)
+					.get(FIGMA_ME_ENDPOINT)
+					.reply(HttpStatusCode.Ok);
+
+				await request(app)
+					.get(CHECK_AUTH_ENDPOINT)
+					.set('Authorization', `JWT ${jwt}`)
+					.expect(HttpStatusCode.Ok)
+					.expect({ authorized: true });
+
+				const credentials = await figmaOAuth2UserCredentialsRepository.get(
+					atlassianUserId,
+					connectInstallation.id,
+				);
+				expect(credentials?.accessToken).toEqual(
+					refreshTokenResponse.access_token,
+				);
+				expect(credentials?.isExpired()).toBeFalsy();
+			});
+
+			it('should return a response indicating that user is not authorized if credentials could not be refreshed', async () => {
+				const connectInstallation = await connectInstallationRepository.upsert(
+					generateConnectInstallationCreateParams(),
+				);
+				const atlassianUserId = uuidv4();
+				await figmaOAuth2UserCredentialsRepository.upsert(
+					generateExpiredFigmaOAuth2UserCredentialCreateParams({
+						refreshToken: REFRESH_TOKEN,
+						atlassianUserId,
+						connectInstallationId: connectInstallation.id,
+					}),
+				);
+				const jwt = generateJiraContextSymmetricJwtToken({
+					connectInstallation,
+					atlassianUserId,
+				});
+
+				nock(FIGMA_OAUTH_API_BASE_URL)
+					.post(FIGMA_OAUTH_REFRESH_TOKEN_ENDPOINT)
+					.query(REFRESH_TOKEN_QUERY_PARAMS)
+					.reply(HttpStatusCode.InternalServerError);
+
+				return request(app)
+					.get(CHECK_AUTH_ENDPOINT)
+					.set('Authorization', `JWT ${jwt}`)
+					.expect(HttpStatusCode.Ok)
+					.expect({
+						authorized: false,
+						grant: {
+							authorizationEndpoint:
+								figmaAuthService.createOAuth2AuthorizationRequest({
+									atlassianUserId,
+									connectInstallation,
+									redirectEndpoint: 'figma/oauth/callback',
+								}),
+						},
+					});
+			});
+		});
+
+		describe('without OAuth credentials stored', () => {
+			it('should return a response indicating that user is not authorized if no database entry exists', async () => {
+				const connectInstallation = await connectInstallationRepository.upsert(
+					generateConnectInstallationCreateParams(),
+				);
+				const atlassianUserId = uuidv4();
+				const jwt = generateJiraContextSymmetricJwtToken({
+					connectInstallation,
+					atlassianUserId,
+				});
+
+				return request(app)
+					.get(CHECK_AUTH_ENDPOINT)
+					.set('Authorization', `JWT ${jwt}`)
+					.expect(HttpStatusCode.Ok)
+					.expect({
+						authorized: false,
+						grant: {
+							authorizationEndpoint:
+								figmaAuthService.createOAuth2AuthorizationRequest({
+									atlassianUserId,
+									connectInstallation,
+									redirectEndpoint: 'figma/oauth/callback',
+								}),
+						},
+					});
+			});
+		});
+	});
+});

--- a/src/web/routes/admin/auth/types.ts
+++ b/src/web/routes/admin/auth/types.ts
@@ -1,0 +1,30 @@
+import type { Request, Response } from 'express';
+
+import type { ConnectInstallation } from '../../../../domain/entities';
+
+export type CheckAuthQueryParameters = { readonly userId: string };
+
+export type CheckAuthResponseBody = {
+	readonly authorized: boolean;
+	readonly grant?: {
+		readonly authorizationEndpoint: string;
+	};
+};
+
+type CheckAuthRequestLocals = {
+	readonly connectInstallation: ConnectInstallation;
+	readonly atlassianUserId: string;
+};
+
+export type CheckAuthRequest = Request<
+	Record<string, never>,
+	CheckAuthResponseBody,
+	never,
+	CheckAuthQueryParameters,
+	CheckAuthRequestLocals
+>;
+
+export type CheckAuthResponse = Response<
+	CheckAuthResponseBody,
+	CheckAuthRequestLocals
+>;

--- a/src/web/routes/admin/teams/index.ts
+++ b/src/web/routes/admin/teams/index.ts
@@ -1,0 +1,1 @@
+export * from './teams-router';

--- a/src/web/routes/admin/teams/integration.test.ts
+++ b/src/web/routes/admin/teams/integration.test.ts
@@ -2,49 +2,49 @@ import { HttpStatusCode } from 'axios';
 import request from 'supertest';
 import { v4 as uuidv4 } from 'uuid';
 
-import app from '../../../app';
-import { NotFoundOperationError } from '../../../common/errors';
-import { getConfig } from '../../../config';
+import app from '../../../../app';
+import { NotFoundOperationError } from '../../../../common/errors';
+import { getConfig } from '../../../../config';
 import type {
 	ConnectInstallation,
 	FigmaOAuth2UserCredentials,
 	FigmaTeamSummary,
-} from '../../../domain/entities';
-import { FigmaTeamAuthStatus } from '../../../domain/entities';
+} from '../../../../domain/entities';
+import { FigmaTeamAuthStatus } from '../../../../domain/entities';
 import {
 	generateConnectInstallationCreateParams,
 	generateFigmaOAuth2UserCredentialCreateParams,
 	generateFigmaTeamCreateParams,
 	generateFigmaTeamSummary,
-} from '../../../domain/entities/testing';
-import { figmaClient } from '../../../infrastructure/figma/figma-client';
+} from '../../../../domain/entities/testing';
+import { figmaClient } from '../../../../infrastructure/figma/figma-client';
 import {
 	generateCreateWebhookResponse,
 	generateGetTeamProjectsResponse,
-} from '../../../infrastructure/figma/figma-client/testing';
+} from '../../../../infrastructure/figma/figma-client/testing';
 import {
 	connectInstallationRepository,
 	figmaOAuth2UserCredentialsRepository,
 	figmaTeamRepository,
-} from '../../../infrastructure/repositories';
+} from '../../../../infrastructure/repositories';
 import {
 	generateJiraContextSymmetricJwtToken,
 	mockFigmaCreateWebhookEndpoint,
 	mockFigmaDeleteWebhookEndpoint,
 	mockFigmaGetTeamProjectsEndpoint,
 	mockJiraSetAppPropertyEndpoint,
-} from '../../testing';
+} from '../../../testing';
 
 const figmaTeamSummaryComparer = (a: FigmaTeamSummary, b: FigmaTeamSummary) =>
 	a.teamId.localeCompare(b.teamId);
 
-const TEAMS_ENDPOINT = '/teams';
+const TEAMS_ENDPOINT = '/admin/teams';
 const connectTeamEndpoint = (teamId: string): string =>
-	`${TEAMS_ENDPOINT}/${teamId}/connect`;
+	`/admin/teams/${teamId}/connect`;
 const disconnectTeamEndpoint = (teamId: string): string =>
-	`${TEAMS_ENDPOINT}/${teamId}/disconnect`;
+	`/admin/teams/${teamId}/disconnect`;
 
-describe('/teams', () => {
+describe('/admin/teams', () => {
 	describe('GET', () => {
 		let targetConnectInstallation: ConnectInstallation;
 		let otherConnectInstallation: ConnectInstallation;

--- a/src/web/routes/admin/teams/schemas.ts
+++ b/src/web/routes/admin/teams/schemas.ts
@@ -3,7 +3,7 @@ import type {
 	DisconnectFigmaTeamRouteParams,
 } from './types';
 
-import type { JSONSchemaTypeWithId } from '../../../infrastructure';
+import type { JSONSchemaTypeWithId } from '../../../../infrastructure';
 
 export const CONNECT_FIGMA_TEAM_ROUTE_PARAMS_SCHEMA: JSONSchemaTypeWithId<ConnectFigmaTeamRouteParams> =
 	{

--- a/src/web/routes/admin/teams/teams-router.ts
+++ b/src/web/routes/admin/teams/teams-router.ts
@@ -14,13 +14,13 @@ import type {
 	ListFigmaTeamsResponse,
 } from './types';
 
-import { assertSchema } from '../../../infrastructure';
+import { assertSchema } from '../../../../infrastructure';
 import {
 	connectFigmaTeamUseCase,
 	disconnectFigmaTeamUseCase,
 	listFigmaTeamsUseCase,
-} from '../../../usecases';
-import { jiraContextSymmetricJwtAuthMiddleware } from '../../middleware/jira';
+} from '../../../../usecases';
+import { jiraContextSymmetricJwtAuthMiddleware } from '../../../middleware/jira';
 
 export const teamsRouter = Router();
 

--- a/src/web/routes/admin/teams/types.ts
+++ b/src/web/routes/admin/teams/types.ts
@@ -3,7 +3,7 @@ import type { Request, Response } from 'express';
 import type {
 	ConnectInstallation,
 	FigmaTeamSummary,
-} from '../../../domain/entities';
+} from '../../../../domain/entities';
 
 export type ConnectFigmaTeamRouteParams = {
 	readonly teamId: string;

--- a/src/web/routes/router.ts
+++ b/src/web/routes/router.ts
@@ -9,7 +9,6 @@ import { authRouter } from './auth';
 import { entitiesRouter } from './entities';
 import { figmaRouter } from './figma';
 import { lifecycleEventsRouter } from './lifecycle-events';
-import { teamsRouter } from './teams';
 
 import { connectAppDescriptor } from '../../atlassian-connect';
 
@@ -26,6 +25,7 @@ rootRouter.get('/atlassian-connect.json', (_: Request, res: Response) => {
 });
 
 // Static resources
+rootRouter.use('/static/admin', Static(join(process.cwd(), 'admin/dist')));
 rootRouter.use('/static', Static(join(process.cwd(), 'static')));
 
 // Connect lifecycle events
@@ -36,8 +36,6 @@ rootRouter.use('/admin', adminRouter);
 rootRouter.use('/auth', authRouter);
 
 rootRouter.use('/entities', entitiesRouter);
-
-rootRouter.use('/teams', teamsRouter);
 
 // Endpoints to handle requests from Figma
 rootRouter.use('/figma', figmaRouter);

--- a/src/web/routes/teams/index.ts
+++ b/src/web/routes/teams/index.ts
@@ -1,3 +1,0 @@
-export * from './teams-router';
-export * from './types';
-export * from './schemas';


### PR DESCRIPTION
The PR addresses an issue with the `checkAuth` endpoint not being accessible from the admin UI. Please, see https://github.com/atlassian-labs/figma-for-jira/pull/106#issuecomment-1774339465 for more detail.

## Changes

- **feat:** Adds a new `/admin/auth/checkAuth` endpoint that can be used to check an admin's auth status from the admin UI.
- **refactor:** Groups all admin-related endpoints under the `/admin` path:
  - `GET /admin/auth/checkAuth`
  - `GET /admin/teams` (before, `GET /teams`)
  - `POST /admin/teams/:teamId/connect` (before, `POST /teams/:teamId/connect`)
  - `POST /admin/teams/:teamId/disconnect` (before, `POST /teams/:teamId/disconnect`)
- **refactor:** Mounts the routes for admin frontend resources under `static/admin` to distinguish the API and static resource routes.

## Remarks

The PR adds a new `/admin/auth/checkAuth` endpoint instead of updating the existing `/admin/auth/checkAuth` endpoint to fit different use cases. While it is tempting to combine these endpoints into 1, there are differences between them that could add a significant complexity into the implementation and testing:

|                        | `/auth/checkAuth`                                                   | `/admin/auth/checkAuth`                                |
|------------------------|---------------------------------------------------------------------|--------------------------------------------------------|
| Purpose                | Implements the standard action required for design integration.     | Implement a custom endpoint for the app UI.            |
| Contact                | Strict (must conform to the Jira contract)                   | Flexible (driven by the app UI needs)                 |
| Authentication         | Server-to-server symmetric JWT. Includes the URL-bound `qsh` claim. | Context symmetric JWT. Includes the fixed `qsh` claim. |
| How is user ID passed? | As `userId` query parameter.                                        | As the `sub` claim in JWT token.                       |

Therefore, the PR reduces the complexity of endpoint implementation at the cost of minor code duplication.