### PR TITLE
FABB-22: Rename get started -> configure

### DIFF
--- a/src/atlassian-connect.ts
+++ b/src/atlassian-connect.ts
@@ -74,10 +74,10 @@ export const connectAppDescriptor = {
 	 * https://developer.atlassian.com/cloud/jira/platform/about-connect-modules-for-jira/
 	 */
 	modules: {
-		postInstallPage: {
-			key: 'figma-get-started',
+		configurePage: {
+			key: 'figma-configure',
 			name: {
-				value: 'Get Started',
+				value: 'Configure',
 			},
 			url: '/static/admin',
 			conditions: [{ condition: 'user_is_admin' }],


### PR DESCRIPTION
Read over the documentation on https://developer.atlassian.com/cloud/jira/platform/modules/admin-page/ and https://developer.atlassian.com/cloud/jira/platform/modules/page/

Looks like it was rendering "Get started" because we were using a `postInstallPage`. To have it render "Configure", we should be using a `configurePage`.

### Test plan
- uninstall/reinstall the app
- assert that it now shows configure instead of get started
- assert that clicking the configure button navigates to the webhook config page
![image](https://github.com/atlassian-labs/figma-for-jira/assets/6136959/24691bc3-0677-4f47-b9a5-bf478bc30a4d)
