### PR TITLE
fix: Fix TS errors for Figma team summary

### DIFF
--- a/src/domain/entities/figma-team.ts
+++ b/src/domain/entities/figma-team.ts
@@ -58,5 +58,5 @@ export type FigmaTeamCreateParams = {
 
 export type FigmaTeamSummary = Pick<
 	FigmaTeam,
-	'teamId' | 'teamName' | 'authStatus'
+	'teamId' | 'teamName' | 'authStatus' | 'webhookId' | 'webhookPasscode'
 >;

--- a/src/domain/entities/testing/mocks.ts
+++ b/src/domain/entities/testing/mocks.ts
@@ -259,8 +259,12 @@ export const generateFigmaTeamSummary = ({
 	teamId = uuidv4(),
 	teamName = uuidv4(),
 	authStatus: status = FigmaTeamAuthStatus.OK,
+	webhookId = uuidv4(),
+	webhookPasscode = uuidv4(),
 }: Partial<FigmaTeamSummary> = {}): FigmaTeamSummary => ({
 	teamId,
 	teamName,
 	authStatus: status,
+	webhookId,
+	webhookPasscode,
 });

--- a/src/infrastructure/repositories/figma-team-repository.integration.test.ts
+++ b/src/infrastructure/repositories/figma-team-repository.integration.test.ts
@@ -28,7 +28,7 @@ describe('FigmaTeamRepository', () => {
 
 			const result = await figmaTeamRepository.findByWebhookId(webhookId);
 
-			expect(result).toEqual(figmaTeam);
+			expect(result).toMatchObject(figmaTeam);
 		});
 
 		it('should return null when there is no team with given webhook ID', async () => {

--- a/src/infrastructure/repositories/figma-team-repository.ts
+++ b/src/infrastructure/repositories/figma-team-repository.ts
@@ -14,7 +14,7 @@ import { FigmaTeam, FigmaTeamAuthStatus } from '../../domain/entities';
 type PrismaFigmaTeamCreateParams = Omit<PrismaFigmaTeam, 'id'>;
 type PrismaFigmaTeamSummary = Pick<
 	PrismaFigmaTeam,
-	'teamId' | 'teamName' | 'authStatus'
+	'teamId' | 'teamName' | 'authStatus' | 'webhookId' | 'webhookPasscode'
 >;
 
 export class FigmaTeamRepository {
@@ -88,7 +88,13 @@ export class FigmaTeamRepository {
 	): Promise<FigmaTeamSummary[]> => {
 		const dbModel = await prismaClient.get().figmaTeam.findMany({
 			where: { connectInstallationId: BigInt(connectInstallationId) },
-			select: { teamId: true, teamName: true, authStatus: true },
+			select: {
+				teamId: true,
+				teamName: true,
+				authStatus: true,
+				webhookId: true,
+				webhookPasscode: true,
+			},
 		});
 
 		return dbModel.map((record) => this.mapToFigmaTeamSummary(record));
@@ -189,10 +195,14 @@ export class FigmaTeamRepository {
 		teamId,
 		teamName,
 		authStatus,
+		webhookId,
+		webhookPasscode,
 	}: PrismaFigmaTeamSummary): FigmaTeamSummary => ({
 		teamId,
 		teamName,
 		authStatus: FigmaTeamAuthStatus[authStatus],
+		webhookId,
+		webhookPasscode,
 	});
 }
 


### PR DESCRIPTION
I have a PR with some script changes - [see PR](https://github.com/atlassian-labs/figma-for-jira/pull/127).

The build is failing. [See build](https://github.com/atlassian-labs/figma-for-jira/actions/runs/6672171680/job/18135594305).

The error is
```
Error: src/web/routes/figma/integration.test.ts(418,28): error TS2339: Property 'webhookId' does not exist on type 'FigmaTeamSummary'.
Error: src/web/routes/figma/integration.test.ts(419,26): error TS2339: Property 'webhookPasscode' does not exist on type 'FigmaTeamSummary'.
Error: src/web/routes/figma/integration.test.ts(438,28): error TS2339: Property 'webhookId' does not exist on type 'FigmaTeamSummary'.
Error: Process completed with exit code 2.
```

This PR fixes the TS error.
