### PR TITLE
MDTZ-1081: Fixed string validation error for ingested-design-urls issue property

### DIFF
--- a/src/infrastructure/ajv.ts
+++ b/src/infrastructure/ajv.ts
@@ -1,8 +1,6 @@
 import type { ErrorObject, JSONSchemaType, ValidateFunction } from 'ajv';
 import Ajv from 'ajv';
 
-import { ensureString } from '../common/string-utils';
-
 export const ajv = new Ajv({ allowUnionTypes: true });
 
 export type JSONSchemaTypeWithId<T> = JSONSchemaType<T> & { $id: string };
@@ -39,9 +37,11 @@ export function parseJsonOfSchema<T>(
 	schema: JSONSchemaTypeWithId<T>,
 ): T {
 	try {
-		const parsed: unknown = JSON.parse(ensureString(value));
-		assertSchema(parsed, schema);
-		return parsed;
+		if (typeof value === 'string') {
+			value = JSON.parse(value);
+		}
+		assertSchema(value, schema);
+		return value;
 	} catch (error) {
 		if (error instanceof SchemaValidationError) {
 			throw error;

--- a/src/infrastructure/jira/jira-service.test.ts
+++ b/src/infrastructure/jira/jira-service.test.ts
@@ -565,7 +565,7 @@ describe('JiraService', () => {
 			jest.spyOn(jiraClient, 'getIssueProperty').mockResolvedValue(
 				generateGetIssuePropertyResponse({
 					key: issuePropertyKeys.INGESTED_DESIGN_URLS,
-					value: JSON.stringify(ingestedDesignPropertyValues),
+					value: ingestedDesignPropertyValues,
 				}),
 			);
 			jest.spyOn(jiraClient, 'setIssueProperty').mockImplementation(jest.fn());
@@ -593,7 +593,7 @@ describe('JiraService', () => {
 			jest.spyOn(jiraClient, 'getIssueProperty').mockResolvedValue(
 				generateGetIssuePropertyResponse({
 					key: issuePropertyKeys.INGESTED_DESIGN_URLS,
-					value: JSON.stringify([design.url]),
+					value: [design.url],
 				}),
 			);
 			jest.spyOn(jiraClient, 'setIssueProperty').mockImplementation(jest.fn());
@@ -607,7 +607,7 @@ describe('JiraService', () => {
 			expect(jiraClient.setIssueProperty).not.toHaveBeenCalled();
 		});
 
-		it.each([1, null, { url: 'url' }])(
+		it.each([1, [1], null, { url: 'url' }])(
 			'should overwrite the existing value if the issue property value is not in the expected shape',
 			async (value) => {
 				const expectedIssuePropertyValue = [design.url];
@@ -615,7 +615,7 @@ describe('JiraService', () => {
 				jest.spyOn(jiraClient, 'getIssueProperty').mockResolvedValue(
 					generateGetIssuePropertyResponse({
 						key: issuePropertyKeys.INGESTED_DESIGN_URLS,
-						value: JSON.stringify(value),
+						value: value,
 					}),
 				);
 				jest.spyOn(jiraClient, 'setIssueProperty').mockResolvedValue();


### PR DESCRIPTION
For the ` ingested-design-urls` issue property schema validation was failing as the value was not a string. Updated the `parseJsonOfSchema` function to handle this