### PR TITLE
NONE: Show a flag after disconnecting a team

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -10,6 +10,7 @@
 	"dependencies": {
 		"@atlaskit/button": "^16.11.0",
 		"@atlaskit/css-reset": "^6.6.1",
+		"@atlaskit/flag": "^15.2.20",
 		"@atlaskit/form": "^8.11.13",
 		"@atlaskit/icon": "^21.12.7",
 		"@atlaskit/image": "^1.1.6",

--- a/admin/src/pages/teams/disconnected-team-flag.tsx
+++ b/admin/src/pages/teams/disconnected-team-flag.tsx
@@ -1,0 +1,33 @@
+import { AutoDismissFlag } from '@atlaskit/flag';
+import CheckCircleIcon from '@atlaskit/icon/glyph/check-circle';
+import { token } from '@atlaskit/tokens';
+
+type DisconnectedTeamFlagProps = {
+	teamId: string;
+	onClose: () => void;
+	onUndo: () => void;
+};
+
+export function DisconnectedTeamFlag({
+	teamId,
+	onClose,
+	onUndo,
+}: DisconnectedTeamFlagProps) {
+	return (
+		<AutoDismissFlag
+			id={teamId}
+			icon={
+				<CheckCircleIcon
+					label=""
+					primaryColor={token('color.icon.success')}
+					size="medium"
+				/>
+			}
+			title="Figma team disconnected"
+			actions={[
+				{ content: 'Got it', onClick: onClose },
+				{ content: 'Undo', onClick: onUndo },
+			]}
+		/>
+	);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
 			"dependencies": {
 				"@atlaskit/button": "^16.11.0",
 				"@atlaskit/css-reset": "^6.6.1",
+				"@atlaskit/flag": "^15.2.20",
 				"@atlaskit/form": "^8.11.13",
 				"@atlaskit/icon": "^21.12.7",
 				"@atlaskit/image": "^1.1.6",
@@ -262,6 +263,30 @@
 			"dependencies": {
 				"@babel/runtime": "^7.0.0",
 				"bind-event-listener": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0"
+			}
+		},
+		"node_modules/@atlaskit/flag": {
+			"version": "15.2.20",
+			"resolved": "https://registry.npmjs.org/@atlaskit/flag/-/flag-15.2.20.tgz",
+			"integrity": "sha512-F9DCAE8O4JaBHWs/Cg3+qjagk4XKb+SAOGWZbqCldAbhVy0rbyxkbbM3qEsoWCsQN5DeIOjaqcB3VK2liFLBxQ==",
+			"dependencies": {
+				"@atlaskit/analytics-next": "^9.1.0",
+				"@atlaskit/button": "^16.10.0",
+				"@atlaskit/ds-explorations": "^3.0.0",
+				"@atlaskit/ds-lib": "^2.2.0",
+				"@atlaskit/focus-ring": "^1.3.0",
+				"@atlaskit/icon": "^21.12.0",
+				"@atlaskit/motion": "^1.5.0",
+				"@atlaskit/portal": "^4.3.0",
+				"@atlaskit/primitives": "^1.6.0",
+				"@atlaskit/theme": "^12.6.0",
+				"@atlaskit/tokens": "^1.28.0",
+				"@atlaskit/visually-hidden": "^1.2.0",
+				"@babel/runtime": "^7.0.0",
+				"@emotion/react": "^11.7.1"
 			},
 			"peerDependencies": {
 				"react": "^16.8.0"


### PR DESCRIPTION
Adds the logic for showing a flag when a team has been disconnected (See video)

https://github.com/atlassian-labs/figma-for-jira/assets/6136959/a734c972-bf06-469d-b93d-6c95954a5ab2

### Test plan
- assert that the flag shows up after a team has been disconnected
- assert that clicking "Got it" closes the flag
- assert that clicking "Undo" reconnects the team