### PR TITLE
[tests] Tweak the regex for jest unit tests to explicitly check for `integration.`

### DIFF
--- a/jest.config.unit.ts
+++ b/jest.config.unit.ts
@@ -3,7 +3,7 @@ import baseConfig from './jest.config';
 
 const config: Config = {
 	...baseConfig,
-	testRegex: '^(?!.*integration.*)(.*)(\\.|/)(test|spec)\\.tsx?$',
+	testRegex: '^(?!.*integration\\..*)(.*)(\\.|/)(test|spec)\\.tsx?$',
 	setupFiles: [
 		...(baseConfig.setupFiles ?? []),
 		'<rootDir>/src/infrastructure/testing/mock-logger.ts',


### PR DESCRIPTION
The regex bit (?!.*integration.*) checks that we don't match a test like integration.test.ts.

Our copy of this repo lives under the directory `integrations/figma-for-jira`. Currently, this regex inadvertently matches all tests within integrations/figma-for-jira because the folder name has the string integration

To fix the regex, I added a check to exclude integration. vs. just the string integration.

I checked that `npm run test:unit` runs both in this copy and in our copy.

![image](https://github.com/atlassian-labs/figma-for-jira/assets/116598948/eeb19f44-4218-42b8-9f38-ebc2ae325746)
