### PR TITLE
[db] Rename DB tables to have the jira_ prefix

### DIFF
--- a/prisma/migrations/20230927081534_initial/migration.sql
+++ b/prisma/migrations/20230927081534_initial/migration.sql
@@ -1,8 +1,8 @@
 -- CreateEnum
-CREATE TYPE "figma_team_auth_status" AS ENUM ('OK', 'ERROR');
+CREATE TYPE "jira_figma_team_auth_status" AS ENUM ('OK', 'ERROR');
 
 -- CreateTable
-CREATE TABLE "connect_installation" (
+CREATE TABLE "jira_connect_installation" (
     "id" BIGSERIAL NOT NULL,
     "key" TEXT NOT NULL,
     "client_key" TEXT NOT NULL,
@@ -14,7 +14,7 @@ CREATE TABLE "connect_installation" (
 );
 
 -- CreateTable
-CREATE TABLE "associated_figma_design" (
+CREATE TABLE "jira_associated_figma_design" (
     "id" BIGSERIAL NOT NULL,
     "file_key" TEXT NOT NULL,
     "node_id" TEXT NOT NULL,
@@ -25,7 +25,7 @@ CREATE TABLE "associated_figma_design" (
 );
 
 -- CreateTable
-CREATE TABLE "figma_oauth2_user_credentials" (
+CREATE TABLE "jira_figma_oauth2_user_credentials" (
     "id" BIGSERIAL NOT NULL,
     "atlassian_user_id" TEXT NOT NULL,
     "access_token" TEXT NOT NULL,
@@ -37,39 +37,39 @@ CREATE TABLE "figma_oauth2_user_credentials" (
 );
 
 -- CreateTable
-CREATE TABLE "figma_team" (
+CREATE TABLE "jira_figma_team" (
     "id" BIGSERIAL NOT NULL,
     "webhook_id" TEXT NOT NULL,
     "webhook_passcode" TEXT NOT NULL,
     "team_id" TEXT NOT NULL,
     "team_name" TEXT NOT NULL,
     "figma_admin_atlassian_user_id" TEXT NOT NULL,
-    "authStatus" "figma_team_auth_status" NOT NULL,
+    "authStatus" "jira_figma_team_auth_status" NOT NULL,
     "connect_installation_id" BIGINT NOT NULL,
 
     CONSTRAINT "figma_team_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "connect_installation_client_key_key" ON "connect_installation"("client_key");
+CREATE UNIQUE INDEX "connect_installation_client_key_key" ON "jira_connect_installation"("client_key");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "associated_figma_design_file_key_node_id_associated-with-ar_key" ON "associated_figma_design"("file_key", "node_id", "associated-with-ari", "connect_installation_id");
+CREATE UNIQUE INDEX "associated_figma_design_file_key_node_id_associated-with-ar_key" ON "jira_associated_figma_design"("file_key", "node_id", "associated-with-ari", "connect_installation_id");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "figma_oauth2_user_credentials_atlassian_user_id_connect_ins_key" ON "figma_oauth2_user_credentials"("atlassian_user_id", "connect_installation_id");
+CREATE UNIQUE INDEX "figma_oauth2_user_credentials_atlassian_user_id_connect_ins_key" ON "jira_figma_oauth2_user_credentials"("atlassian_user_id", "connect_installation_id");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "figma_team_webhook_id_key" ON "figma_team"("webhook_id");
+CREATE UNIQUE INDEX "figma_team_webhook_id_key" ON "jira_figma_team"("webhook_id");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "figma_team_team_id_connect_installation_id_key" ON "figma_team"("team_id", "connect_installation_id");
+CREATE UNIQUE INDEX "figma_team_team_id_connect_installation_id_key" ON "jira_figma_team"("team_id", "connect_installation_id");
 
 -- AddForeignKey
-ALTER TABLE "associated_figma_design" ADD CONSTRAINT "associated_figma_design_connect_installation_id_fkey" FOREIGN KEY ("connect_installation_id") REFERENCES "connect_installation"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+ALTER TABLE "jira_associated_figma_design" ADD CONSTRAINT "associated_figma_design_connect_installation_id_fkey" FOREIGN KEY ("connect_installation_id") REFERENCES "jira_connect_installation"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
 
 -- AddForeignKey
-ALTER TABLE "figma_oauth2_user_credentials" ADD CONSTRAINT "figma_oauth2_user_credentials_connect_installation_id_fkey" FOREIGN KEY ("connect_installation_id") REFERENCES "connect_installation"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+ALTER TABLE "jira_figma_oauth2_user_credentials" ADD CONSTRAINT "figma_oauth2_user_credentials_connect_installation_id_fkey" FOREIGN KEY ("connect_installation_id") REFERENCES "jira_connect_installation"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
 
 -- AddForeignKey
-ALTER TABLE "figma_team" ADD CONSTRAINT "figma_team_connect_installation_id_fkey" FOREIGN KEY ("connect_installation_id") REFERENCES "connect_installation"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+ALTER TABLE "jira_figma_team" ADD CONSTRAINT "figma_team_connect_installation_id_fkey" FOREIGN KEY ("connect_installation_id") REFERENCES "jira_connect_installation"("id") ON DELETE CASCADE ON UPDATE NO ACTION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,7 +18,7 @@ model ConnectInstallation {
   FigmaTeam                  FigmaTeam[]
   AssociatedFigmaDesign      AssociatedFigmaDesign[]
 
-  @@map("connect_installation")
+  @@map("jira_connect_installation")
 }
 
 model AssociatedFigmaDesign {
@@ -31,7 +31,7 @@ model AssociatedFigmaDesign {
   connectInstallationId BigInt              @map("connect_installation_id")
 
   @@unique([fileKey, nodeId, associatedWithAri, connectInstallationId])
-  @@map("associated_figma_design")
+  @@map("jira_associated_figma_design")
 }
 
 model FigmaOAuth2UserCredentials {
@@ -45,14 +45,14 @@ model FigmaOAuth2UserCredentials {
   connectInstallationId BigInt              @map("connect_installation_id")
 
   @@unique([atlassianUserId, connectInstallationId])
-  @@map("figma_oauth2_user_credentials")
+  @@map("jira_figma_oauth2_user_credentials")
 }
 
 enum FigmaTeamAuthStatus {
   OK
   ERROR
 
-  @@map("figma_team_auth_status")
+  @@map("jira_figma_team_auth_status")
 }
 
 model FigmaTeam {
@@ -68,5 +68,5 @@ model FigmaTeam {
   connectInstallationId     BigInt              @map("connect_installation_id")
 
   @@unique([teamId, connectInstallationId])
-  @@map("figma_team")
+  @@map("jira_figma_team")
 }


### PR DESCRIPTION
We are setting up the DB for the figma-for-jira app in staging and prod. In the future, we may want to use the same DB for other integrations. This PR renames the DB tables to have the `jira_` prefix so we can have unique DB table names.

⚠️ After this change merges, you will need to drop and regenerate your local DB:
```
npm run db:reset:dev
npm run db:generate
```

## Testing
- I checked my local DB to confirm the tables show up as expected
```
docker exec -it figma-for-jira-db bash
psql figma_for_jira -U figma_for_jira_app
```
![image](https://github.com/atlassian-labs/figma-for-jira/assets/116598948/f0a94df1-4daf-4900-b46a-0ee666004383)
- Unit / integration tests should pass.
- I tested installing the app locally, and it worked as expected.