### PR TITLE
[logging] Remove duplicate tracer

### DIFF
--- a/src/web/routes/router.ts
+++ b/src/web/routes/router.ts
@@ -1,7 +1,3 @@
-// Must come before importing any instrumented module.
-// eslint-disable-next-line import/no-unassigned-import
-import '../../infrastructure/tracer';
-
 import { HttpStatusCode } from 'axios';
 import type { Request, Response } from 'express';
 import { Router, static as Static } from 'express';


### PR DESCRIPTION
In a previous PR, I added the Datadog tracer library. https://github.com/atlassian-labs/figma-for-jira/pull/154/files

I accidentally added it twice. This PR removes the duplicate import. There is already an entrypoint in src/app.ts.