### PR TITLE
NONE: pin hashes for images and actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -4,10 +4,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@bea5baf987ba7aa777a8a0b4ace377a21c45c381 # v3
         with:
           node-version: '18'
           cache: 'npm'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bookworm-slim as build
+FROM node:18-bookworm-slim@sha256:b50c0b5628a4a10093a2b4b8b7a7060c10e5983abb8ea89a7892fc6ddb0730e3 as build
 
 # Compile TS
 WORKDIR /app
@@ -10,7 +10,7 @@ RUN npm run db:generate
 COPY src ./src
 RUN npm run build
 
-FROM node:18-bookworm-slim as app
+FROM node:18-bookworm-slim@sha256:b50c0b5628a4a10093a2b4b8b7a7060c10e5983abb8ea89a7892fc6ddb0730e3 as app
 
 RUN apt-get update -y && apt-get install -y openssl
 


### PR DESCRIPTION
Images referenced from a Dockerfile FROM should always be pinned to an exact SHA-256 hash. This gives us confidence that builds are repeatable and changes to base images are always obvious in CI. This is essentially Docker's equivalent of a "lockfile". Same applies to gh actions

### Test plan
- assert that docker build still works as expected
- assert that the gh action runs as expected