### PR TITLE
FABB-4: Update switch accounts flow to navigate directly to the accounts picker

### DIFF
--- a/admin/src/pages/teams/figma-teams-connector.tsx
+++ b/admin/src/pages/teams/figma-teams-connector.tsx
@@ -17,8 +17,7 @@ import {
 	Link,
 	Page,
 } from '../../components';
-import { useAuthenticate } from '../../hooks';
-import { parseTeamIdFromFigmaUrl } from '../../utils';
+import { openInBrowser, parseTeamIdFromFigmaUrl } from '../../utils';
 
 type ConnectTeamProps = {
 	authorizationEndpoint: string;
@@ -34,7 +33,17 @@ export function FigmaTeamConnector({
 	site,
 }: ConnectTeamProps) {
 	const queryClient = useQueryClient();
-	const authenticate = useAuthenticate(authorizationEndpoint);
+	const switchFigmaUser = () => {
+		// Use URL API to handle encoding.
+		const switchFigmaUserUrl = new URL('switch_user', 'https://www.figma.com');
+		switchFigmaUserUrl.searchParams.set('cont', authorizationEndpoint);
+		// Redirect a user to `switchFigmaUserUrl`.
+
+		// We don't set up any logic for auto closing the window here since Figma
+		// ends up setting `window.opener` to `null` when the user selects an account.
+		openInBrowser(switchFigmaUserUrl.toString());
+	};
+
 	const [validationError, setValidationError] = useState<string | null>(null);
 	const connectTeamMutation = useMutation({
 		mutationFn: async (teamId: string) => {
@@ -167,7 +176,7 @@ export function FigmaTeamConnector({
 				</div>
 				<div>
 					Logged in as <strong>{currentUser.email}</strong>.{' '}
-					<Link onClick={authenticate}>Change Figma account</Link>
+					<Link onClick={switchFigmaUser}>Change Figma account</Link>
 				</div>
 			</div>
 		);


### PR DESCRIPTION
This PR updates the logic for clicking `Change Figma account` to navigate directly to Figma's account selector page instead of the auth grant screen.

### Test Plan
- Click `Change Figma account`
- Assert that it navigates to the account picker page in Figma
- Assert that this works even when you're only logged into 1 account (screenshot)
![image](https://github.com/atlassian-labs/figma-for-jira/assets/6136959/9ce81b38-47a3-4d03-b754-6ccf4c073b5c)
- Assert that after selecting an account, it will go through the auth grant flow