### PR TITLE
[logging] Add the Datadog tracer 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,7 @@ JIRA_CONNECT_KEY_SERVER_URL=https://connect-install-keys.atlassian.com
 # Optional. These env variables are used to configure Datadog for tracing.
 DD_SERVICE=figma-for-jira
 DD_ENV=dev
+DD_TRACE_ENABLED=false
 
 ###############################################################
 ## The env variables below are required only for development ##

--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,10 @@ FIGMA_OAUTH2_STATE_SECRET_KEY=
 # See for more detail: https://developer.atlassian.com/cloud/jira/platform/security-for-connect-apps/#validating-installation-lifecycle-requests
 JIRA_CONNECT_KEY_SERVER_URL=https://connect-install-keys.atlassian.com
 
+# Optional. These env variables are used to configure Datadog for tracing.
+DD_SERVICE=figma-for-jira
+DD_ENV=dev
+
 ###############################################################
 ## The env variables below are required only for development ##
 ###############################################################

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 				"ajv": "^8.12.0",
 				"atlassian-jwt": "^2.0.2",
 				"axios": "^1.4.0",
+				"dd-trace": "^4.17.0",
 				"express": "^4.18.2",
 				"pino": "^8.15.0",
 				"pino-http": "^8.4.0",
@@ -1306,6 +1307,99 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
+		"node_modules/@datadog/native-appsec": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-4.0.0.tgz",
+			"integrity": "sha512-myTguXJ3VQHS2E1ylNsSF1avNpDmq5t+K4Q47wdzeakGc3sDIDDyEbvuFTujl9c9wBIkup94O1mZj5DR37ajzA==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"node-gyp-build": "^3.9.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@datadog/native-iast-rewriter": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.1.3.tgz",
+			"integrity": "sha512-4oxMFz5ZEpOK3pRc9KjquMgkRP6D+oPQVIzOk4dgG8fl2iepHtCa3gna/fQBfdWIiX5a2j65O3R1zNp2ckk8JA==",
+			"dependencies": {
+				"lru-cache": "^7.14.0",
+				"node-gyp-build": "^4.5.0"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@datadog/native-iast-rewriter/node_modules/lru-cache": {
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
+			"integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
+			}
+		},
+		"node_modules/@datadog/native-iast-taint-tracking": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.6.1.tgz",
+			"integrity": "sha512-V1X0UbEROcEkqP4IIovqK9uu8jPXq80m8xOW1Vb6xJ9otO3eBphvDFDSa/OJ4pEYhajjjmGlraLlV6rXjaSGlQ==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"node-gyp-build": "^3.9.0"
+			}
+		},
+		"node_modules/@datadog/native-metrics": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-2.0.0.tgz",
+			"integrity": "sha512-YklGVwUtmKGYqFf1MNZuOHvTYdKuR4+Af1XkWcMD8BwOAjxmd9Z+97328rCOY8TFUJzlGUPaXzB8j2qgG/BMwA==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"node-addon-api": "^6.1.0",
+				"node-gyp-build": "^3.9.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@datadog/pprof": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-4.0.0.tgz",
+			"integrity": "sha512-1rQV6arh5fp7BWshjHgKmhNzXELAIod1Y4ydkI7XRcRim35uBoxQgPy1VgMCuLjfzco7112Vt8bkfQxo9bIdoA==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"delay": "^5.0.0",
+				"node-gyp-build": "<4.0",
+				"p-limit": "^3.1.0",
+				"pprof-format": "^2.0.7",
+				"source-map": "^0.7.4"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@datadog/pprof/node_modules/source-map": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@datadog/sketches-js": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@datadog/sketches-js/-/sketches-js-2.1.0.tgz",
+			"integrity": "sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew=="
+		},
 		"node_modules/@emotion/babel-plugin": {
 			"version": "11.11.0",
 			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
@@ -2390,6 +2484,36 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.7.0.tgz",
+			"integrity": "sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/core": {
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.0.tgz",
+			"integrity": "sha512-PCW0UCIazJRw4Q8m3Z1A20kJqKTCB4Ob02bFjov3sHozspHGnY21O7T8Q20XKe168N4Px+n7Mt4dkcay3fy92Q==",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "1.18.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.8.0"
+			}
+		},
+		"node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.0.tgz",
+			"integrity": "sha512-Bxtd+h2+rBv3XBHZaoXq133/hzgAQvbl2Kg5a9cG4ozfiUJHC9Xkblt7PrLc9CbzwWQpSxUxWoZJHXT3lUlkOw==",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
 			"dev": true,
@@ -2435,6 +2559,60 @@
 		"node_modules/@prisma/engines-version": {
 			"version": "5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e",
 			"license": "Apache-2.0"
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.0"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+		},
+		"node_modules/@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
 		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.27.8",
@@ -2655,8 +2833,7 @@
 		"node_modules/@types/node": {
 			"version": "18.17.1",
 			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/node/-/node-18.17.1.tgz",
-			"integrity": "sha512-xlR1jahfizdplZYRU59JlUx9uzF1ARa8jbhM11ccpCJya8kvos5jwdm2ZAgxSCwOl0fq21svP18EVwPBXMQudw==",
-			"dev": true
+			"integrity": "sha512-xlR1jahfizdplZYRU59JlUx9uzF1ARa8jbhM11ccpCJya8kvos5jwdm2ZAgxSCwOl0fq21svP18EVwPBXMQudw=="
 		},
 		"node_modules/@types/parse-json": {
 			"version": "4.0.1",
@@ -3023,13 +3200,20 @@
 		},
 		"node_modules/acorn": {
 			"version": "8.10.0",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-import-assertions": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+			"integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+			"peerDependencies": {
+				"acorn": "^8"
 			}
 		},
 		"node_modules/acorn-jsx": {
@@ -3679,7 +3863,6 @@
 		},
 		"node_modules/cjs-module-lexer": {
 			"version": "1.2.3",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/cliui": {
@@ -3862,6 +4045,11 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/crypto-randomuuid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-randomuuid/-/crypto-randomuuid-1.0.0.tgz",
+			"integrity": "sha512-/RC5F4l1SCqD/jazwUF6+t34Cd8zTSAGZ7rvvZu1whZUhD2a5MOGKjSGowoGcpj/cbVZk1ZODIooJEQQq3nNAA=="
+		},
 		"node_modules/csstype": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
@@ -3873,6 +4061,65 @@
 			"license": "MIT",
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/dd-trace": {
+			"version": "4.17.0",
+			"resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-4.17.0.tgz",
+			"integrity": "sha512-qLutasPUGy5JiR42XVXWH4/KScqf01Xhpkp3d+ykEr5Bha1F5P8IuP6Ule9285fBQClEgVvIB0Frm+PSDO5idQ==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"@datadog/native-appsec": "^4.0.0",
+				"@datadog/native-iast-rewriter": "2.1.3",
+				"@datadog/native-iast-taint-tracking": "1.6.1",
+				"@datadog/native-metrics": "^2.0.0",
+				"@datadog/pprof": "4.0.0",
+				"@datadog/sketches-js": "^2.1.0",
+				"@opentelemetry/api": "^1.0.0",
+				"@opentelemetry/core": "^1.14.0",
+				"crypto-randomuuid": "^1.0.0",
+				"diagnostics_channel": "^1.1.0",
+				"ignore": "^5.2.4",
+				"import-in-the-middle": "^1.4.2",
+				"int64-buffer": "^0.1.9",
+				"ipaddr.js": "^2.1.0",
+				"istanbul-lib-coverage": "3.2.0",
+				"jest-docblock": "^29.7.0",
+				"koalas": "^1.0.2",
+				"limiter": "^1.1.4",
+				"lodash.kebabcase": "^4.1.1",
+				"lodash.pick": "^4.4.0",
+				"lodash.sortby": "^4.7.0",
+				"lodash.uniq": "^4.5.0",
+				"lru-cache": "^7.14.0",
+				"methods": "^1.1.2",
+				"module-details-from-path": "^1.0.3",
+				"msgpack-lite": "^0.1.26",
+				"node-abort-controller": "^3.1.1",
+				"opentracing": ">=0.12.1",
+				"path-to-regexp": "^0.1.2",
+				"protobufjs": "^7.2.4",
+				"retry": "^0.13.1",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/dd-trace/node_modules/ipaddr.js": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+			"integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/dd-trace/node_modules/lru-cache": {
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/debug": {
@@ -3935,6 +4182,17 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/delay": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+			"integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
 			"license": "MIT",
@@ -3959,7 +4217,6 @@
 		},
 		"node_modules/detect-newline": {
 			"version": "3.1.0",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -3977,6 +4234,14 @@
 			"dependencies": {
 				"asap": "^2.0.0",
 				"wrappy": "1"
+			}
+		},
+		"node_modules/diagnostics_channel": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/diagnostics_channel/-/diagnostics_channel-1.1.0.tgz",
+			"integrity": "sha512-OE1ngLDjSBPG6Tx0YATELzYzy3RKHC+7veQ8gLa8yS7AAgw65mFbVdcsu3501abqOZCEZqZyAIemB0zXlqDSuw==",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/diff": {
@@ -4636,6 +4901,11 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/event-lite": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/event-lite/-/event-lite-0.1.3.tgz",
+			"integrity": "sha512-8qz9nOz5VeD2z96elrEKD2U433+L3DWdUdDkOINLGOJvx1GsMBbMn0aCeu28y8/e85A6mCigBiFlYMnTBEGlSw=="
 		},
 		"node_modules/event-target-shim": {
 			"version": "5.0.1",
@@ -5514,7 +5784,6 @@
 		},
 		"node_modules/ignore": {
 			"version": "5.2.4",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -5539,6 +5808,17 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/import-in-the-middle": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
+			"integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
+			"dependencies": {
+				"acorn": "^8.8.2",
+				"acorn-import-assertions": "^1.9.0",
+				"cjs-module-lexer": "^1.2.2",
+				"module-details-from-path": "^1.0.3"
 			}
 		},
 		"node_modules/import-local": {
@@ -5579,6 +5859,11 @@
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"license": "ISC"
+		},
+		"node_modules/int64-buffer": {
+			"version": "0.1.10",
+			"resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
+			"integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA=="
 		},
 		"node_modules/internal-slot": {
 			"version": "1.0.5",
@@ -5867,7 +6152,6 @@
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.0",
-			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=8"
@@ -6139,9 +6423,9 @@
 			}
 		},
 		"node_modules/jest-docblock": {
-			"version": "29.4.3",
-			"dev": true,
-			"license": "MIT",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+			"integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
 			"dependencies": {
 				"detect-newline": "^3.0.0"
 			},
@@ -6637,6 +6921,14 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/koalas": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/koalas/-/koalas-1.0.2.tgz",
+			"integrity": "sha512-RYhBbYaTTTHId3l6fnMZc3eGQNW6FVCqMG6AMwA5I1Mafr6AflaXeoi6x3xQuATRotGYRLk6+1ELZH4dstFNOA==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/leven": {
 			"version": "3.1.0",
 			"dev": true,
@@ -6656,6 +6948,11 @@
 			"engines": {
 				"node": ">= 0.8.0"
 			}
+		},
+		"node_modules/limiter": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+			"integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
 		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
@@ -6690,6 +6987,11 @@
 			"version": "4.17.21",
 			"license": "MIT"
 		},
+		"node_modules/lodash.kebabcase": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+			"integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g=="
+		},
 		"node_modules/lodash.memoize": {
 			"version": "4.1.2",
 			"dev": true,
@@ -6699,6 +7001,26 @@
 			"version": "4.6.2",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/lodash.pick": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+			"integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q=="
+		},
+		"node_modules/lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+		},
+		"node_modules/lodash.uniq": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+		},
+		"node_modules/long": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+			"integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
 		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
@@ -6713,7 +7035,6 @@
 		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^4.0.0"
@@ -6881,9 +7202,33 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/module-details-from-path": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+			"integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"license": "MIT"
+		},
+		"node_modules/msgpack-lite": {
+			"version": "0.1.26",
+			"resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
+			"integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
+			"dependencies": {
+				"event-lite": "^0.1.1",
+				"ieee754": "^1.1.8",
+				"int64-buffer": "^0.1.9",
+				"isarray": "^1.0.0"
+			},
+			"bin": {
+				"msgpack": "bin/msgpack"
+			}
+		},
+		"node_modules/msgpack-lite/node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.6",
@@ -6935,6 +7280,16 @@
 				"node": ">= 10.13"
 			}
 		},
+		"node_modules/node-abort-controller": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+			"integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
+		},
+		"node_modules/node-addon-api": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+			"integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
+		},
 		"node_modules/node-fetch": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -6952,6 +7307,16 @@
 				"encoding": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/node-gyp-build": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+			"integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
 			}
 		},
 		"node_modules/node-int64": {
@@ -7271,6 +7636,14 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/opentracing": {
+			"version": "0.14.7",
+			"resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
+			"integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==",
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
 		"node_modules/optionator": {
 			"version": "0.9.3",
 			"dev": true,
@@ -7289,7 +7662,6 @@
 		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
@@ -7578,6 +7950,11 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
+		"node_modules/pprof-format": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.0.7.tgz",
+			"integrity": "sha512-1qWaGAzwMpaXJP9opRa23nPnt2Egi7RMNoNBptEE/XwHbcn4fC2b/4U4bKc5arkGkIh2ZabpF2bEb+c5GNHEKA=="
+		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"dev": true,
@@ -7691,6 +8068,29 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/protobufjs": {
+			"version": "7.2.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+			"integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/node": ">=13.7.0",
+				"long": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/proxy-addr": {
@@ -8069,6 +8469,14 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
 			"dev": true,
@@ -8242,7 +8650,6 @@
 		},
 		"node_modules/semver": {
 			"version": "7.5.4",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -9469,7 +9876,6 @@
 		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
@@ -9515,7 +9921,6 @@
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"ajv": "^8.12.0",
 		"atlassian-jwt": "^2.0.2",
 		"axios": "^1.4.0",
+		"dd-trace": "^4.17.0",
 		"express": "^4.18.2",
 		"pino": "^8.15.0",
 		"pino-http": "^8.4.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,6 @@
+// Must come before importing any instrumented module.
+// eslint-disable-next-line import/no-unassigned-import
+import './infrastructure/tracer';
 import express, { json } from 'express';
 
 import { errorHandlerMiddleware, httpLoggerMiddleware } from './web/middleware';

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -47,8 +47,8 @@ export const getConfig = (): Config => {
 				level: readEnvVarString('LOG_LEVEL', ''),
 			},
 			tracer: {
-				service: readEnvVarString('DD_SERVICE'),
-				env: readEnvVarString('DD_ENV'),
+				service: readEnvVarString('DD_SERVICE', ''),
+				env: readEnvVarString('DD_ENV', ''),
 			},
 			figma: {
 				webBaseUrl: readEnvVarString('FIGMA_WEB_BASE_URL'),

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -14,6 +14,7 @@ export type Config = {
 	readonly tracer: {
 		readonly service: string;
 		readonly env: string;
+		readonly enabled: boolean;
 	};
 	readonly figma: {
 		readonly webBaseUrl: string;
@@ -49,6 +50,7 @@ export const getConfig = (): Config => {
 			tracer: {
 				service: readEnvVarString('DD_SERVICE', ''),
 				env: readEnvVarString('DD_ENV', ''),
+				enabled: readEnvVarString('DD_TRACE_ENABLED', '') === 'true',
 			},
 			figma: {
 				webBaseUrl: readEnvVarString('FIGMA_WEB_BASE_URL'),

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -11,6 +11,10 @@ export type Config = {
 	readonly logging: {
 		readonly level: string;
 	};
+	readonly tracer: {
+		readonly service: string;
+		readonly env: string;
+	};
 	readonly figma: {
 		readonly webBaseUrl: string;
 		readonly apiBaseUrl: string;
@@ -41,6 +45,10 @@ export const getConfig = (): Config => {
 			},
 			logging: {
 				level: readEnvVarString('LOG_LEVEL', ''),
+			},
+			tracer: {
+				service: readEnvVarString('DD_SERVICE'),
+				env: readEnvVarString('DD_ENV'),
 			},
 			figma: {
 				webBaseUrl: readEnvVarString('FIGMA_WEB_BASE_URL'),

--- a/src/config/testing/mocks.ts
+++ b/src/config/testing/mocks.ts
@@ -11,6 +11,11 @@ export const mockConfig: Config = {
 	logging: {
 		level: 'TEST',
 	},
+	tracer: {
+		service: 'figma-for-jira',
+		env: 'dev',
+		enabled: false,
+	},
 	figma: {
 		webBaseUrl: 'https://www.figma.com',
 

--- a/src/infrastructure/tracer.ts
+++ b/src/infrastructure/tracer.ts
@@ -1,15 +1,17 @@
 import ddTrace from 'dd-trace';
 
+import { getConfig } from '../config/config';
+
 const tracer = ddTrace.init({
-	service: process.env.FIGMA_SERVICE_NAME || '',
+	service: getConfig().tracer.service,
 	profiling: true,
-	env: process.env.DD_ENV || '',
+	env: getConfig().tracer.env,
 	runtimeMetrics: true,
 	logInjection: true,
-	tags: { figma_service: process.env.FIGMA_SERVICE_NAME || '' },
+	tags: { figma_service: getConfig().tracer.service },
 });
 
 tracer.use('express', {
 	enabled: true,
-	service: process.env.FIGMA_SERVICE_NAME || '',
+	service: getConfig().tracer.service,
 });

--- a/src/infrastructure/tracer.ts
+++ b/src/infrastructure/tracer.ts
@@ -1,0 +1,15 @@
+import ddTrace from 'dd-trace';
+
+const tracer = ddTrace.init({
+	service: process.env.FIGMA_SERVICE_NAME || '',
+	profiling: true,
+	env: process.env.DD_ENV || '',
+	runtimeMetrics: true,
+	logInjection: true,
+	tags: { figma_service: process.env.FIGMA_SERVICE_NAME || '' },
+});
+
+tracer.use('express', {
+	enabled: true,
+	service: process.env.FIGMA_SERVICE_NAME || '',
+});

--- a/src/web/routes/router.ts
+++ b/src/web/routes/router.ts
@@ -1,3 +1,7 @@
+// Must come before importing any instrumented module.
+// eslint-disable-next-line import/no-unassigned-import
+import '../../infrastructure/tracer';
+
 import { HttpStatusCode } from 'axios';
 import type { Request, Response } from 'express';
 import { Router, static as Static } from 'express';


### PR DESCRIPTION
When we deploy the figma-for-jira app, we use Datadog to track the service metric / logs. This PR adds Datadog to the public repo. In practice, this should be a no-op. 