### PR TITLE
NONE: Show warning modal when disconnecting a team

### DIFF
--- a/admin/src/pages/teams/disconnect-team-unauthorized-section-message.tsx
+++ b/admin/src/pages/teams/disconnect-team-unauthorized-section-message.tsx
@@ -1,0 +1,16 @@
+import SectionMessage from '@atlaskit/section-message';
+import { css } from '@emotion/react';
+
+import { FigmaPermissionsPopup } from '../../components';
+
+export function DisconnectTeamUnauthorizedSectionMessage() {
+	return (
+		<SectionMessage css={css({ width: '100%' })} appearance="error">
+			You must be an admin of your Figma team to remove a connected team.{' '}
+			<FigmaPermissionsPopup>
+				Check your Figma permissions
+			</FigmaPermissionsPopup>{' '}
+			and try again.
+		</SectionMessage>
+	);
+}

--- a/admin/src/pages/teams/disconnect-team-warning-modal.tsx
+++ b/admin/src/pages/teams/disconnect-team-warning-modal.tsx
@@ -1,0 +1,52 @@
+import Button, { LoadingButton } from '@atlaskit/button';
+import Modal, {
+	ModalBody,
+	ModalFooter,
+	ModalHeader,
+	ModalTitle,
+} from '@atlaskit/modal-dialog';
+
+import type { FigmaTeamSummary } from '../../api';
+
+type DisconnectTeamWarningModalProps = {
+	team: FigmaTeamSummary;
+	onClose: () => void;
+	disconnectTeam: (teamId: string) => void;
+	isDisconnectingTeam: boolean;
+};
+
+export function DisconnectTeamWarningModal({
+	team,
+	onClose,
+	disconnectTeam,
+	isDisconnectingTeam,
+}: DisconnectTeamWarningModalProps) {
+	return (
+		<Modal onClose={onClose}>
+			<ModalHeader>
+				<ModalTitle appearance="warning">
+					Disconnect Figma team from Jira
+				</ModalTitle>
+			</ModalHeader>
+			<ModalBody>
+				Are you sure you want to disconnect <strong>{team.teamName}</strong>{' '}
+				from Jira? Disconnecting means that you will no longer be able to see
+				updates from this design team in Jira. You can still connect your team
+				to Jira again later.
+			</ModalBody>
+			<ModalFooter>
+				<Button appearance="subtle" onClick={onClose}>
+					Cancel
+				</Button>
+				<LoadingButton
+					appearance="warning"
+					onClick={() => disconnectTeam(team.teamId)}
+					isLoading={isDisconnectingTeam}
+					autoFocus
+				>
+					Disconnect Figma team
+				</LoadingButton>
+			</ModalFooter>
+		</Modal>
+	);
+}

--- a/admin/src/pages/teams/generic-error-section-message.tsx
+++ b/admin/src/pages/teams/generic-error-section-message.tsx
@@ -1,0 +1,16 @@
+import SectionMessage from '@atlaskit/section-message';
+import { css } from '@emotion/react';
+
+import { FigmaPermissionsPopup } from '../../components';
+
+export function GenericErrorSectionMessage() {
+	return (
+		<SectionMessage css={css({ width: '100%' })} appearance="error">
+			Something went wrong.{' '}
+			<FigmaPermissionsPopup>
+				Check your Figma permissions
+			</FigmaPermissionsPopup>{' '}
+			and try again.
+		</SectionMessage>
+	);
+}


### PR DESCRIPTION
Adds the logic for showing a warning modal when disconnecting a team.


https://github.com/atlassian-labs/figma-for-jira/assets/6136959/03570fc5-a241-46ae-8e42-f47db9281e74

### Test plan
- try to disconnect a team
- assert that the modal shows up
- assert that the cancel closes the modal and disconnect disconnects the team
- hard code an error in the disconnect request
- assert that on error, the modal closes and the appropriate error message is rendered