### PR TITLE
[fix] Remove undefined variable errorType

### DIFF
--- a/static/auth-result/index.html
+++ b/static/auth-result/index.html
@@ -30,7 +30,6 @@
               {
                 type: 'auth:failure',
                 message: errorMessage || 'Unable to connect the account.',
-                errorType,
               },
               '*',
             );


### PR DESCRIPTION
The variable `errorType` is not defined. This PR removes it.
```
auth-result/?success=false:33 Uncaught ReferenceError: errorType is not defined
    at auth-result/?success=false:33:17
```

This is resulting in an error on the /static/auth-result/?success=false after completing oauth.