### PR TITLE
NONE: Improve reliability and consistency

### DIFF
--- a/src/infrastructure/figma/figma-client/figma-client.ts
+++ b/src/infrastructure/figma/figma-client/figma-client.ts
@@ -200,7 +200,7 @@ export class FigmaClient {
 	 */
 	getDevResources = async ({
 		fileKey,
-		nodeIds: node_ids,
+		nodeIds,
 		accessToken,
 	}: GetDevResourcesRequest): Promise<GetDevResourcesResponse> =>
 		withAxiosErrorTranslation(async () => {
@@ -208,7 +208,7 @@ export class FigmaClient {
 				`${getConfig().figma.apiBaseUrl}/v1/files/${fileKey}/dev_resources`,
 				{
 					params: {
-						node_ids,
+						node_ids: nodeIds?.join(','),
 					},
 					headers: {
 						['Authorization']: `Bearer ${accessToken}`,

--- a/src/infrastructure/figma/figma-client/types.ts
+++ b/src/infrastructure/figma/figma-client/types.ts
@@ -71,7 +71,7 @@ export type CreateDevResourcesResponse = {
 
 export type GetDevResourcesRequest = {
 	readonly fileKey: string;
-	readonly nodeIds?: string;
+	readonly nodeIds?: string[];
 	readonly accessToken: string;
 };
 

--- a/src/infrastructure/figma/figma-service.test.ts
+++ b/src/infrastructure/figma/figma-service.test.ts
@@ -280,7 +280,7 @@ describe('FigmaService', () => {
 		});
 	});
 
-	describe('createDevResourceForJiraIssue', () => {
+	describe('tryCreateDevResourceForJiraIssue', () => {
 		const MOCK_CREDENTIALS = generateFigmaOAuth2UserCredentials();
 		beforeEach(() => {
 			jest

--- a/src/usecases/associate-entity-use-case.test.ts
+++ b/src/usecases/associate-entity-use-case.test.ts
@@ -42,7 +42,7 @@ describe('associateEntityUseCase', () => {
 			.spyOn(jiraService, 'saveDesignUrlInIssueProperties')
 			.mockResolvedValue();
 		jest
-			.spyOn(figmaService, 'createDevResourceForJiraIssue')
+			.spyOn(figmaService, 'tryCreateDevResourceForJiraIssue')
 			.mockResolvedValue();
 		jest
 			.spyOn(associatedFigmaDesignRepository, 'upsert')
@@ -70,7 +70,7 @@ describe('associateEntityUseCase', () => {
 			atlassianDesign,
 			connectInstallation,
 		);
-		expect(figmaService.createDevResourceForJiraIssue).toHaveBeenCalledWith({
+		expect(figmaService.tryCreateDevResourceForJiraIssue).toHaveBeenCalledWith({
 			designId,
 			issue: {
 				key: issue.key,
@@ -112,7 +112,7 @@ describe('associateEntityUseCase', () => {
 			.spyOn(jiraService, 'saveDesignUrlInIssueProperties')
 			.mockResolvedValue();
 		jest
-			.spyOn(figmaService, 'createDevResourceForJiraIssue')
+			.spyOn(figmaService, 'tryCreateDevResourceForJiraIssue')
 			.mockResolvedValue();
 		jest.spyOn(associatedFigmaDesignRepository, 'upsert');
 

--- a/src/usecases/associate-entity-use-case.ts
+++ b/src/usecases/associate-entity-use-case.ts
@@ -62,7 +62,7 @@ export const associateEntityUseCase = {
 					design,
 					connectInstallation,
 				),
-				figmaService.createDevResourceForJiraIssue({
+				figmaService.tryCreateDevResourceForJiraIssue({
 					designId: figmaDesignId,
 					issue: {
 						url: buildJiraIssueUrl(connectInstallation.baseUrl, issue.key),

--- a/src/usecases/disassociate-entity-use-case.test.ts
+++ b/src/usecases/disassociate-entity-use-case.test.ts
@@ -35,7 +35,7 @@ describe('disassociateEntityUseCase', () => {
 		jest
 			.spyOn(jiraService, 'deleteDesignUrlInIssueProperties')
 			.mockResolvedValue();
-		jest.spyOn(figmaService, 'deleteDevResourceIfExists').mockResolvedValue();
+		jest.spyOn(figmaService, 'deleteDevResource').mockResolvedValue();
 		jest
 			.spyOn(
 				associatedFigmaDesignRepository,
@@ -65,7 +65,7 @@ describe('disassociateEntityUseCase', () => {
 			atlassianDesign,
 			params.connectInstallation,
 		);
-		expect(figmaService.deleteDevResourceIfExists).toHaveBeenCalledWith({
+		expect(figmaService.deleteDevResource).toHaveBeenCalledWith({
 			designId: designId,
 			devResourceUrl: `${connectInstallation.baseUrl}/browse/${issue.key}`,
 			user: {
@@ -100,7 +100,7 @@ describe('disassociateEntityUseCase', () => {
 		jest
 			.spyOn(jiraService, 'deleteDesignUrlInIssueProperties')
 			.mockResolvedValue();
-		jest.spyOn(figmaService, 'deleteDevResourceIfExists').mockResolvedValue();
+		jest.spyOn(figmaService, 'deleteDevResource').mockResolvedValue();
 		jest.spyOn(
 			associatedFigmaDesignRepository,
 			'deleteByDesignIdAndAssociatedWithAriAndConnectInstallationId',

--- a/src/usecases/disassociate-entity-use-case.ts
+++ b/src/usecases/disassociate-entity-use-case.ts
@@ -74,7 +74,7 @@ export const disassociateEntityUseCase = {
 					design,
 					connectInstallation,
 				),
-				figmaService.deleteDevResourceIfExists({
+				figmaService.deleteDevResource({
 					designId: figmaDesignId,
 					devResourceUrl: buildJiraIssueUrl(
 						connectInstallation.baseUrl,


### PR DESCRIPTION
## Changes

- **feat:** Update `FigmaService.deleteDevResource` to not throw an error if a Dev Resource was concurrently deleted by another user.
- **refactor** Renames `FigmaService.createDevResourceForJiraIssue` to `FigmaService.tryCreateDevResourceForJiraIssue` to highlight that it creates a Dev Resource on a best-efforts basis.
- **refactor:** Updates `FigmaClient.getDevResources` to accept `nodeIds` as an array instead of a comma separated string. See https://www.figma.com/developers/api#get-dev-resources-endpoint (`node_ids` query parameter) for more detail.
- **tests:** Adds unit tests for `FigmaService.deleteDevResource`.