### PR TITLE
NONE: Add logic for auto closing the post auth page

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -25,7 +25,8 @@
 		"@tanstack/react-query": "^5.0.5",
 		"axios": "^1.5.1",
 		"react": "^18.2.0",
-		"react-dom": "^18.2.0"
+		"react-dom": "^18.2.0",
+		"zod": "^3.22.4"
 	},
 	"devDependencies": {
 		"@emotion/babel-plugin": "^11.11.0",

--- a/admin/src/hooks/index.ts
+++ b/admin/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useAuthenticate';

--- a/admin/src/hooks/useAuthenticate.ts
+++ b/admin/src/hooks/useAuthenticate.ts
@@ -1,0 +1,56 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { z } from 'zod';
+
+import { openInBrowser } from '../utils';
+
+const authResultSchema = z.discriminatedUnion('type', [
+	z.object({
+		type: z.literal('auth:success'),
+	}),
+	z.object({
+		type: z.literal('auth:failure'),
+		message: z.string(),
+	}),
+]);
+
+export function useAuthenticate(authorizationEndpoint: string): () => void {
+	const queryClient = useQueryClient();
+	const authenticate = useCallback(
+		function authenticateImpl() {
+			const authWindow = openInBrowser(authorizationEndpoint);
+
+			function onAuthMessage(event: MessageEvent) {
+				if (event.origin !== window.location.origin) {
+					return;
+				}
+
+				const authResultResult = authResultSchema.safeParse(event.data);
+				if (!authResultResult.success) {
+					return;
+				}
+
+				const authResult = authResultResult.data;
+
+				switch (authResult.type) {
+					case 'auth:success': {
+						void queryClient.invalidateQueries({ queryKey: ['adminMe'] });
+						break;
+					}
+
+					case 'auth:failure': {
+						console.log(authResult.message);
+						break;
+					}
+				}
+				authWindow?.close();
+				window.removeEventListener('message', onAuthMessage);
+			}
+
+			window.addEventListener('message', onAuthMessage);
+		},
+		[authorizationEndpoint],
+	);
+
+	return authenticate;
+}

--- a/admin/src/pages/auth/auth-page.tsx
+++ b/admin/src/pages/auth/auth-page.tsx
@@ -6,13 +6,14 @@ import { token } from '@atlaskit/tokens';
 import { css } from '@emotion/react';
 
 import { ConnectBanner, FigmaPermissionsPopup, Page } from '../../components';
-import { openInBrowser } from '../../utils';
+import { useAuthenticate } from '../../hooks';
 
 type AuthPageProps = {
 	authorizationEndpoint: string;
 };
 
 export function AuthPage({ authorizationEndpoint }: AuthPageProps) {
+	const authenticate = useAuthenticate(authorizationEndpoint);
 	return (
 		<Page>
 			<div
@@ -77,7 +78,7 @@ export function AuthPage({ authorizationEndpoint }: AuthPageProps) {
 				</div>
 				<Button
 					appearance="primary"
-					onClick={() => openInBrowser(authorizationEndpoint)}
+					onClick={authenticate}
 					iconAfter={<ArrowRightIcon label="" size="medium" />}
 				>
 					Continue

--- a/admin/src/pages/teams/figma-teams-connector.tsx
+++ b/admin/src/pages/teams/figma-teams-connector.tsx
@@ -17,6 +17,7 @@ import {
 	Link,
 	Page,
 } from '../../components';
+import { useAuthenticate } from '../../hooks';
 import { parseTeamIdFromFigmaUrl } from '../../utils';
 
 type ConnectTeamProps = {
@@ -33,6 +34,7 @@ export function FigmaTeamConnector({
 	site,
 }: ConnectTeamProps) {
 	const queryClient = useQueryClient();
+	const authenticate = useAuthenticate(authorizationEndpoint);
 	const [validationError, setValidationError] = useState<string | null>(null);
 	const connectTeamMutation = useMutation({
 		mutationFn: async (teamId: string) => {
@@ -165,7 +167,7 @@ export function FigmaTeamConnector({
 				</div>
 				<div>
 					Logged in as <strong>{currentUser.email}</strong>.{' '}
-					<Link href={authorizationEndpoint}>Change Figma account</Link>
+					<Link onClick={authenticate}>Change Figma account</Link>
 				</div>
 			</div>
 		);

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,8 @@
 				"@tanstack/react-query": "^5.0.5",
 				"axios": "^1.5.1",
 				"react": "^18.2.0",
-				"react-dom": "^18.2.0"
+				"react-dom": "^18.2.0",
+				"zod": "^3.22.4"
 			},
 			"devDependencies": {
 				"@emotion/babel-plugin": "^11.11.0",
@@ -9496,6 +9497,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "3.22.4",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+			"integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		}
 	}


### PR DESCRIPTION
Adds logic for auto closing the post auth page. I added zod as a dependency to safely parse the messages we get from the post auth page.

### Test plan
- go through the login flow and assert that after going through the grant flow, the tab auto closes
- repeat for the switch user flow