### PR TITLE
MDTZ-1072: Make `/admin` endpoints accessible only by Jira admins

### DIFF
--- a/src/infrastructure/jira/jira-client/jira-client.test.ts
+++ b/src/infrastructure/jira/jira-client/jira-client.test.ts
@@ -4,12 +4,18 @@ import axios, { AxiosError, AxiosHeaders, HttpStatusCode } from 'axios';
 import { jiraClient } from './jira-client';
 import { createJwtToken } from './jwt-utils';
 import {
+	generateCheckPermissionsRequest,
+	generateCheckPermissionsResponse,
 	generateGetIssuePropertyResponse,
 	generateGetIssueResponse,
 	generateSubmitDesignsRequest,
 	generateSuccessfulSubmitDesignsResponse,
 	MOCK_JWT_TOKEN,
 } from './testing';
+import type {
+	CheckPermissionsRequest,
+	CheckPermissionsResponse,
+} from './types';
 
 import { NotFoundOperationError } from '../../../common/errors';
 import type { ConnectInstallation } from '../../../domain/entities';
@@ -272,6 +278,31 @@ describe('JiraClient', () => {
 				`${connectInstallation.baseUrl}/rest/atlassian-connect/1/addons/${connectInstallation.key}/properties/${propertyKey}`,
 				'some value',
 				{ headers },
+			);
+		});
+	});
+
+	describe('checkPermissions', () => {
+		it('should check permissions', async () => {
+			const request: CheckPermissionsRequest =
+				generateCheckPermissionsRequest();
+			const response: CheckPermissionsResponse =
+				generateCheckPermissionsResponse();
+			jest.spyOn(axios, 'post').mockResolvedValue({
+				status: HttpStatusCode.Ok,
+				data: response,
+			});
+
+			const result = await jiraClient.checkPermissions(
+				request,
+				connectInstallation,
+			);
+
+			expect(result).toBe(response);
+			expect(axios.post).toHaveBeenCalledWith(
+				`${connectInstallation.baseUrl}/rest/api/3/permissions/check`,
+				request,
+				defaultExpectedRequestHeaders(),
 			);
 		});
 	});

--- a/src/infrastructure/jira/jira-client/schemas.ts
+++ b/src/infrastructure/jira/jira-client/schemas.ts
@@ -6,6 +6,7 @@ import type { JSONSchemaType } from 'ajv';
 
 import type {
 	Association,
+	CheckPermissionsResponse,
 	DesignKey,
 	GetIssuePropertyResponse,
 	GetIssueResponse,
@@ -36,7 +37,7 @@ const ASSOCIATION_SCHEMA: JSONSchemaType<Association> = {
 
 export const SUBMIT_DESIGNS_RESPONSE_SCHEMA: JSONSchemaTypeWithId<SubmitDesignsResponse> =
 	{
-		$id: 'jira-software-cloud-api:submit-design-data:response',
+		$id: 'jira-software-cloud-api:post:submit-design-data:response',
 		type: 'object',
 		properties: {
 			acceptedEntities: {
@@ -79,7 +80,7 @@ export const SUBMIT_DESIGNS_RESPONSE_SCHEMA: JSONSchemaTypeWithId<SubmitDesignsR
 
 export const GET_ISSUE_RESPONSE_SCHEMA: JSONSchemaTypeWithId<GetIssueResponse> =
 	{
-		$id: 'jira-software-cloud-api:get-issue:response',
+		$id: 'jira-software-cloud-api:get:issue:response',
 		type: 'object',
 		properties: {
 			id: { type: 'string' },
@@ -96,13 +97,26 @@ export const GET_ISSUE_RESPONSE_SCHEMA: JSONSchemaTypeWithId<GetIssueResponse> =
 		required: ['id', 'key', 'self'],
 	} as const;
 
-export const GET_ISSUE_PROPERTY_RESPONSE_SCHEMA: JSONSchemaTypeWithId<
-	Omit<GetIssuePropertyResponse, 'value'>
-> = {
-	$id: 'jira-software-cloud-api:get-issue-property:response',
+export const GET_ISSUE_PROPERTY_RESPONSE_SCHEMA = {
+	$id: 'jira-software-cloud-api:get:issue-property:response',
 	type: 'object',
 	properties: {
 		key: { type: 'string' },
 	},
 	required: ['key'],
-} as const;
+} as JSONSchemaTypeWithId<
+	Omit<GetIssuePropertyResponse, 'value'>
+> as JSONSchemaTypeWithId<GetIssuePropertyResponse>;
+
+export const CHECK_PERMISSIONS_RESPONSE_SCHEMA: JSONSchemaTypeWithId<CheckPermissionsResponse> =
+	{
+		$id: 'jira-software-cloud-api:post:check-permissions:response',
+		type: 'object',
+		properties: {
+			globalPermissions: {
+				type: 'array',
+				items: { type: 'string' },
+			},
+		},
+		required: ['globalPermissions'],
+	} as const;

--- a/src/infrastructure/jira/jira-client/testing/mocks.ts
+++ b/src/infrastructure/jira/jira-client/testing/mocks.ts
@@ -11,6 +11,8 @@ import {
 import type { JwtTokenParams } from '../jwt-utils';
 import type {
 	Association,
+	CheckPermissionsRequest,
+	CheckPermissionsResponse,
 	GetIssuePropertyResponse,
 	GetIssueResponse,
 	SubmitDesignsRequest,
@@ -134,4 +136,18 @@ export const generateGetIssuePropertyResponse = ({
 }: Partial<GetIssuePropertyResponse> = {}): GetIssuePropertyResponse => ({
 	key,
 	value,
+});
+
+export const generateCheckPermissionsRequest = ({
+	accountId = uuidv4(),
+	globalPermissions = ['ADMINISTER'],
+}: Partial<CheckPermissionsRequest> = {}): CheckPermissionsRequest => ({
+	accountId,
+	globalPermissions,
+});
+
+export const generateCheckPermissionsResponse = ({
+	globalPermissions = ['ADMINISTER'],
+}: Partial<CheckPermissionsResponse> = {}): CheckPermissionsResponse => ({
+	globalPermissions,
 });

--- a/src/infrastructure/jira/jira-client/types.ts
+++ b/src/infrastructure/jira/jira-client/types.ts
@@ -50,3 +50,12 @@ export type SubmitDesignsResponse = {
 	readonly unknownIssueKeys?: string[];
 	readonly unknownAssociations?: Association[];
 };
+
+export type CheckPermissionsRequest = {
+	readonly accountId: string;
+	readonly globalPermissions?: string[];
+};
+
+export type CheckPermissionsResponse = {
+	readonly globalPermissions: string[];
+};

--- a/src/infrastructure/jira/jira-service.test.ts
+++ b/src/infrastructure/jira/jira-service.test.ts
@@ -1,9 +1,11 @@
 import type { AxiosResponse } from 'axios';
 import { AxiosError, HttpStatusCode } from 'axios';
+import { v4 as uuidv4 } from 'uuid';
 
 import { SubmitDesignJiraOperationError } from './errors';
 import { jiraClient } from './jira-client';
 import {
+	generateCheckPermissionsResponse,
 	generateFailedSubmitDesignsResponse,
 	generateGetIssuePropertyResponse,
 	generateSubmitDesignsResponseWithUnknownData,
@@ -954,6 +956,42 @@ describe('JiraService', () => {
 				configurationState.valueOf(),
 				connectInstallation,
 			);
+		});
+	});
+
+	describe('setConfigurationStateInAppProperties', () => {
+		it('should return false if user does not have ADMINISTER permission', async () => {
+			const atlassianUserId = uuidv4();
+			const connectInstallation = generateConnectInstallation();
+			jest.spyOn(jiraClient, 'checkPermissions').mockResolvedValue(
+				generateCheckPermissionsResponse({
+					globalPermissions: [],
+				}),
+			);
+
+			const result = await jiraService.isAdmin(
+				atlassianUserId,
+				connectInstallation,
+			);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false if user has ADMINISTER permission', async () => {
+			const atlassianUserId = uuidv4();
+			const connectInstallation = generateConnectInstallation();
+			jest.spyOn(jiraClient, 'checkPermissions').mockResolvedValue(
+				generateCheckPermissionsResponse({
+					globalPermissions: ['ADMINISTER'],
+				}),
+			);
+
+			const result = await jiraService.isAdmin(
+				atlassianUserId,
+				connectInstallation,
+			);
+
+			expect(result).toBe(true);
 		});
 	});
 });

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -50,6 +50,8 @@ export enum ConfigurationState {
 	UNCONFIGURED = 'UNCONFIGURED',
 }
 
+export const JIRA_ADMIN_GLOBAL_PERMISSION = 'ADMINISTER';
+
 class JiraService {
 	submitDesign = async (
 		params: SubmitDesignParams,
@@ -357,6 +359,21 @@ class JiraService {
 			}
 		}
 	}
+
+	isAdmin = async (
+		atlassianUserId: string,
+		connectInstallation: ConnectInstallation,
+	): Promise<boolean> => {
+		const response = await jiraClient.checkPermissions(
+			{
+				accountId: atlassianUserId,
+				globalPermissions: [JIRA_ADMIN_GLOBAL_PERMISSION],
+			},
+			connectInstallation,
+		);
+
+		return response.globalPermissions.includes(JIRA_ADMIN_GLOBAL_PERMISSION);
+	};
 
 	/**
 	 * This isn't ideal but must be done as it's how the current implementation works

--- a/src/web/middleware/jira/index.ts
+++ b/src/web/middleware/jira/index.ts
@@ -1,4 +1,5 @@
 export * from './jira-asymmetric-jwt-auth-middleware';
+export * from './jira-admin-only-auth-middleware';
 export * from './jira-context-symmetric-jwt-auth-middleware';
 export * from './jira-server-symmetric-jwt-auth-middleware';
 export * from './extract-user-id-from-headers-middleware';

--- a/src/web/middleware/jira/jira-admin-only-auth-middleware.ts
+++ b/src/web/middleware/jira/jira-admin-only-auth-middleware.ts
@@ -1,0 +1,31 @@
+import type { NextFunction, Request, Response } from 'express';
+
+import type { ConnectInstallation } from '../../../domain/entities';
+import { jiraService } from '../../../infrastructure/jira';
+import { UnauthorizedError } from '../errors';
+
+export const jiraAdminOnlyAuthMiddleware = (
+	req: Request,
+	res: Response<
+		unknown,
+		{ atlassianUserId: string; connectInstallation: ConnectInstallation }
+	>,
+	next: NextFunction,
+): void => {
+	const { atlassianUserId, connectInstallation } = res.locals;
+
+	jiraService
+		.isAdmin(atlassianUserId, connectInstallation)
+		.then((isAdmin) => {
+			if (!isAdmin) {
+				return next(
+					new UnauthorizedError(
+						'Unauthorized. The resource is available only for admins.',
+					),
+				);
+			}
+
+			next();
+		})
+		.catch(next);
+};

--- a/src/web/routes/admin/admin-router.ts
+++ b/src/web/routes/admin/admin-router.ts
@@ -3,11 +3,17 @@ import { Router } from 'express';
 import { authRouter } from './auth';
 import { teamsRouter } from './teams';
 
-import { jiraContextSymmetricJwtAuthMiddleware } from '../../middleware/jira';
+import {
+	jiraAdminOnlyAuthMiddleware,
+	jiraContextSymmetricJwtAuthMiddleware,
+} from '../../middleware/jira';
 
 export const adminRouter = Router();
 
-adminRouter.use(jiraContextSymmetricJwtAuthMiddleware);
+adminRouter.use(
+	jiraContextSymmetricJwtAuthMiddleware,
+	jiraAdminOnlyAuthMiddleware,
+);
 
 adminRouter.use('/auth', authRouter);
 adminRouter.use('/teams', teamsRouter);

--- a/src/web/routes/admin/auth/integration.test.ts
+++ b/src/web/routes/admin/auth/integration.test.ts
@@ -19,201 +19,279 @@ import {
 	connectInstallationRepository,
 	figmaOAuth2UserCredentialsRepository,
 } from '../../../../infrastructure/repositories';
-import { generateJiraContextSymmetricJwtToken } from '../../../testing';
+import {
+	generateJiraContextSymmetricJwtToken,
+	mockFigmaMeEndpoint,
+	mockJiraCheckPermissionsEndpoint,
+} from '../../../testing';
 
-const FIGMA_API_BASE_URL = getConfig().figma.apiBaseUrl;
 const FIGMA_OAUTH_API_BASE_URL =
 	getConfig().figma.oauth2.authorizationServerBaseUrl;
 
 const FIGMA_OAUTH_REFRESH_TOKEN_ENDPOINT = '/api/oauth/refresh';
-const FIGMA_ME_ENDPOINT = '/v1/me';
 const CHECK_AUTH_ENDPOINT = '/admin/auth/checkAuth';
 
 describe('/admin/auth', () => {
 	describe('/checkAuth', () => {
-		describe('with valid OAuth credentials stored', () => {
-			it('should return a response indicating that user is authorized if /me endpoint responds with a non-error response code', async () => {
-				const connectInstallation = await connectInstallationRepository.upsert(
-					generateConnectInstallationCreateParams(),
-				);
-				const atlassianUserId = uuidv4();
-				await figmaOAuth2UserCredentialsRepository.upsert(
-					generateFigmaOAuth2UserCredentialCreateParams({
-						atlassianUserId,
-						connectInstallationId: connectInstallation.id,
-					}),
-				);
-				const jwt = generateJiraContextSymmetricJwtToken({
-					connectInstallation,
-					atlassianUserId,
-				});
-
-				nock(FIGMA_API_BASE_URL)
-					.get(FIGMA_ME_ENDPOINT)
-					.reply(HttpStatusCode.Ok);
-
-				return request(app)
-					.get(CHECK_AUTH_ENDPOINT)
-					.set('Authorization', `JWT ${jwt}`)
-					.expect(HttpStatusCode.Ok)
-					.expect({ authorized: true });
-			});
-
-			it('should return a response indicating that user is not authorized if the /me endpoint responds with a 403', async () => {
-				const connectInstallation = await connectInstallationRepository.upsert(
-					generateConnectInstallationCreateParams(),
-				);
-				const atlassianUserId = uuidv4();
-				await figmaOAuth2UserCredentialsRepository.upsert(
-					generateFigmaOAuth2UserCredentialCreateParams({
-						atlassianUserId,
-						connectInstallationId: connectInstallation.id,
-					}),
-				);
-				const jwt = generateJiraContextSymmetricJwtToken({
-					connectInstallation,
-					atlassianUserId,
-				});
-
-				nock(FIGMA_API_BASE_URL)
-					.get(FIGMA_ME_ENDPOINT)
-					.reply(HttpStatusCode.Forbidden);
-
-				return request(app)
-					.get(CHECK_AUTH_ENDPOINT)
-					.set('Authorization', `JWT ${jwt}`)
-					.expect(HttpStatusCode.Ok)
-					.expect({
-						authorized: false,
-						grant: {
-							authorizationEndpoint:
-								figmaAuthService.createOAuth2AuthorizationRequest({
-									atlassianUserId,
-									connectInstallation,
-									redirectEndpoint: 'figma/oauth/callback',
-								}),
-						},
-					});
-			});
+		const REFRESH_TOKEN = uuidv4();
+		const REFRESH_TOKEN_QUERY_PARAMS = generateRefreshOAuth2TokenQueryParams({
+			client_id: getConfig().figma.oauth2.clientId,
+			client_secret: getConfig().figma.oauth2.clientSecret,
+			refresh_token: REFRESH_TOKEN,
 		});
 
-		describe('with expired OAuth credentials stored', () => {
-			const REFRESH_TOKEN = uuidv4();
-			const REFRESH_TOKEN_QUERY_PARAMS = generateRefreshOAuth2TokenQueryParams({
-				client_id: getConfig().figma.oauth2.clientId,
-				client_secret: getConfig().figma.oauth2.clientSecret,
-				refresh_token: REFRESH_TOKEN,
+		it('should return a response indicating that user is authorized if user is authorized', async () => {
+			const connectInstallation = await connectInstallationRepository.upsert(
+				generateConnectInstallationCreateParams(),
+			);
+			const atlassianUserId = uuidv4();
+			await figmaOAuth2UserCredentialsRepository.upsert(
+				generateFigmaOAuth2UserCredentialCreateParams({
+					atlassianUserId,
+					connectInstallationId: connectInstallation.id,
+				}),
+			);
+			const jwt = generateJiraContextSymmetricJwtToken({
+				connectInstallation,
+				atlassianUserId,
 			});
 
-			it('should return a response indicating that user is authorized if credentials were refreshed', async () => {
-				const connectInstallation = await connectInstallationRepository.upsert(
-					generateConnectInstallationCreateParams(),
-				);
-				const atlassianUserId = uuidv4();
-				await figmaOAuth2UserCredentialsRepository.upsert(
-					generateExpiredFigmaOAuth2UserCredentialCreateParams({
-						refreshToken: REFRESH_TOKEN,
-						atlassianUserId,
-						connectInstallationId: connectInstallation.id,
-					}),
-				);
-				const refreshTokenResponse = generateRefreshOAuth2TokenResponse();
-				const jwt = generateJiraContextSymmetricJwtToken({
-					connectInstallation,
-					atlassianUserId,
-				});
-
-				nock(FIGMA_OAUTH_API_BASE_URL)
-					.post(FIGMA_OAUTH_REFRESH_TOKEN_ENDPOINT)
-					.query(REFRESH_TOKEN_QUERY_PARAMS)
-					.reply(HttpStatusCode.Ok, refreshTokenResponse);
-				nock(FIGMA_API_BASE_URL)
-					.get(FIGMA_ME_ENDPOINT)
-					.reply(HttpStatusCode.Ok);
-
-				await request(app)
-					.get(CHECK_AUTH_ENDPOINT)
-					.set('Authorization', `JWT ${jwt}`)
-					.expect(HttpStatusCode.Ok)
-					.expect({ authorized: true });
-
-				const credentials = await figmaOAuth2UserCredentialsRepository.get(
-					atlassianUserId,
-					connectInstallation.id,
-				);
-				expect(credentials?.accessToken).toEqual(
-					refreshTokenResponse.access_token,
-				);
-				expect(credentials?.isExpired()).toBeFalsy();
+			mockJiraCheckPermissionsEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				request: {
+					accountId: atlassianUserId,
+					globalPermissions: ['ADMINISTER'],
+				},
+				response: {
+					globalPermissions: ['ADMINISTER'],
+				},
 			});
+			mockFigmaMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
 
-			it('should return a response indicating that user is not authorized if credentials could not be refreshed', async () => {
-				const connectInstallation = await connectInstallationRepository.upsert(
-					generateConnectInstallationCreateParams(),
-				);
-				const atlassianUserId = uuidv4();
-				await figmaOAuth2UserCredentialsRepository.upsert(
-					generateExpiredFigmaOAuth2UserCredentialCreateParams({
-						refreshToken: REFRESH_TOKEN,
-						atlassianUserId,
-						connectInstallationId: connectInstallation.id,
-					}),
-				);
-				const jwt = generateJiraContextSymmetricJwtToken({
-					connectInstallation,
-					atlassianUserId,
-				});
-
-				nock(FIGMA_OAUTH_API_BASE_URL)
-					.post(FIGMA_OAUTH_REFRESH_TOKEN_ENDPOINT)
-					.query(REFRESH_TOKEN_QUERY_PARAMS)
-					.reply(HttpStatusCode.InternalServerError);
-
-				return request(app)
-					.get(CHECK_AUTH_ENDPOINT)
-					.set('Authorization', `JWT ${jwt}`)
-					.expect(HttpStatusCode.Ok)
-					.expect({
-						authorized: false,
-						grant: {
-							authorizationEndpoint:
-								figmaAuthService.createOAuth2AuthorizationRequest({
-									atlassianUserId,
-									connectInstallation,
-									redirectEndpoint: 'figma/oauth/callback',
-								}),
-						},
-					});
-			});
+			return request(app)
+				.get(CHECK_AUTH_ENDPOINT)
+				.set('Authorization', `JWT ${jwt}`)
+				.expect(HttpStatusCode.Ok)
+				.expect({ authorized: true });
 		});
 
-		describe('without OAuth credentials stored', () => {
-			it('should return a response indicating that user is not authorized if no database entry exists', async () => {
-				const connectInstallation = await connectInstallationRepository.upsert(
-					generateConnectInstallationCreateParams(),
-				);
-				const atlassianUserId = uuidv4();
-				const jwt = generateJiraContextSymmetricJwtToken({
-					connectInstallation,
-					atlassianUserId,
-				});
-
-				return request(app)
-					.get(CHECK_AUTH_ENDPOINT)
-					.set('Authorization', `JWT ${jwt}`)
-					.expect(HttpStatusCode.Ok)
-					.expect({
-						authorized: false,
-						grant: {
-							authorizationEndpoint:
-								figmaAuthService.createOAuth2AuthorizationRequest({
-									atlassianUserId,
-									connectInstallation,
-									redirectEndpoint: 'figma/oauth/callback',
-								}),
-						},
-					});
+		it('should return a response indicating that user is not authorized if no credentials stored', async () => {
+			const connectInstallation = await connectInstallationRepository.upsert(
+				generateConnectInstallationCreateParams(),
+			);
+			const atlassianUserId = uuidv4();
+			const jwt = generateJiraContextSymmetricJwtToken({
+				connectInstallation,
+				atlassianUserId,
 			});
+
+			mockJiraCheckPermissionsEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				request: {
+					accountId: atlassianUserId,
+					globalPermissions: ['ADMINISTER'],
+				},
+				response: {
+					globalPermissions: ['ADMINISTER'],
+				},
+			});
+
+			return request(app)
+				.get(CHECK_AUTH_ENDPOINT)
+				.set('Authorization', `JWT ${jwt}`)
+				.expect(HttpStatusCode.Ok)
+				.expect({
+					authorized: false,
+					grant: {
+						authorizationEndpoint:
+							figmaAuthService.createOAuth2AuthorizationRequest({
+								atlassianUserId,
+								connectInstallation,
+								redirectEndpoint: 'figma/oauth/callback',
+							}),
+					},
+				});
+		});
+
+		it('should return a response indicating that user is authorized if credentials were refreshed', async () => {
+			const connectInstallation = await connectInstallationRepository.upsert(
+				generateConnectInstallationCreateParams(),
+			);
+			const atlassianUserId = uuidv4();
+			await figmaOAuth2UserCredentialsRepository.upsert(
+				generateExpiredFigmaOAuth2UserCredentialCreateParams({
+					refreshToken: REFRESH_TOKEN,
+					atlassianUserId,
+					connectInstallationId: connectInstallation.id,
+				}),
+			);
+			const refreshTokenResponse = generateRefreshOAuth2TokenResponse();
+			const jwt = generateJiraContextSymmetricJwtToken({
+				connectInstallation,
+				atlassianUserId,
+			});
+
+			mockJiraCheckPermissionsEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				request: {
+					accountId: atlassianUserId,
+					globalPermissions: ['ADMINISTER'],
+				},
+				response: {
+					globalPermissions: ['ADMINISTER'],
+				},
+			});
+			nock(FIGMA_OAUTH_API_BASE_URL)
+				.post(FIGMA_OAUTH_REFRESH_TOKEN_ENDPOINT)
+				.query(REFRESH_TOKEN_QUERY_PARAMS)
+				.reply(HttpStatusCode.Ok, refreshTokenResponse);
+			mockFigmaMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
+
+			await request(app)
+				.get(CHECK_AUTH_ENDPOINT)
+				.set('Authorization', `JWT ${jwt}`)
+				.expect(HttpStatusCode.Ok)
+				.expect({ authorized: true });
+
+			const credentials = await figmaOAuth2UserCredentialsRepository.get(
+				atlassianUserId,
+				connectInstallation.id,
+			);
+			expect(credentials?.accessToken).toEqual(
+				refreshTokenResponse.access_token,
+			);
+			expect(credentials?.isExpired()).toBeFalsy();
+		});
+
+		it('should return a response indicating that user is not authorized if credentials could not be refreshed', async () => {
+			const connectInstallation = await connectInstallationRepository.upsert(
+				generateConnectInstallationCreateParams(),
+			);
+			const atlassianUserId = uuidv4();
+			await figmaOAuth2UserCredentialsRepository.upsert(
+				generateExpiredFigmaOAuth2UserCredentialCreateParams({
+					refreshToken: REFRESH_TOKEN,
+					atlassianUserId,
+					connectInstallationId: connectInstallation.id,
+				}),
+			);
+			const jwt = generateJiraContextSymmetricJwtToken({
+				connectInstallation,
+				atlassianUserId,
+			});
+
+			mockJiraCheckPermissionsEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				request: {
+					accountId: atlassianUserId,
+					globalPermissions: ['ADMINISTER'],
+				},
+				response: {
+					globalPermissions: ['ADMINISTER'],
+				},
+			});
+			nock(FIGMA_OAUTH_API_BASE_URL)
+				.post(FIGMA_OAUTH_REFRESH_TOKEN_ENDPOINT)
+				.query(REFRESH_TOKEN_QUERY_PARAMS)
+				.reply(HttpStatusCode.InternalServerError);
+
+			return request(app)
+				.get(CHECK_AUTH_ENDPOINT)
+				.set('Authorization', `JWT ${jwt}`)
+				.expect(HttpStatusCode.Ok)
+				.expect({
+					authorized: false,
+					grant: {
+						authorizationEndpoint:
+							figmaAuthService.createOAuth2AuthorizationRequest({
+								atlassianUserId,
+								connectInstallation,
+								redirectEndpoint: 'figma/oauth/callback',
+							}),
+					},
+				});
+		});
+
+		it('should return a response indicating that user is not authorized if the /me endpoint responds with a 403', async () => {
+			const connectInstallation = await connectInstallationRepository.upsert(
+				generateConnectInstallationCreateParams(),
+			);
+			const atlassianUserId = uuidv4();
+			await figmaOAuth2UserCredentialsRepository.upsert(
+				generateFigmaOAuth2UserCredentialCreateParams({
+					atlassianUserId,
+					connectInstallationId: connectInstallation.id,
+				}),
+			);
+			const jwt = generateJiraContextSymmetricJwtToken({
+				connectInstallation,
+				atlassianUserId,
+			});
+
+			mockJiraCheckPermissionsEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				request: {
+					accountId: atlassianUserId,
+					globalPermissions: ['ADMINISTER'],
+				},
+				response: {
+					globalPermissions: ['ADMINISTER'],
+				},
+			});
+			mockFigmaMeEndpoint({
+				baseUrl: getConfig().figma.apiBaseUrl,
+				status: HttpStatusCode.Forbidden,
+			});
+
+			return request(app)
+				.get(CHECK_AUTH_ENDPOINT)
+				.set('Authorization', `JWT ${jwt}`)
+				.expect(HttpStatusCode.Ok)
+				.expect({
+					authorized: false,
+					grant: {
+						authorizationEndpoint:
+							figmaAuthService.createOAuth2AuthorizationRequest({
+								atlassianUserId,
+								connectInstallation,
+								redirectEndpoint: 'figma/oauth/callback',
+							}),
+					},
+				});
+		});
+
+		it('should return unauthorized error if a user is not Jira admin', async () => {
+			const connectInstallation = await connectInstallationRepository.upsert(
+				generateConnectInstallationCreateParams(),
+			);
+			const atlassianUserId = uuidv4();
+			await figmaOAuth2UserCredentialsRepository.upsert(
+				generateFigmaOAuth2UserCredentialCreateParams({
+					atlassianUserId,
+					connectInstallationId: connectInstallation.id,
+				}),
+			);
+			const jwt = generateJiraContextSymmetricJwtToken({
+				connectInstallation,
+				atlassianUserId,
+			});
+
+			mockJiraCheckPermissionsEndpoint({
+				baseUrl: connectInstallation.baseUrl,
+				request: {
+					accountId: atlassianUserId,
+					globalPermissions: ['ADMINISTER'],
+				},
+				response: {
+					globalPermissions: [],
+				},
+			});
+			mockFigmaMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
+
+			return request(app)
+				.get(CHECK_AUTH_ENDPOINT)
+				.set('Authorization', `JWT ${jwt}`)
+				.expect(HttpStatusCode.Unauthorized);
 		});
 	});
 });

--- a/src/web/routes/auth/integration.test.ts
+++ b/src/web/routes/auth/integration.test.ts
@@ -19,239 +19,230 @@ import {
 	connectInstallationRepository,
 	figmaOAuth2UserCredentialsRepository,
 } from '../../../infrastructure/repositories';
-import { generateJiraServerSymmetricJwtToken } from '../../testing';
+import {
+	generateJiraServerSymmetricJwtToken,
+	mockFigmaMeEndpoint,
+} from '../../testing';
 
-const FIGMA_API_BASE_URL = getConfig().figma.apiBaseUrl;
 const FIGMA_OAUTH_API_BASE_URL =
 	getConfig().figma.oauth2.authorizationServerBaseUrl;
-
 const FIGMA_OAUTH_REFRESH_TOKEN_ENDPOINT = '/api/oauth/refresh';
-const FIGMA_ME_ENDPOINT = '/v1/me';
 const CHECK_AUTH_ENDPOINT = '/auth/checkAuth';
 
 describe('/auth', () => {
 	describe('/checkAuth', () => {
-		describe('with valid OAuth credentials stored', () => {
-			it('should return a response indicating that user is authorized if /me endpoint responds with a non-error response code', async () => {
-				const connectInstallation = await connectInstallationRepository.upsert(
-					generateConnectInstallationCreateParams(),
-				);
-				const atlassianUserId = uuidv4();
-				await figmaOAuth2UserCredentialsRepository.upsert(
-					generateFigmaOAuth2UserCredentialCreateParams({
-						atlassianUserId,
-						connectInstallationId: connectInstallation.id,
-					}),
-				);
-				const jwt = generateJiraServerSymmetricJwtToken({
-					request: {
-						method: 'GET',
-						pathname: '/auth/checkAuth',
-						query: { userId: atlassianUserId },
-					},
-					connectInstallation,
-				});
-
-				nock(FIGMA_API_BASE_URL)
-					.get(FIGMA_ME_ENDPOINT)
-					.reply(HttpStatusCode.Ok);
-
-				return request(app)
-					.get(CHECK_AUTH_ENDPOINT)
-					.query({
-						userId: atlassianUserId,
-					})
-					.set('Authorization', `JWT ${jwt}`)
-					.expect(HttpStatusCode.Ok)
-					.expect({ type: '3LO', authorized: true });
-			});
-
-			it('should return a response indicating that user is not authorized if the /me endpoint responds with a 403', async () => {
-				const connectInstallation = await connectInstallationRepository.upsert(
-					generateConnectInstallationCreateParams(),
-				);
-				const atlassianUserId = uuidv4();
-				await figmaOAuth2UserCredentialsRepository.upsert(
-					generateFigmaOAuth2UserCredentialCreateParams({
-						atlassianUserId,
-						connectInstallationId: connectInstallation.id,
-					}),
-				);
-				const jwt = generateJiraServerSymmetricJwtToken({
-					request: {
-						method: 'GET',
-						pathname: '/auth/checkAuth',
-						query: { userId: atlassianUserId },
-					},
-					connectInstallation,
-				});
-
-				nock(FIGMA_API_BASE_URL)
-					.get(FIGMA_ME_ENDPOINT)
-					.reply(HttpStatusCode.Forbidden);
-
-				return request(app)
-					.get(CHECK_AUTH_ENDPOINT)
-					.query({
-						userId: atlassianUserId,
-					})
-					.set('Authorization', `JWT ${jwt}`)
-					.expect(HttpStatusCode.Ok)
-					.expect({
-						type: '3LO',
-						authorized: false,
-						grant: {
-							authorizationEndpoint:
-								figmaAuthService.createOAuth2AuthorizationRequest({
-									atlassianUserId,
-									connectInstallation,
-									redirectEndpoint: 'figma/oauth/callback',
-								}),
-						},
-					});
-			});
+		const REFRESH_TOKEN = uuidv4();
+		const REFRESH_TOKEN_QUERY_PARAMS = generateRefreshOAuth2TokenQueryParams({
+			client_id: getConfig().figma.oauth2.clientId,
+			client_secret: getConfig().figma.oauth2.clientSecret,
+			refresh_token: REFRESH_TOKEN,
 		});
 
-		describe('with expired OAuth credentials stored', () => {
-			const REFRESH_TOKEN = uuidv4();
-			const REFRESH_TOKEN_QUERY_PARAMS = generateRefreshOAuth2TokenQueryParams({
-				client_id: getConfig().figma.oauth2.clientId,
-				client_secret: getConfig().figma.oauth2.clientSecret,
-				refresh_token: REFRESH_TOKEN,
-			});
-
-			it('should return a response indicating that user is authorized if credentials were refreshed', async () => {
-				const connectInstallation = await connectInstallationRepository.upsert(
-					generateConnectInstallationCreateParams(),
-				);
-				const atlassianUserId = uuidv4();
-				await figmaOAuth2UserCredentialsRepository.upsert(
-					generateExpiredFigmaOAuth2UserCredentialCreateParams({
-						refreshToken: REFRESH_TOKEN,
-						atlassianUserId,
-						connectInstallationId: connectInstallation.id,
-					}),
-				);
-				const refreshTokenResponse = generateRefreshOAuth2TokenResponse();
-				const jwt = generateJiraServerSymmetricJwtToken({
-					request: {
-						method: 'GET',
-						pathname: '/auth/checkAuth',
-						query: { userId: atlassianUserId },
-					},
-					connectInstallation,
-				});
-
-				nock(FIGMA_OAUTH_API_BASE_URL)
-					.post(FIGMA_OAUTH_REFRESH_TOKEN_ENDPOINT)
-					.query(REFRESH_TOKEN_QUERY_PARAMS)
-					.reply(HttpStatusCode.Ok, refreshTokenResponse);
-				nock(FIGMA_API_BASE_URL)
-					.get(FIGMA_ME_ENDPOINT)
-					.reply(HttpStatusCode.Ok);
-
-				await request(app)
-					.get(CHECK_AUTH_ENDPOINT)
-					.query({
-						userId: atlassianUserId,
-					})
-					.set('Authorization', `JWT ${jwt}`)
-					.expect(HttpStatusCode.Ok)
-					.expect({ type: '3LO', authorized: true });
-
-				const credentials = await figmaOAuth2UserCredentialsRepository.get(
+		it('should return a response indicating that user is authorized if user is authorized', async () => {
+			const connectInstallation = await connectInstallationRepository.upsert(
+				generateConnectInstallationCreateParams(),
+			);
+			const atlassianUserId = uuidv4();
+			await figmaOAuth2UserCredentialsRepository.upsert(
+				generateFigmaOAuth2UserCredentialCreateParams({
 					atlassianUserId,
-					connectInstallation.id,
-				);
-				expect(credentials?.accessToken).toEqual(
-					refreshTokenResponse.access_token,
-				);
-				expect(credentials?.isExpired()).toBeFalsy();
+					connectInstallationId: connectInstallation.id,
+				}),
+			);
+			const jwt = generateJiraServerSymmetricJwtToken({
+				request: {
+					method: 'GET',
+					pathname: '/auth/checkAuth',
+					query: { userId: atlassianUserId },
+				},
+				connectInstallation,
 			});
 
-			it('should return a response indicating that user is not authorized if credentials could not be refreshed', async () => {
-				const connectInstallation = await connectInstallationRepository.upsert(
-					generateConnectInstallationCreateParams(),
-				);
-				const atlassianUserId = uuidv4();
-				await figmaOAuth2UserCredentialsRepository.upsert(
-					generateExpiredFigmaOAuth2UserCredentialCreateParams({
-						refreshToken: REFRESH_TOKEN,
-						atlassianUserId,
-						connectInstallationId: connectInstallation.id,
-					}),
-				);
-				const jwt = generateJiraServerSymmetricJwtToken({
-					request: {
-						method: 'GET',
-						pathname: '/auth/checkAuth',
-						query: { userId: atlassianUserId },
-					},
-					connectInstallation,
-				});
+			mockFigmaMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
 
-				nock(FIGMA_OAUTH_API_BASE_URL)
-					.post(FIGMA_OAUTH_REFRESH_TOKEN_ENDPOINT)
-					.query(REFRESH_TOKEN_QUERY_PARAMS)
-					.reply(HttpStatusCode.InternalServerError);
-
-				return request(app)
-					.get(CHECK_AUTH_ENDPOINT)
-					.query({
-						userId: atlassianUserId,
-					})
-					.set('Authorization', `JWT ${jwt}`)
-					.expect(HttpStatusCode.Ok)
-					.expect({
-						type: '3LO',
-						authorized: false,
-						grant: {
-							authorizationEndpoint:
-								figmaAuthService.createOAuth2AuthorizationRequest({
-									atlassianUserId,
-									connectInstallation,
-									redirectEndpoint: 'figma/oauth/callback',
-								}),
-						},
-					});
-			});
+			return request(app)
+				.get(CHECK_AUTH_ENDPOINT)
+				.query({
+					userId: atlassianUserId,
+				})
+				.set('Authorization', `JWT ${jwt}`)
+				.expect(HttpStatusCode.Ok)
+				.expect({ type: '3LO', authorized: true });
 		});
 
-		describe('without OAuth credentials stored', () => {
-			it('should return a response indicating that user is not authorized if no database entry exists', async () => {
-				const connectInstallation = await connectInstallationRepository.upsert(
-					generateConnectInstallationCreateParams(),
-				);
-				const atlassianUserId = uuidv4();
-				const jwt = generateJiraServerSymmetricJwtToken({
-					request: {
-						method: 'GET',
-						pathname: '/auth/checkAuth',
-						query: { userId: atlassianUserId },
-					},
-					connectInstallation,
-				});
-
-				return request(app)
-					.get(CHECK_AUTH_ENDPOINT)
-					.query({
-						userId: atlassianUserId,
-					})
-					.set('Authorization', `JWT ${jwt}`)
-					.expect(HttpStatusCode.Ok)
-					.expect({
-						type: '3LO',
-						authorized: false,
-						grant: {
-							authorizationEndpoint:
-								figmaAuthService.createOAuth2AuthorizationRequest({
-									atlassianUserId,
-									connectInstallation,
-									redirectEndpoint: 'figma/oauth/callback',
-								}),
-						},
-					});
+		it('should return a response indicating that user is not authorized if no credentials stored', async () => {
+			const connectInstallation = await connectInstallationRepository.upsert(
+				generateConnectInstallationCreateParams(),
+			);
+			const atlassianUserId = uuidv4();
+			const jwt = generateJiraServerSymmetricJwtToken({
+				request: {
+					method: 'GET',
+					pathname: '/auth/checkAuth',
+					query: { userId: atlassianUserId },
+				},
+				connectInstallation,
 			});
+
+			return request(app)
+				.get(CHECK_AUTH_ENDPOINT)
+				.query({
+					userId: atlassianUserId,
+				})
+				.set('Authorization', `JWT ${jwt}`)
+				.expect(HttpStatusCode.Ok)
+				.expect({
+					type: '3LO',
+					authorized: false,
+					grant: {
+						authorizationEndpoint:
+							figmaAuthService.createOAuth2AuthorizationRequest({
+								atlassianUserId,
+								connectInstallation,
+								redirectEndpoint: 'figma/oauth/callback',
+							}),
+					},
+				});
+		});
+
+		it('should return a response indicating that user is authorized if credentials were refreshed', async () => {
+			const connectInstallation = await connectInstallationRepository.upsert(
+				generateConnectInstallationCreateParams(),
+			);
+			const atlassianUserId = uuidv4();
+			await figmaOAuth2UserCredentialsRepository.upsert(
+				generateExpiredFigmaOAuth2UserCredentialCreateParams({
+					refreshToken: REFRESH_TOKEN,
+					atlassianUserId,
+					connectInstallationId: connectInstallation.id,
+				}),
+			);
+			const refreshTokenResponse = generateRefreshOAuth2TokenResponse();
+			const jwt = generateJiraServerSymmetricJwtToken({
+				request: {
+					method: 'GET',
+					pathname: '/auth/checkAuth',
+					query: { userId: atlassianUserId },
+				},
+				connectInstallation,
+			});
+
+			nock(FIGMA_OAUTH_API_BASE_URL)
+				.post(FIGMA_OAUTH_REFRESH_TOKEN_ENDPOINT)
+				.query(REFRESH_TOKEN_QUERY_PARAMS)
+				.reply(HttpStatusCode.Ok, refreshTokenResponse);
+			mockFigmaMeEndpoint({ baseUrl: getConfig().figma.apiBaseUrl });
+
+			await request(app)
+				.get(CHECK_AUTH_ENDPOINT)
+				.query({
+					userId: atlassianUserId,
+				})
+				.set('Authorization', `JWT ${jwt}`)
+				.expect(HttpStatusCode.Ok)
+				.expect({ type: '3LO', authorized: true });
+
+			const credentials = await figmaOAuth2UserCredentialsRepository.get(
+				atlassianUserId,
+				connectInstallation.id,
+			);
+			expect(credentials?.accessToken).toEqual(
+				refreshTokenResponse.access_token,
+			);
+			expect(credentials?.isExpired()).toBeFalsy();
+		});
+
+		it('should return a response indicating that user is not authorized if credentials could not be refreshed', async () => {
+			const connectInstallation = await connectInstallationRepository.upsert(
+				generateConnectInstallationCreateParams(),
+			);
+			const atlassianUserId = uuidv4();
+			await figmaOAuth2UserCredentialsRepository.upsert(
+				generateExpiredFigmaOAuth2UserCredentialCreateParams({
+					refreshToken: REFRESH_TOKEN,
+					atlassianUserId,
+					connectInstallationId: connectInstallation.id,
+				}),
+			);
+			const jwt = generateJiraServerSymmetricJwtToken({
+				request: {
+					method: 'GET',
+					pathname: '/auth/checkAuth',
+					query: { userId: atlassianUserId },
+				},
+				connectInstallation,
+			});
+
+			nock(FIGMA_OAUTH_API_BASE_URL)
+				.post(FIGMA_OAUTH_REFRESH_TOKEN_ENDPOINT)
+				.query(REFRESH_TOKEN_QUERY_PARAMS)
+				.reply(HttpStatusCode.InternalServerError);
+
+			return request(app)
+				.get(CHECK_AUTH_ENDPOINT)
+				.query({
+					userId: atlassianUserId,
+				})
+				.set('Authorization', `JWT ${jwt}`)
+				.expect(HttpStatusCode.Ok)
+				.expect({
+					type: '3LO',
+					authorized: false,
+					grant: {
+						authorizationEndpoint:
+							figmaAuthService.createOAuth2AuthorizationRequest({
+								atlassianUserId,
+								connectInstallation,
+								redirectEndpoint: 'figma/oauth/callback',
+							}),
+					},
+				});
+		});
+
+		it('should return a response indicating that user is not authorized if the /me endpoint responds with a 403', async () => {
+			const connectInstallation = await connectInstallationRepository.upsert(
+				generateConnectInstallationCreateParams(),
+			);
+			const atlassianUserId = uuidv4();
+			await figmaOAuth2UserCredentialsRepository.upsert(
+				generateFigmaOAuth2UserCredentialCreateParams({
+					atlassianUserId,
+					connectInstallationId: connectInstallation.id,
+				}),
+			);
+			const jwt = generateJiraServerSymmetricJwtToken({
+				request: {
+					method: 'GET',
+					pathname: '/auth/checkAuth',
+					query: { userId: atlassianUserId },
+				},
+				connectInstallation,
+			});
+
+			mockFigmaMeEndpoint({
+				baseUrl: getConfig().figma.apiBaseUrl,
+				status: HttpStatusCode.Forbidden,
+			});
+
+			return request(app)
+				.get(CHECK_AUTH_ENDPOINT)
+				.query({
+					userId: atlassianUserId,
+				})
+				.set('Authorization', `JWT ${jwt}`)
+				.expect(HttpStatusCode.Ok)
+				.expect({
+					type: '3LO',
+					authorized: false,
+					grant: {
+						authorizationEndpoint:
+							figmaAuthService.createOAuth2AuthorizationRequest({
+								atlassianUserId,
+								connectInstallation,
+								redirectEndpoint: 'figma/oauth/callback',
+							}),
+					},
+				});
 		});
 	});
 });

--- a/src/web/testing/jira-api-mocks.ts
+++ b/src/web/testing/jira-api-mocks.ts
@@ -4,11 +4,14 @@ import nock from 'nock';
 
 import { generateJiraIssueId } from '../../domain/entities/testing';
 import type {
+	CheckPermissionsRequest,
+	CheckPermissionsResponse,
 	GetIssuePropertyResponse,
 	SubmitDesignsRequest,
 	SubmitDesignsResponse,
 } from '../../infrastructure/jira/jira-client';
 import {
+	generateCheckPermissionsResponse,
 	generateGetIssuePropertyResponse,
 	generateGetIssueResponse,
 	generateSuccessfulSubmitDesignsResponse,
@@ -113,4 +116,20 @@ export const mockJiraSetAppPropertyEndpoint = ({
 			request,
 		)
 		.reply(status);
+};
+
+export const mockJiraCheckPermissionsEndpoint = ({
+	baseUrl,
+	request,
+	status = HttpStatusCode.Ok,
+	response = generateCheckPermissionsResponse(),
+}: {
+	baseUrl: string;
+	request: CheckPermissionsRequest;
+	status?: HttpStatusCode;
+	response?: CheckPermissionsResponse;
+}) => {
+	nock(baseUrl)
+		.post(`/rest/api/3/permissions/check`, request)
+		.reply(status, response);
 };


### PR DESCRIPTION
## Changes

 -**feat:** Implements `jiraAdminOnlyAuthMiddleware` to restrict access to endpoints to Jira admins.
 -**feat:** Applies `jiraAdminOnlyAuthMiddleware` to all `/admin` endpoints.
 -**test:** Applies minor refactoring to related integration tests.