### PR TITLE
NONE: Set `is-configured` app property key according to the current contract

### DIFF
--- a/src/infrastructure/jira/jira-service.test.ts
+++ b/src/infrastructure/jira/jira-service.test.ts
@@ -16,7 +16,7 @@ import type {
 	IngestedDesignUrlIssuePropertyValue,
 } from './jira-service';
 import {
-	ConfigurationState,
+	ConfigurationStatus,
 	issuePropertyKeys,
 	jiraService,
 } from './jira-service';
@@ -909,20 +909,20 @@ describe('JiraService', () => {
 		});
 	});
 
-	describe('setConfigurationStateInAppProperties', () => {
-		it('should set configuration state in app properties', async () => {
-			const configurationState = ConfigurationState.CONFIGURED;
+	describe('setAppConfigurationStatus', () => {
+		it('should set configuration status in app properties', async () => {
+			const configurationState = ConfigurationStatus.CONFIGURED;
 			const connectInstallation = generateConnectInstallation();
 			jest.spyOn(jiraClient, 'setAppProperty').mockResolvedValue(undefined);
 
-			await jiraService.setConfigurationStateInAppProperties(
+			await jiraService.setAppConfigurationStatus(
 				configurationState,
 				connectInstallation,
 			);
 
 			expect(jiraClient.setAppProperty).toHaveBeenCalledWith(
 				'is-configured',
-				{ isConfigured: configurationState.valueOf() },
+				{ status: configurationState },
 				connectInstallation,
 			);
 		});

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -43,7 +43,7 @@ export const appPropertyKeys = {
 	CONFIGURATION_STATE: 'is-configured',
 };
 
-export enum ConfigurationState {
+export enum ConfigurationStatus {
 	CONFIGURED = 'CONFIGURED',
 	NOT_CONFIGURED = 'NOT_CONFIGURED',
 }
@@ -330,13 +330,13 @@ class JiraService {
 		}
 	};
 
-	setConfigurationStateInAppProperties = async (
-		configurationState: ConfigurationState,
+	setAppConfigurationStatus = async (
+		configurationStatus: ConfigurationStatus,
 		connectInstallation: ConnectInstallation,
 	): Promise<void> => {
 		return await jiraClient.setAppProperty(
 			appPropertyKeys.CONFIGURATION_STATE,
-			{ isConfigured: configurationState.valueOf() },
+			{ status: configurationStatus },
 			connectInstallation,
 		);
 	};

--- a/src/usecases/connect-figma-team-use-case.test.ts
+++ b/src/usecases/connect-figma-team-use-case.test.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { type FigmaTeam, FigmaTeamAuthStatus } from '../domain/entities';
 import { generateConnectInstallation } from '../domain/entities/testing';
 import { figmaService } from '../infrastructure/figma';
-import { ConfigurationState, jiraService } from '../infrastructure/jira';
+import { ConfigurationStatus, jiraService } from '../infrastructure/jira';
 import { figmaTeamRepository } from '../infrastructure/repositories';
 
 import { connectFigmaTeamUseCase } from '.';
@@ -24,7 +24,7 @@ describe('connectFigmaTeamUseCase', () => {
 			.spyOn(figmaTeamRepository, 'upsert')
 			.mockResolvedValue({} as FigmaTeam);
 		jest
-			.spyOn(jiraService, 'setConfigurationStateInAppProperties')
+			.spyOn(jiraService, 'setAppConfigurationStatus')
 			.mockResolvedValue(undefined);
 
 		await connectFigmaTeamUseCase.execute(
@@ -54,8 +54,8 @@ describe('connectFigmaTeamUseCase', () => {
 			connectInstallationId: connectInstallation.id,
 		});
 
-		expect(jiraService.setConfigurationStateInAppProperties).toBeCalledWith(
-			ConfigurationState.CONFIGURED,
+		expect(jiraService.setAppConfigurationStatus).toBeCalledWith(
+			ConfigurationStatus.CONFIGURED,
 			connectInstallation,
 		);
 	});

--- a/src/usecases/connect-figma-team-use-case.ts
+++ b/src/usecases/connect-figma-team-use-case.ts
@@ -1,9 +1,9 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { FigmaTeamAuthStatus } from '../domain/entities';
 import type { ConnectInstallation, FigmaTeamSummary } from '../domain/entities';
+import { FigmaTeamAuthStatus } from '../domain/entities';
 import { figmaService } from '../infrastructure/figma';
-import { ConfigurationState, jiraService } from '../infrastructure/jira';
+import { ConfigurationStatus, jiraService } from '../infrastructure/jira';
 import { figmaTeamRepository } from '../infrastructure/repositories';
 
 export const connectFigmaTeamUseCase = {
@@ -35,8 +35,8 @@ export const connectFigmaTeamUseCase = {
 			connectInstallationId: connectInstallation.id,
 		});
 
-		await jiraService.setConfigurationStateInAppProperties(
-			ConfigurationState.CONFIGURED,
+		await jiraService.setAppConfigurationStatus(
+			ConfigurationStatus.CONFIGURED,
 			connectInstallation,
 		);
 

--- a/src/usecases/disconnect-figma-team-use-case.test.ts
+++ b/src/usecases/disconnect-figma-team-use-case.test.ts
@@ -5,7 +5,7 @@ import {
 	generateFigmaTeam,
 } from '../domain/entities/testing';
 import { figmaService } from '../infrastructure/figma';
-import { ConfigurationState, jiraService } from '../infrastructure/jira';
+import { ConfigurationStatus, jiraService } from '../infrastructure/jira';
 import { figmaTeamRepository } from '../infrastructure/repositories';
 
 describe('disconnectFigmaTeamUseCase', () => {
@@ -23,7 +23,7 @@ describe('disconnectFigmaTeamUseCase', () => {
 			.spyOn(figmaTeamRepository, 'findManyByConnectInstallationId')
 			.mockResolvedValue([]);
 		jest
-			.spyOn(jiraService, 'setConfigurationStateInAppProperties')
+			.spyOn(jiraService, 'setAppConfigurationStatus')
 			.mockResolvedValue(undefined);
 
 		await disconnectFigmaTeamUseCase.execute(
@@ -42,8 +42,8 @@ describe('disconnectFigmaTeamUseCase', () => {
 		expect(figmaTeamRepository.findManyByConnectInstallationId).toBeCalledWith(
 			connectInstallation.id,
 		);
-		expect(jiraService.setConfigurationStateInAppProperties).toBeCalledWith(
-			ConfigurationState.NOT_CONFIGURED,
+		expect(jiraService.setAppConfigurationStatus).toBeCalledWith(
+			ConfigurationStatus.NOT_CONFIGURED,
 			connectInstallation,
 		);
 	});
@@ -82,8 +82,6 @@ describe('disconnectFigmaTeamUseCase', () => {
 		expect(figmaTeamRepository.findManyByConnectInstallationId).toBeCalledWith(
 			connectInstallation.id,
 		);
-		expect(
-			jiraService.setConfigurationStateInAppProperties,
-		).not.toHaveBeenCalled();
+		expect(jiraService.setAppConfigurationStatus).not.toHaveBeenCalled();
 	});
 });

--- a/src/usecases/disconnect-figma-team-use-case.ts
+++ b/src/usecases/disconnect-figma-team-use-case.ts
@@ -1,6 +1,6 @@
 import type { ConnectInstallation } from '../domain/entities';
 import { figmaService } from '../infrastructure/figma';
-import { ConfigurationState, jiraService } from '../infrastructure/jira';
+import { ConfigurationStatus, jiraService } from '../infrastructure/jira';
 import { figmaTeamRepository } from '../infrastructure/repositories';
 
 export const disconnectFigmaTeamUseCase = {
@@ -24,8 +24,8 @@ export const disconnectFigmaTeamUseCase = {
 			);
 
 		if (configuredTeams.length === 0) {
-			await jiraService.setConfigurationStateInAppProperties(
-				ConfigurationState.NOT_CONFIGURED,
+			await jiraService.setAppConfigurationStatus(
+				ConfigurationStatus.NOT_CONFIGURED,
 				connectInstallation,
 			);
 		}

--- a/src/web/routes/admin/teams/integration.test.ts
+++ b/src/web/routes/admin/teams/integration.test.ts
@@ -235,7 +235,7 @@ describe('/admin/teams', () => {
 				baseUrl: connectInstallation.baseUrl,
 				appKey: connectInstallation.key,
 				propertyKey: 'is-configured',
-				request: { isConfigured: `CONFIGURED` },
+				request: { status: `CONFIGURED` },
 			});
 
 			await request(app)
@@ -381,7 +381,7 @@ describe('/admin/teams', () => {
 				baseUrl: connectInstallation.baseUrl,
 				appKey: connectInstallation.key,
 				propertyKey: 'is-configured',
-				request: { isConfigured: `NOT_CONFIGURED` },
+				request: { status: `NOT_CONFIGURED` },
 			});
 
 			await request(app)
@@ -440,7 +440,7 @@ describe('/admin/teams', () => {
 				baseUrl: connectInstallation.baseUrl,
 				appKey: connectInstallation.key,
 				propertyKey: 'is-configured',
-				request: { isConfigured: `NOT_CONFIGURED` },
+				request: { status: `NOT_CONFIGURED` },
 			});
 
 			await request(app)


### PR DESCRIPTION
## Changes

- **feat:** Sets `is-configured` app property key according to the current contract.