### PR TITLE
MDTZ-1150: Updated Figma URL parsing to handle prototype links

### DIFF
--- a/src/domain/entities/figma-design-identifier.test.ts
+++ b/src/domain/entities/figma-design-identifier.test.ts
@@ -82,10 +82,32 @@ describe('FigmaDesignIdentifier', () => {
 			expect(result).toStrictEqual(new FigmaDesignIdentifier(fileKey, nodeId));
 		});
 
+		it('should return an identifier when URL is a prototype link', () => {
+			const fileKey = generateFigmaFileKey();
+			const nodeId = '42:1';
+			const designUrl = `https://www.figma.com/proto/${fileKey}?node-id=42%3A1`;
+
+			const result = FigmaDesignIdentifier.fromFigmaDesignUrl(designUrl);
+
+			expect(result).toStrictEqual(new FigmaDesignIdentifier(fileKey, nodeId));
+		});
+
+		it('should return an identifier when URL is a prototype link with additional query parameters', () => {
+			const fileKey = generateFigmaFileKey();
+			const nodeId = '42:1';
+			const designUrl = `https://www.figma.com/proto/${fileKey}?type=design&node-id=42%3A1&scaling=min-zoom&page-id=935%3A206682&starting-point-node-id=1197%3A290236`;
+
+			const result = FigmaDesignIdentifier.fromFigmaDesignUrl(designUrl);
+
+			expect(result).toStrictEqual(new FigmaDesignIdentifier(fileKey, nodeId));
+		});
+
 		it.each([
 			`https://www.figma.com`,
 			`https://www.figma.com/file`,
+			`https://www.figma.com/proto`,
 			`https://www.figma.com?param=file%2Fsome-id`,
+			`https://www.figma.com?param=proto%2Fsome-id`,
 			'',
 		])('should throw when URL has an unexpected format', (input: string) => {
 			expect(() => FigmaDesignIdentifier.fromFigmaDesignUrl(input)).toThrow();

--- a/src/domain/entities/figma-design-identifier.ts
+++ b/src/domain/entities/figma-design-identifier.ts
@@ -37,7 +37,9 @@ export class FigmaDesignIdentifier {
 		const parsedUrl = new URL(url);
 
 		const pathComponents = parsedUrl.pathname.split('/');
-		const filePathComponentId = pathComponents.findIndex((x) => x === 'file');
+		const filePathComponentId = pathComponents.findIndex(
+			(x) => x === 'file' || x === 'proto',
+		);
 
 		const fileKey = pathComponents[filePathComponentId + 1];
 		const nodeId = parsedUrl.searchParams.get('node-id')?.replace('-', ':');


### PR DESCRIPTION
Updated parsing logic of Figma URLs to account for prototype links and allow the file key to be extracted. 

Tested change with the local app in staging: https://www.loom.com/share/fd9e07c8f87144da86cb5bf418e7d602