### PR TITLE
NONE: render a success message on the auth result page

### DIFF
--- a/static/auth-result/index.html
+++ b/static/auth-result/index.html
@@ -4,19 +4,178 @@
     <meta charset="utf-8" />
     <title></title>
   </head>
-  <body>
+  <body
+    style="
+      font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        Segoe UI,
+        Roboto,
+        Oxygen,
+        Ubuntu,
+        Fira Sans,
+        Droid Sans,
+        Helvetica Neue,
+        sans-serif;
+      width: 100vw;
+      height: 100vh;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    "
+  >
+    <div
+      id="success-message"
+      style="
+        visibility: hidden;
+        box-sizing: border-box;
+        width: 392px;
+        padding: 64px 32px;
+        border-radius: 3px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 32px;
+        border: 1px solid rgba(9, 30, 66, 0.14);
+      "
+    >
+      <svg
+        width="174"
+        height="52"
+        viewBox="0 0 80 33"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g clip-path="url(#clip0_2_11)">
+          <g opacity="0.6">
+            <path
+              d="M-12.3507 12.2053H33.0167C33.1251 12.2053 33.2305 12.2405 33.3172 12.3057L38.6366 16.3057C38.9026 16.5057 38.9026 16.9049 38.6366 17.1049L33.3172 21.1049C33.2305 21.1701 33.1251 21.2053 33.0167 21.2053H-12.3507C-12.6268 21.2053 -12.8507 20.9815 -12.8507 20.7053V12.7053C-12.8507 12.4292 -12.6268 12.2053 -12.3507 12.2053Z"
+              fill="url(#paint0_linear_2_11)"
+              stroke="url(#paint1_linear_2_11)"
+            />
+          </g>
+          <g opacity="0.6">
+            <path
+              d="M92.3507 12.2053H46.9833C46.8749 12.2053 46.7695 12.2405 46.6828 12.3057L41.3634 16.3057C41.0974 16.5057 41.0974 16.9049 41.3634 17.1049L46.6828 21.1049C46.7695 21.1701 46.8749 21.2053 46.9833 21.2053H92.3507C92.6269 21.2053 92.8507 20.9815 92.8507 20.7053V12.7053C92.8507 12.4292 92.6269 12.2053 92.3507 12.2053Z"
+              fill="url(#paint2_linear_2_11)"
+              stroke="url(#paint3_linear_2_11)"
+            />
+          </g>
+          <rect
+            x="24"
+            y="0.705322"
+            width="32"
+            height="32"
+            rx="12"
+            fill="white"
+          />
+          <path
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            d="M53.3333 16.7053C53.3333 24.0691 47.3638 30.0387 40 30.0387C32.6362 30.0387 26.6667 24.0691 26.6667 16.7053C26.6667 9.34153 32.6362 3.37199 40 3.37199C47.3638 3.37199 53.3333 9.34153 53.3333 16.7053ZM36.5099 15.4639C36.6725 15.5338 36.8197 15.6353 36.9427 15.7627L38.6667 17.4867L43.0573 13.096C43.1803 12.9687 43.3275 12.8671 43.4901 12.7972C43.6528 12.7273 43.8278 12.6906 44.0048 12.689C44.1818 12.6875 44.3574 12.7212 44.5213 12.7883C44.6851 12.8553 44.834 12.9543 44.9592 13.0795C45.0844 13.2047 45.1834 13.3535 45.2504 13.5174C45.3175 13.6813 45.3512 13.8568 45.3497 14.0339C45.3481 14.2109 45.3113 14.3859 45.2415 14.5486C45.1716 14.7112 45.07 14.8584 44.9427 14.9814L39.6093 20.3147C39.3593 20.5646 39.0202 20.7051 38.6667 20.7051C38.3131 20.7051 37.974 20.5646 37.724 20.3147L35.0573 17.648C34.93 17.525 34.8284 17.3779 34.7585 17.2152C34.6886 17.0526 34.6519 16.8776 34.6503 16.7006C34.6488 16.5235 34.6825 16.3479 34.7496 16.1841C34.8166 16.0202 34.9156 15.8713 35.0408 15.7462C35.166 15.621 35.3149 15.522 35.4787 15.4549C35.6426 15.3879 35.8182 15.3541 35.9952 15.3557C36.1722 15.3572 36.3472 15.394 36.5099 15.4639Z"
+            fill="#22A06B"
+          />
+        </g>
+        <defs>
+          <linearGradient
+            id="paint0_linear_2_11"
+            x1="48.6816"
+            y1="16.7053"
+            x2="3.99166"
+            y2="16.7053"
+            gradientUnits="userSpaceOnUse"
+          >
+            <stop stop-color="#57D9A3" />
+            <stop offset="1" stop-color="#57D9A3" stop-opacity="0" />
+          </linearGradient>
+          <linearGradient
+            id="paint1_linear_2_11"
+            x1="40.0009"
+            y1="16.7053"
+            x2="20.5009"
+            y2="16.7053"
+            gradientUnits="userSpaceOnUse"
+          >
+            <stop stop-color="#57D9A3" />
+            <stop offset="1" stop-color="#57D9A3" stop-opacity="0" />
+          </linearGradient>
+          <linearGradient
+            id="paint2_linear_2_11"
+            x1="31.3184"
+            y1="16.7053"
+            x2="76.0083"
+            y2="16.7053"
+            gradientUnits="userSpaceOnUse"
+          >
+            <stop stop-color="#57D9A3" />
+            <stop offset="1" stop-color="#57D9A3" stop-opacity="0" />
+          </linearGradient>
+          <linearGradient
+            id="paint3_linear_2_11"
+            x1="39.9991"
+            y1="16.7053"
+            x2="59.4991"
+            y2="16.7053"
+            gradientUnits="userSpaceOnUse"
+          >
+            <stop stop-color="#57D9A3" />
+            <stop offset="1" stop-color="#57D9A3" stop-opacity="0" />
+          </linearGradient>
+          <clipPath id="clip0_2_11">
+            <rect
+              width="80"
+              height="32"
+              fill="white"
+              transform="translate(0 0.705322)"
+            />
+          </clipPath>
+        </defs>
+      </svg>
+      <h1
+        style="
+          color: rgba(23, 43, 77, 1);
+          font-size: 24px;
+          font-style: normal;
+          font-weight: 500;
+          line-height: 28px;
+          margin: 0;
+        "
+      >
+        Access granted
+      </h1>
+      <p
+        style="
+          color: rgba(68, 84, 111, 1);
+          text-align: center;
+
+          font-size: 14px;
+          font-style: normal;
+          font-weight: 400;
+          line-height: 20px;
+          margin: 0;
+        "
+      >
+        You may close this tab and return to Jira to start using 'Figma for
+        Jira'
+      </p>
+    </div>
     <script>
-      if (window.opener) {
-        function parseQueryParamAsBoolean(value) {
-          return value.toLowerCase() === 'true';
+      function parseQueryParamAsBoolean(value) {
+        return value.toLowerCase() === 'true';
+      }
+      const params = new URLSearchParams(window.location.search);
+      if (params.has('success')) {
+        const success = parseQueryParamAsBoolean(params.get('success'));
+        const errorMessage = params.get('errorMessage');
+
+        if (success) {
+          const successMessage = document.getElementById('success-message');
+          if (successMessage) {
+            successMessage.style.visibility = 'visible';
+          }
         }
 
-        const params = new URLSearchParams(window.location.search);
-
-        if (params.has('success')) {
-          const success = parseQueryParamAsBoolean(params.get('success'));
-          const errorMessage = params.get('errorMessage');
-
+        if (window.opener) {
           // Send the authentication result to the opener window
           if (success) {
             window.opener.postMessage(


### PR DESCRIPTION
When completing the auth flow - in the case that we don't auto close the window, we want to add a success page telling the user to close their window.

lol tbh, I thought about setting up an entire vite/react app for this - but that felt like overkill for 1 page that should be auto closing the majority of the time. So instead, I just inline the styles and added a tiny bit of JS so we don't show the success message if the auth flow failed.

Screenshot:
![finally-central-silkworm_ngrok-free_app_static_auth-result__success_true](https://github.com/atlassian-labs/figma-for-jira/assets/6136959/6351a77d-337d-4706-982a-94cbc779b921)

### Test plan
- assert the window opener message passing still works by testing against https://github.com/atlassian-labs/figma-for-jira/pull/146
- navigate to `/static/auth-result?success=true` and assert that the success screen shows up
- navigate to `/static/auth-result?success=false` and assert that the screen is blank