### PR TITLE
NONE: Resolve the issue with setting Connect app property.

### DIFF
--- a/src/infrastructure/jira/jira-client/jira-client.test.ts
+++ b/src/infrastructure/jira/jira-client/jira-client.test.ts
@@ -208,7 +208,7 @@ describe('JiraClient', () => {
 
 			expect(axios.put).toHaveBeenCalledWith(
 				`${connectInstallation.baseUrl}/rest/api/2/issue/${issueId}/properties/${propertyKey}`,
-				'some value',
+				JSON.stringify('some value'),
 				{ headers },
 			);
 		});
@@ -272,11 +272,11 @@ describe('JiraClient', () => {
 
 			const headers = defaultExpectedRequestHeaders()
 				.headers.setAccept('application/json')
-				.setContentType('text/plain');
+				.setContentType('application/json');
 
 			expect(axios.put).toHaveBeenCalledWith(
 				`${connectInstallation.baseUrl}/rest/atlassian-connect/1/addons/${connectInstallation.key}/properties/${propertyKey}`,
-				'some value',
+				JSON.stringify('some value'),
 				{ headers },
 			);
 		});

--- a/src/infrastructure/jira/jira-client/jira-client.ts
+++ b/src/infrastructure/jira/jira-client/jira-client.ts
@@ -160,7 +160,7 @@ class JiraClient {
 				connectInstallation.baseUrl,
 			);
 
-			await axios.put(url.toString(), value, {
+			await axios.put(url.toString(), JSON.stringify(value), {
 				headers: new AxiosHeaders()
 					.setAuthorization(
 						this.buildAuthorizationHeader(url, 'PUT', connectInstallation),
@@ -194,7 +194,7 @@ class JiraClient {
 		});
 
 	/**
-	 * Sets a connect app property
+	 * Sets a connect app property.
 	 *
 	 * @see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-app-properties/#api-rest-atlassian-connect-1-addons-addonkey-properties-propertykey-put
 	 */
@@ -209,13 +209,13 @@ class JiraClient {
 				connectInstallation.baseUrl,
 			);
 
-			await axios.put(url.toString(), value, {
+			await axios.put(url.toString(), JSON.stringify(value), {
 				headers: new AxiosHeaders()
 					.setAuthorization(
 						this.buildAuthorizationHeader(url, 'PUT', connectInstallation),
 					)
 					.setAccept('application/json')
-					.setContentType('text/plain'),
+					.setContentType('application/json'),
 			});
 		});
 

--- a/src/infrastructure/jira/jira-service.test.ts
+++ b/src/infrastructure/jira/jira-service.test.ts
@@ -358,19 +358,15 @@ describe('JiraService', () => {
 				connectInstallation,
 			);
 
-			const expectedIssuePropertyValue = JSON.stringify(
+			expect(jiraClient.setIssueProperty).toHaveBeenCalledWith(
+				issueId,
+				issuePropertyKeys.ATTACHED_DESIGN_URL_V2,
 				JSON.stringify([
 					{
 						url: design.url,
 						name: design.displayName,
 					},
 				]),
-			);
-
-			expect(jiraClient.setIssueProperty).toHaveBeenCalledWith(
-				issueId,
-				issuePropertyKeys.ATTACHED_DESIGN_URL_V2,
-				expectedIssuePropertyValue,
 				connectInstallation,
 			);
 		});
@@ -397,7 +393,9 @@ describe('JiraService', () => {
 				connectInstallation,
 			);
 
-			const expectedIssuePropertyValue = JSON.stringify(
+			expect(jiraClient.setIssueProperty).toHaveBeenCalledWith(
+				issueId,
+				issuePropertyKeys.ATTACHED_DESIGN_URL_V2,
 				JSON.stringify([
 					...attachedDesignPropertyValues,
 					{
@@ -405,12 +403,6 @@ describe('JiraService', () => {
 						name: design.displayName,
 					},
 				]),
-			);
-
-			expect(jiraClient.setIssueProperty).toHaveBeenCalledWith(
-				issueId,
-				issuePropertyKeys.ATTACHED_DESIGN_URL_V2,
-				expectedIssuePropertyValue,
 				connectInstallation,
 			);
 		});
@@ -444,15 +436,6 @@ describe('JiraService', () => {
 		])(
 			'should overwrite the existing value if the issue property value is not in the expected shape',
 			async (value) => {
-				const expectedIssuePropertyValue = JSON.stringify(
-					JSON.stringify([
-						{
-							url: design.url,
-							name: design.displayName,
-						},
-					]),
-				);
-
 				jest.spyOn(jiraClient, 'getIssueProperty').mockResolvedValue(
 					generateGetIssuePropertyResponse({
 						key: issuePropertyKeys.ATTACHED_DESIGN_URL_V2,
@@ -470,22 +453,18 @@ describe('JiraService', () => {
 				expect(jiraClient.setIssueProperty).toBeCalledWith(
 					issueId,
 					issuePropertyKeys.ATTACHED_DESIGN_URL_V2,
-					expectedIssuePropertyValue,
+					JSON.stringify([
+						{
+							url: design.url,
+							name: design.displayName,
+						},
+					]),
 					connectInstallation,
 				);
 			},
 		);
 
 		it('should overwrite with the new value if the issue property value received from jira is not a string', async () => {
-			const expectedIssuePropertyValue = JSON.stringify(
-				JSON.stringify([
-					{
-						url: design.url,
-						name: design.displayName,
-					},
-				]),
-			);
-
 			jest
 				.spyOn(jiraClient, 'getIssueProperty')
 				.mockResolvedValue(generateGetIssuePropertyResponse({ value: 1 }));
@@ -500,7 +479,12 @@ describe('JiraService', () => {
 			expect(jiraClient.setIssueProperty).toBeCalledWith(
 				issueId,
 				issuePropertyKeys.ATTACHED_DESIGN_URL_V2,
-				expectedIssuePropertyValue,
+				JSON.stringify([
+					{
+						url: design.url,
+						name: design.displayName,
+					},
+				]),
 				connectInstallation,
 			);
 		});
@@ -551,12 +535,10 @@ describe('JiraService', () => {
 				connectInstallation,
 			);
 
-			const expectedIssuePropertyValue = [design.url];
-
 			expect(jiraClient.setIssueProperty).toHaveBeenCalledWith(
 				issueId,
 				issuePropertyKeys.INGESTED_DESIGN_URLS,
-				expectedIssuePropertyValue,
+				[design.url],
 				connectInstallation,
 			);
 		});
@@ -578,15 +560,10 @@ describe('JiraService', () => {
 				connectInstallation,
 			);
 
-			const expectedIssuePropertyValue = [
-				...ingestedDesignPropertyValues,
-				design.url,
-			];
-
 			expect(jiraClient.setIssueProperty).toHaveBeenCalledWith(
 				issueId,
 				issuePropertyKeys.INGESTED_DESIGN_URLS,
-				expectedIssuePropertyValue,
+				[...ingestedDesignPropertyValues, design.url],
 				connectInstallation,
 			);
 		});
@@ -612,8 +589,6 @@ describe('JiraService', () => {
 		it.each([1, [1], null, { url: 'url' }])(
 			'should overwrite the existing value if the issue property value is not in the expected shape',
 			async (value) => {
-				const expectedIssuePropertyValue = [design.url];
-
 				jest.spyOn(jiraClient, 'getIssueProperty').mockResolvedValue(
 					generateGetIssuePropertyResponse({
 						key: issuePropertyKeys.INGESTED_DESIGN_URLS,
@@ -631,15 +606,13 @@ describe('JiraService', () => {
 				expect(jiraClient.setIssueProperty).toBeCalledWith(
 					issueId,
 					issuePropertyKeys.INGESTED_DESIGN_URLS,
-					expectedIssuePropertyValue,
+					[design.url],
 					connectInstallation,
 				);
 			},
 		);
 
 		it('should overwrite with the new value if the issue property value received from jira is not a string', async () => {
-			const expectedIssuePropertyValue = [design.url];
-
 			jest
 				.spyOn(jiraClient, 'getIssueProperty')
 				.mockResolvedValue(generateGetIssuePropertyResponse({ value: 1 }));
@@ -654,7 +627,7 @@ describe('JiraService', () => {
 			expect(jiraClient.setIssueProperty).toBeCalledWith(
 				issueId,
 				issuePropertyKeys.INGESTED_DESIGN_URLS,
-				expectedIssuePropertyValue,
+				[design.url],
 				connectInstallation,
 			);
 		});
@@ -816,14 +789,10 @@ describe('JiraService', () => {
 				connectInstallation,
 			);
 
-			const expectedIssuePropertyValue = JSON.stringify(
-				JSON.stringify([designPropertyValue]),
-			);
-
 			expect(jiraClient.setIssueProperty).toHaveBeenCalledWith(
 				issueId,
 				issuePropertyKeys.ATTACHED_DESIGN_URL_V2,
-				expectedIssuePropertyValue,
+				JSON.stringify([designPropertyValue]),
 				connectInstallation,
 			);
 		});

--- a/src/infrastructure/jira/jira-service.test.ts
+++ b/src/infrastructure/jira/jira-service.test.ts
@@ -922,7 +922,7 @@ describe('JiraService', () => {
 
 			expect(jiraClient.setAppProperty).toHaveBeenCalledWith(
 				'is-configured',
-				configurationState.valueOf(),
+				{ isConfigured: configurationState.valueOf() },
 				connectInstallation,
 			);
 		});

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -186,7 +186,8 @@ class JiraService {
 		return jiraClient.setIssueProperty(
 			issueIdOrKey,
 			issuePropertyKeys.ATTACHED_DESIGN_URL_V2,
-			this.superStringify(newValue),
+			// Stringify the value twice for backwards compatibility (once here and once by `JiraClient.setIssueProperty`)
+			JSON.stringify(newValue),
 			connectInstallation,
 		);
 	};
@@ -318,7 +319,8 @@ class JiraService {
 			await jiraClient.setIssueProperty(
 				issueIdOrKey,
 				issuePropertyKeys.ATTACHED_DESIGN_URL_V2,
-				this.superStringify(newAttachedDesignUrlIssuePropertyValue),
+				// Stringify the value twice for backwards compatibility (once here and once by `JiraClient.setIssueProperty`)
+				JSON.stringify(newAttachedDesignUrlIssuePropertyValue),
 				connectInstallation,
 			);
 		} else {
@@ -378,16 +380,6 @@ class JiraService {
 
 		return response.globalPermissions.includes(JIRA_ADMIN_GLOBAL_PERMISSION);
 	};
-
-	/**
-	 * This isn't ideal but must be done as it's how the current implementation works
-	 * Need to keep this way so current implementation doesn't break
-	 */
-	private superStringify(
-		issuePropertyValue: AttachedDesignUrlV2IssuePropertyValue[],
-	) {
-		return JSON.stringify(JSON.stringify(issuePropertyValue));
-	}
 
 	private throwIfSubmitDesignResponseHasErrors = (
 		response: SubmitDesignsResponse,

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -43,16 +43,16 @@ export const appPropertyKeys = {
 	CONFIGURATION_STATE: 'is-configured',
 };
 
+export enum ConfigurationState {
+	CONFIGURED = 'CONFIGURED',
+	NOT_CONFIGURED = 'NOT_CONFIGURED',
+}
+
 export const issuePropertyKeys = {
 	ATTACHED_DESIGN_URL: 'attached-design-url',
 	ATTACHED_DESIGN_URL_V2: 'attached-design-url-v2',
 	INGESTED_DESIGN_URLS: 'figma-for-jira:ingested-design-urls',
 };
-
-export enum ConfigurationState {
-	CONFIGURED = 'CONFIGURED',
-	UNCONFIGURED = 'UNCONFIGURED',
-}
 
 export const JIRA_ADMIN_GLOBAL_PERMISSION = 'ADMINISTER';
 
@@ -336,7 +336,7 @@ class JiraService {
 	): Promise<void> => {
 		return await jiraClient.setAppProperty(
 			appPropertyKeys.CONFIGURATION_STATE,
-			configurationState.valueOf(),
+			{ isConfigured: configurationState.valueOf() },
 			connectInstallation,
 		);
 	};

--- a/src/usecases/disconnect-figma-team-use-case.test.ts
+++ b/src/usecases/disconnect-figma-team-use-case.test.ts
@@ -43,7 +43,7 @@ describe('disconnectFigmaTeamUseCase', () => {
 			connectInstallation.id,
 		);
 		expect(jiraService.setConfigurationStateInAppProperties).toBeCalledWith(
-			ConfigurationState.UNCONFIGURED,
+			ConfigurationState.NOT_CONFIGURED,
 			connectInstallation,
 		);
 	});

--- a/src/usecases/disconnect-figma-team-use-case.ts
+++ b/src/usecases/disconnect-figma-team-use-case.ts
@@ -25,7 +25,7 @@ export const disconnectFigmaTeamUseCase = {
 
 		if (configuredTeams.length === 0) {
 			await jiraService.setConfigurationStateInAppProperties(
-				ConfigurationState.UNCONFIGURED,
+				ConfigurationState.NOT_CONFIGURED,
 				connectInstallation,
 			);
 		}

--- a/src/web/routes/admin/teams/integration.test.ts
+++ b/src/web/routes/admin/teams/integration.test.ts
@@ -235,7 +235,7 @@ describe('/admin/teams', () => {
 				baseUrl: connectInstallation.baseUrl,
 				appKey: connectInstallation.key,
 				propertyKey: 'is-configured',
-				request: JSON.stringify(`CONFIGURED`),
+				request: { isConfigured: `CONFIGURED` },
 			});
 
 			await request(app)
@@ -373,7 +373,7 @@ describe('/admin/teams', () => {
 				baseUrl: connectInstallation.baseUrl,
 				appKey: connectInstallation.key,
 				propertyKey: 'is-configured',
-				request: JSON.stringify(`UNCONFIGURED`),
+				request: { isConfigured: `NOT_CONFIGURED` },
 			});
 
 			await request(app)
@@ -424,7 +424,7 @@ describe('/admin/teams', () => {
 				baseUrl: connectInstallation.baseUrl,
 				appKey: connectInstallation.key,
 				propertyKey: 'is-configured',
-				request: JSON.stringify(`UNCONFIGURED`),
+				request: { isConfigured: `NOT_CONFIGURED` },
 			});
 
 			await request(app)

--- a/src/web/routes/admin/teams/integration.test.ts
+++ b/src/web/routes/admin/teams/integration.test.ts
@@ -235,7 +235,7 @@ describe('/admin/teams', () => {
 				baseUrl: connectInstallation.baseUrl,
 				appKey: connectInstallation.key,
 				propertyKey: 'is-configured',
-				request: `CONFIGURED`,
+				request: JSON.stringify(`CONFIGURED`),
 			});
 
 			await request(app)
@@ -373,7 +373,7 @@ describe('/admin/teams', () => {
 				baseUrl: connectInstallation.baseUrl,
 				appKey: connectInstallation.key,
 				propertyKey: 'is-configured',
-				request: `UNCONFIGURED`,
+				request: JSON.stringify(`UNCONFIGURED`),
 			});
 
 			await request(app)
@@ -424,7 +424,7 @@ describe('/admin/teams', () => {
 				baseUrl: connectInstallation.baseUrl,
 				appKey: connectInstallation.key,
 				propertyKey: 'is-configured',
-				request: `UNCONFIGURED`,
+				request: JSON.stringify(`UNCONFIGURED`),
 			});
 
 			await request(app)


### PR DESCRIPTION
## Changes

- **fix:** Update `JiraClient.setAppProperty` to 
  - accept `application/json` from the [Set app property](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-app-properties/#api-rest-atlassian-connect-1-addons-addonkey-properties-propertykey-put) endpoint.
  - explicitly serialize "[Set app property](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-app-properties/#api-rest-atlassian-connect-1-addons-addonkey-properties-propertykey-put)" request to JSON as it expects "a valid, non-empty JSON blob".
- **refactor:** Reduce technical debt by updating `JiraClient.setIssueProperty` by analogue with `JiraClient.setAppProperty`. Replaces `superStringify` (confirmed earlier with @atlasctz) with explicit JSON encoding in `JiraClient`.