### PR TITLE
NONE: Support static ngrok urls when making a tunnel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,10 @@ JIRA_CONNECT_KEY_SERVER_URL=https://connect-install-keys.atlassian.com
 
 # Auth Token for ngrok: https://dashboard.ngrok.com/get-started/setup
 NGROK_AUTHTOKEN=
+# Static domain for ngrok. For free users, You can create one on https://dashboard.ngrok.com/cloud-edge/domains
+# eg. foo-bar-baz.ngrok-free.app
+NGROK_DOMAIN=
+
 # Atlassian Jira URL eg. https://example-app.atlassian.net
 ATLASSIAN_URL=
 # Your Jira login email

--- a/scripts/make-tunnel.sh
+++ b/scripts/make-tunnel.sh
@@ -7,4 +7,4 @@ set -o allexport
 source "$SCRIPT_DIR"/../.env set
 set +o allexport
 
-docker run --init --rm --publish='4040:4040' 'wernight/ngrok' ngrok http -log stdout --authtoken "$NGROK_AUTHTOKEN" host.docker.internal:"$SERVER_PORT"
+docker run --init --rm --publish='4040:4040' 'wernight/ngrok' ngrok http -log stdout -hostname=$NGROK_DOMAIN --authtoken "$NGROK_AUTHTOKEN" host.docker.internal:"$SERVER_PORT"


### PR DESCRIPTION
Heh, it's annoying to have to update all our callback urls etc and reinstall the connect app when restarting the tunnel. So updated this to support using a static domain we get from ngrok.

Even free users are able to create one at https://dashboard.ngrok.com/cloud-edge/domains although it may be limited to 1

In any case, this PR updates it so that when using the tunnel, it will always resolve to the specified ngrok domain. No more reseting the callback urls and reinstalling the connect app!

### Test plan
- run `npm run start:tunnel`
- Assert that it tunnels to the specified ngrok url in your .env file
- Assert that this does not change when quitting and rerunning the command
- Assert that this url is usable for installing the app, auth, etc