### PR TITLE
MDTZ-1175: Remove Figma File name from design URL. Encode URL path parameters in API clients.

### DIFF
--- a/src/common/url-utils.test.ts
+++ b/src/common/url-utils.test.ts
@@ -1,0 +1,21 @@
+import { appendToPathname } from './url-utils';
+
+describe('urlUtils', () => {
+	describe('removeTrailingSlashFromPathname', () => {
+		it.each([
+			[new URL('https://test.com'), '1', new URL('https://test.com/1')],
+			[new URL('https://test.com/'), '1', new URL('https://test.com/1')],
+			[new URL('https://test.com/'), '/1', new URL('https://test.com/1')],
+			[new URL('https://test.com/v'), '1', new URL('https://test.com/v/1')],
+			[new URL('https://test.com/v'), '/1', new URL('https://test.com/v/1')],
+			[new URL('https://test.com/v/'), '/1', new URL('https://test.com/v/1')],
+		])(
+			'should return a URL with appended path segment',
+			(url, path, expected) => {
+				const result = appendToPathname(url, path).toString();
+
+				expect(result).toBe(expected.toString());
+			},
+		);
+	});
+});

--- a/src/common/url-utils.ts
+++ b/src/common/url-utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns a new URL with the given `segment` appended to `url.pathname`.
+ */
+export const appendToPathname = (url: URL, segment: string): URL => {
+	const pathnameWithoutTrailingSlash = url.pathname.replace(/\/$/, '');
+	const segmentPathWithoutLeadingSlash = segment.replace(/^\//, '');
+
+	const result = new URL(url.toString());
+	result.pathname = [
+		pathnameWithoutTrailingSlash,
+		segmentPathWithoutLeadingSlash,
+	].join('/');
+
+	return result;
+};

--- a/src/domain/entities/testing/mocks.ts
+++ b/src/domain/entities/testing/mocks.ts
@@ -45,7 +45,6 @@ export const generateFigmaDesignIdentifier = ({
 export const generateFigmaDesignUrl = ({
 	fileKey = generateFigmaFileKey(),
 	nodeId,
-	fileName = generateFigmaFileName(),
 	mode,
 }: {
 	fileKey?: string;
@@ -53,7 +52,7 @@ export const generateFigmaDesignUrl = ({
 	fileName?: string;
 	mode?: string;
 } = {}) => {
-	const url = new URL(`https://www.figma.com/file/${fileKey}/${fileName}`);
+	const url = new URL(`https://www.figma.com/file/${fileKey}/`);
 	if (nodeId) {
 		url.searchParams.append('node-id', nodeId);
 	}

--- a/src/domain/entities/testing/mocks.ts
+++ b/src/domain/entities/testing/mocks.ts
@@ -49,10 +49,9 @@ export const generateFigmaDesignUrl = ({
 }: {
 	fileKey?: string;
 	nodeId?: string;
-	fileName?: string;
 	mode?: string;
 } = {}) => {
-	const url = new URL(`https://www.figma.com/file/${fileKey}/`);
+	const url = new URL(`https://www.figma.com/file/${fileKey}`);
 	if (nodeId) {
 		url.searchParams.append('node-id', nodeId);
 	}
@@ -151,13 +150,11 @@ export const generateAtlassianDesign = ({
 	url = generateFigmaDesignUrl({
 		fileKey: FigmaDesignIdentifier.fromAtlassianDesignId(id).fileKey,
 		nodeId: FigmaDesignIdentifier.fromAtlassianDesignId(id).nodeId,
-		fileName: displayName,
 		mode: 'design',
 	}),
 	liveEmbedUrl = generateFigmaDesignUrl({
 		fileKey: FigmaDesignIdentifier.fromAtlassianDesignId(id).fileKey,
 		nodeId: FigmaDesignIdentifier.fromAtlassianDesignId(id).nodeId,
-		fileName: displayName,
 		mode: 'design',
 	}),
 	status = AtlassianDesignStatus.UNKNOWN,

--- a/src/infrastructure/figma/figma-client/figma-client.ts
+++ b/src/infrastructure/figma/figma-client/figma-client.ts
@@ -48,25 +48,23 @@ export class FigmaClient {
 	 */
 	getOAuth2Token = async (code: string): Promise<GetOAuth2TokenResponse> =>
 		withAxiosErrorTranslation(async () => {
-			const params = new URLSearchParams();
-			params.append('client_id', getConfig().figma.oauth2.clientId);
-			params.append('client_secret', getConfig().figma.oauth2.clientSecret);
-			params.append(
+			const url = new URL(
+				'/api/oauth/token',
+				getConfig().figma.oauth2.authorizationServerBaseUrl,
+			);
+			url.searchParams.append('client_id', getConfig().figma.oauth2.clientId);
+			url.searchParams.append(
+				'client_secret',
+				getConfig().figma.oauth2.clientSecret,
+			);
+			url.searchParams.append(
 				'redirect_uri',
 				`${getConfig().app.baseUrl}/figma/oauth/callback`,
 			);
-			params.append('code', code);
-			params.append('grant_type', 'authorization_code');
+			url.searchParams.append('code', code);
+			url.searchParams.append('grant_type', 'authorization_code');
 
-			const response = await axios.post<GetOAuth2TokenResponse>(
-				`${
-					getConfig().figma.oauth2.authorizationServerBaseUrl
-				}/api/oauth/token`,
-				null,
-				{
-					params,
-				},
-			);
+			const response = await axios.post<unknown>(url.toString());
 
 			assertSchema(response.data, GET_OAUTH2_TOKEN_RESPONSE_SCHEMA);
 
@@ -84,18 +82,18 @@ export class FigmaClient {
 		refreshToken: string,
 	): Promise<RefreshOAuth2TokenResponse> =>
 		withAxiosErrorTranslation(async () => {
-			const params = new URLSearchParams();
-			params.append('client_id', getConfig().figma.oauth2.clientId);
-			params.append('client_secret', getConfig().figma.oauth2.clientSecret);
-			params.append('refresh_token', refreshToken);
-
-			const response = await axios.post<RefreshOAuth2TokenResponse>(
-				`${
-					getConfig().figma.oauth2.authorizationServerBaseUrl
-				}/api/oauth/refresh`,
-				null,
-				{ params },
+			const url = new URL(
+				'/api/oauth/refresh',
+				getConfig().figma.oauth2.authorizationServerBaseUrl,
 			);
+			url.searchParams.append('client_id', getConfig().figma.oauth2.clientId);
+			url.searchParams.append(
+				'client_secret',
+				getConfig().figma.oauth2.clientSecret,
+			);
+			url.searchParams.append('refresh_token', refreshToken);
+
+			const response = await axios.post<unknown>(url.toString());
 
 			assertSchema(response.data, REFRESH_OAUTH2_TOKEN_RESPONSE_SCHEMA);
 
@@ -111,14 +109,13 @@ export class FigmaClient {
 	 */
 	me = async (accessToken: string): Promise<GetMeResponse> =>
 		withAxiosErrorTranslation(async () => {
-			const response = await axios.get<GetMeResponse>(
-				`${getConfig().figma.apiBaseUrl}/v1/me`,
-				{
-					headers: {
-						['Authorization']: `Bearer ${accessToken}`,
-					},
+			const url = new URL(`/v1/me`, getConfig().figma.apiBaseUrl);
+
+			const response = await axios.get<unknown>(url.toString(), {
+				headers: {
+					['Authorization']: `Bearer ${accessToken}`,
 				},
-			);
+			});
 
 			assertSchema(response.data, GET_ME_RESPONSE_SCHEMA);
 
@@ -140,7 +137,9 @@ export class FigmaClient {
 	): Promise<GetFileMetaResponse> =>
 		withAxiosErrorTranslation(async () => {
 			const url = new URL(
-				`${getConfig().figma.apiBaseUrl}/v1/files/${fileKey}/meta`,
+				`${getConfig().figma.apiBaseUrl}/v1/files/${encodeURIComponent(
+					fileKey,
+				)}/meta`,
 			);
 
 			const response = await axios.get<unknown>(url.toString(), {
@@ -168,7 +167,9 @@ export class FigmaClient {
 	): Promise<GetFileResponse> =>
 		withAxiosErrorTranslation(async () => {
 			const url = new URL(
-				`${getConfig().figma.apiBaseUrl}/v1/files/${fileKey}`,
+				`${getConfig().figma.apiBaseUrl}/v1/files/${encodeURIComponent(
+					fileKey,
+				)}`,
 			);
 
 			if (params.ids != null) {
@@ -207,15 +208,13 @@ export class FigmaClient {
 		accessToken: string,
 	): Promise<CreateDevResourcesResponse> =>
 		withAxiosErrorTranslation(async () => {
-			const response = await axios.post<unknown>(
-				`${getConfig().figma.apiBaseUrl}/v1/dev_resources`,
-				request,
-				{
-					headers: {
-						['Authorization']: `Bearer ${accessToken}`,
-					},
+			const url = new URL(`/v1/dev_resources`, getConfig().figma.apiBaseUrl);
+
+			const response = await axios.post<unknown>(url.toString(), request, {
+				headers: {
+					['Authorization']: `Bearer ${accessToken}`,
 				},
-			);
+			});
 
 			assertSchema(response.data, CREATE_DEV_RESOURCE_RESPONSE_SCHEMA);
 
@@ -235,17 +234,19 @@ export class FigmaClient {
 		accessToken,
 	}: GetDevResourcesRequest): Promise<GetDevResourcesResponse> =>
 		withAxiosErrorTranslation(async () => {
-			const response = await axios.get<unknown>(
-				`${getConfig().figma.apiBaseUrl}/v1/files/${fileKey}/dev_resources`,
-				{
-					params: {
-						node_ids: nodeIds?.join(','),
-					},
-					headers: {
-						['Authorization']: `Bearer ${accessToken}`,
-					},
-				},
+			const url = new URL(
+				`/v1/files/${encodeURIComponent(fileKey)}/dev_resources`,
+				getConfig().figma.apiBaseUrl,
 			);
+			if (nodeIds?.length) {
+				url.searchParams.append('node_ids', nodeIds.join(','));
+			}
+
+			const response = await axios.get<unknown>(url.toString(), {
+				headers: {
+					['Authorization']: `Bearer ${accessToken}`,
+				},
+			});
 
 			assertSchema(response.data, GET_DEV_RESOURCE_RESPONSE_SCHEMA);
 
@@ -265,18 +266,18 @@ export class FigmaClient {
 		accessToken,
 	}: DeleteDevResourceRequest): Promise<void> =>
 		withAxiosErrorTranslation(async () => {
-			const response = await axios.delete<void>(
-				`${
-					getConfig().figma.apiBaseUrl
-				}/v1/files/${fileKey}/dev_resources/${devResourceId}`,
-				{
-					headers: {
-						['Authorization']: `Bearer ${accessToken}`,
-					},
-				},
+			const url = new URL(
+				`/v1/files/${encodeURIComponent(
+					fileKey,
+				)}/dev_resources/${encodeURIComponent(devResourceId)}`,
+				getConfig().figma.apiBaseUrl,
 			);
 
-			return response.data;
+			await axios.delete<unknown>(url.toString(), {
+				headers: {
+					['Authorization']: `Bearer ${accessToken}`,
+				},
+			});
 		});
 
 	/**
@@ -291,15 +292,13 @@ export class FigmaClient {
 		accessToken: string,
 	): Promise<CreateWebhookResponse> =>
 		withAxiosErrorTranslation(async () => {
-			const response = await axios.post<unknown>(
-				`${getConfig().figma.apiBaseUrl}/v2/webhooks`,
-				request,
-				{
-					headers: {
-						['Authorization']: `Bearer ${accessToken}`,
-					},
+			const url = new URL(`/v2/webhooks`, getConfig().figma.apiBaseUrl);
+
+			const response = await axios.post<unknown>(url.toString(), request, {
+				headers: {
+					['Authorization']: `Bearer ${accessToken}`,
 				},
-			);
+			});
 
 			assertSchema(response.data, CREATE_WEBHOOK_RESPONSE);
 
@@ -318,14 +317,16 @@ export class FigmaClient {
 		accessToken: string,
 	): Promise<void> =>
 		withAxiosErrorTranslation(async () => {
-			await axios.delete<CreateWebhookResponse>(
-				`${getConfig().figma.apiBaseUrl}/v2/webhooks/${webhookId}`,
-				{
-					headers: {
-						['Authorization']: `Bearer ${accessToken}`,
-					},
-				},
+			const url = new URL(
+				`/v2/webhooks/${encodeURIComponent(webhookId)}`,
+				getConfig().figma.apiBaseUrl,
 			);
+
+			await axios.delete<unknown>(url.toString(), {
+				headers: {
+					['Authorization']: `Bearer ${accessToken}`,
+				},
+			});
 		});
 
 	/**
@@ -340,14 +341,16 @@ export class FigmaClient {
 		accessToken: string,
 	): Promise<GetTeamProjectsResponse> =>
 		withAxiosErrorTranslation(async () => {
-			const response = await axios.get<unknown>(
-				`${getConfig().figma.apiBaseUrl}/v1/teams/${teamId}/projects`,
-				{
-					headers: {
-						['Authorization']: `Bearer ${accessToken}`,
-					},
-				},
+			const url = new URL(
+				`/v1/teams/${encodeURIComponent(teamId)}/projects`,
+				getConfig().figma.apiBaseUrl,
 			);
+
+			const response = await axios.get<unknown>(url.toString(), {
+				headers: {
+					['Authorization']: `Bearer ${accessToken}`,
+				},
+			});
 
 			assertSchema(response.data, GET_TEAM_PROJECTS_RESPONSE_SCHEMA);
 

--- a/src/infrastructure/figma/figma-client/figma-client.ts
+++ b/src/infrastructure/figma/figma-client/figma-client.ts
@@ -137,9 +137,8 @@ export class FigmaClient {
 	): Promise<GetFileMetaResponse> =>
 		withAxiosErrorTranslation(async () => {
 			const url = new URL(
-				`${getConfig().figma.apiBaseUrl}/v1/files/${encodeURIComponent(
-					fileKey,
-				)}/meta`,
+				`/v1/files/${encodeURIComponent(fileKey)}/meta`,
+				getConfig().figma.apiBaseUrl,
 			);
 
 			const response = await axios.get<unknown>(url.toString(), {
@@ -167,9 +166,8 @@ export class FigmaClient {
 	): Promise<GetFileResponse> =>
 		withAxiosErrorTranslation(async () => {
 			const url = new URL(
-				`${getConfig().figma.apiBaseUrl}/v1/files/${encodeURIComponent(
-					fileKey,
-				)}`,
+				`/v1/files/${encodeURIComponent(fileKey)}`,
+				getConfig().figma.apiBaseUrl,
 			);
 
 			if (params.ids != null) {

--- a/src/infrastructure/figma/transformers/utils.test.ts
+++ b/src/infrastructure/figma/transformers/utils.test.ts
@@ -45,7 +45,7 @@ describe('utils', () => {
 				fileName: 'Test Design',
 			});
 
-			expect(result).toEqual(`https://www.figma.com/file/${fileKey}/`);
+			expect(result).toEqual(`https://www.figma.com/file/${fileKey}`);
 		});
 
 		it('should return a url for Figma node', () => {
@@ -59,7 +59,7 @@ describe('utils', () => {
 			});
 
 			expect(result).toEqual(
-				`https://www.figma.com/file/${fileKey}/?node-id=1%3A3`,
+				`https://www.figma.com/file/${fileKey}?node-id=1%3A3`,
 			);
 		});
 	});
@@ -73,7 +73,7 @@ describe('utils', () => {
 				fileName: 'Test Design',
 			});
 
-			expect(result).toEqual(`https://www.figma.com/file/${fileKey}/?mode=dev`);
+			expect(result).toEqual(`https://www.figma.com/file/${fileKey}?mode=dev`);
 		});
 
 		it('should return a url for Figma node', () => {
@@ -87,7 +87,7 @@ describe('utils', () => {
 			});
 
 			expect(result).toEqual(
-				`https://www.figma.com/file/${fileKey}/?node-id=1%3A3&mode=dev`,
+				`https://www.figma.com/file/${fileKey}?node-id=1%3A3&mode=dev`,
 			);
 		});
 	});

--- a/src/infrastructure/figma/transformers/utils.ts
+++ b/src/infrastructure/figma/transformers/utils.ts
@@ -6,7 +6,6 @@ import { getConfig } from '../../../config';
  */
 export const buildDesignUrl = ({
 	fileKey,
-	fileName,
 	nodeId,
 }: {
 	fileKey: string;
@@ -14,11 +13,34 @@ export const buildDesignUrl = ({
 	nodeId?: string;
 }): string => {
 	const url = new URL(
-		`${getConfig().figma.webBaseUrl}/file/${fileKey}/${fileName}`,
+		`/file/${encodeURIComponent(fileKey)}/`,
+		getConfig().figma.webBaseUrl,
 	);
 	if (nodeId) {
 		url.searchParams.append('node-id', nodeId);
 	}
+	return url.toString();
+};
+
+/**
+ * Builds an Inspect Mode URL to a Figma design given Figma file/node metadata.
+ */
+export const buildInspectUrl = ({
+	fileKey,
+	nodeId,
+}: {
+	fileKey: string;
+	fileName: string;
+	nodeId?: string;
+}): string => {
+	const url = new URL(
+		`/file/${encodeURIComponent(fileKey)}/`,
+		getConfig().figma.webBaseUrl,
+	);
+	if (nodeId) {
+		url.searchParams.append('node-id', nodeId);
+	}
+	url.searchParams.set('mode', 'dev');
 	return url.toString();
 };
 
@@ -37,31 +59,9 @@ export const buildLiveEmbedUrl = ({
 	nodeId?: string;
 }): string => {
 	const inspectUrl = buildInspectUrl({ fileKey, fileName, nodeId });
-	const url = new URL(`${getConfig().figma.webBaseUrl}/embed`);
+	const url = new URL(`/embed`, getConfig().figma.webBaseUrl);
 	url.searchParams.append('embed_host', 'figma-jira-add-on');
 	url.searchParams.append('url', inspectUrl);
-	return url.toString();
-};
-
-/**
- * Builds an Inspect Mode URL to a Figma design given Figma file/node metadata.
- */
-export const buildInspectUrl = ({
-	fileKey,
-	fileName,
-	nodeId,
-}: {
-	fileKey: string;
-	fileName: string;
-	nodeId?: string;
-}): string => {
-	const url = new URL(
-		`${getConfig().figma.webBaseUrl}/file/${fileKey}/${fileName}`,
-	);
-	if (nodeId) {
-		url.searchParams.append('node-id', nodeId);
-	}
-	url.searchParams.set('mode', 'dev');
 	return url.toString();
 };
 

--- a/src/infrastructure/figma/transformers/utils.ts
+++ b/src/infrastructure/figma/transformers/utils.ts
@@ -13,7 +13,7 @@ export const buildDesignUrl = ({
 	nodeId?: string;
 }): string => {
 	const url = new URL(
-		`/file/${encodeURIComponent(fileKey)}/`,
+		`/file/${encodeURIComponent(fileKey)}`,
 		getConfig().figma.webBaseUrl,
 	);
 	if (nodeId) {
@@ -34,7 +34,7 @@ export const buildInspectUrl = ({
 	nodeId?: string;
 }): string => {
 	const url = new URL(
-		`/file/${encodeURIComponent(fileKey)}/`,
+		`/file/${encodeURIComponent(fileKey)}`,
 		getConfig().figma.webBaseUrl,
 	);
 	if (nodeId) {

--- a/src/infrastructure/jira/inbound-auth/connect-key-server-client.ts
+++ b/src/infrastructure/jira/inbound-auth/connect-key-server-client.ts
@@ -13,9 +13,12 @@ export class ConnectKeyServerClient {
 	 */
 	getAtlassianConnectPublicKey = async (keyId: string): Promise<string> =>
 		withAxiosErrorTranslation(async () => {
-			const response = await axios.get<string>(
-				`${getConfig().jira.connectKeyServerUrl}/${keyId}`,
+			const url = new URL(
+				`/${encodeURIComponent(keyId)}`,
+				getConfig().jira.connectKeyServerUrl,
 			);
+
+			const response = await axios.get<string>(url.toString());
 			return response.data;
 		});
 }

--- a/src/infrastructure/jira/jira-client/jira-client.test.ts
+++ b/src/infrastructure/jira/jira-client/jira-client.test.ts
@@ -19,10 +19,7 @@ import type {
 
 import { SchemaValidationError } from '../../../common/schema-validation';
 import type { ConnectInstallation } from '../../../domain/entities';
-import {
-	generateConnectInstallation,
-	generateFigmaDesignIdentifier,
-} from '../../../domain/entities/testing';
+import { generateConnectInstallation } from '../../../domain/entities/testing';
 import { NotFoundHttpClientError } from '../../http-client-errors';
 
 jest.mock('./jwt-utils');
@@ -74,26 +71,6 @@ describe('JiraClient', () => {
 			await expect(() =>
 				jiraClient.submitDesigns(request, connectInstallation),
 			).rejects.toThrowError(SchemaValidationError);
-		});
-	});
-
-	describe('deleteDesign', () => {
-		it('should delete design', async () => {
-			const designId = generateFigmaDesignIdentifier();
-			jest.spyOn(axios, 'delete').mockResolvedValue(undefined);
-
-			const result = await jiraClient.deleteDesign(
-				designId,
-				connectInstallation,
-			);
-
-			expect(result).toBe(designId);
-			expect(axios.delete).toHaveBeenCalledWith(
-				`${
-					connectInstallation.baseUrl
-				}/rest/designs/1.0/design/${designId.toAtlassianDesignId()}`,
-				defaultExpectedRequestHeaders(),
-			);
 		});
 	});
 

--- a/src/infrastructure/jira/jira-client/jira-client.ts
+++ b/src/infrastructure/jira/jira-client/jira-client.ts
@@ -19,10 +19,7 @@ import type {
 
 import { Duration } from '../../../common/duration';
 import { assertSchema } from '../../../common/schema-validation';
-import type {
-	ConnectInstallation,
-	FigmaDesignIdentifier,
-} from '../../../domain/entities';
+import type { ConnectInstallation } from '../../../domain/entities';
 import { withAxiosErrorTranslation } from '../../axios-utils';
 
 const TOKEN_EXPIRES_IN = Duration.ofMinutes(3);
@@ -56,35 +53,13 @@ class JiraClient {
 
 			const response = await axios.post<unknown>(url.toString(), payload, {
 				headers: new AxiosHeaders().setAuthorization(
-					this.buildAuthorizationHeader(url, 'POST', connectInstallation),
+					this.buildAuthorizationHeader('POST', url, connectInstallation),
 				),
 			});
 
 			assertSchema(response.data, SUBMIT_DESIGNS_RESPONSE_SCHEMA);
 
 			return response.data;
-		});
-
-	/**
-	 * @throws {HttpClientError} An error associated with specific HTTP response status codes.
-	 */
-	deleteDesign = async (
-		designId: FigmaDesignIdentifier,
-		connectInstallation: ConnectInstallation,
-	): Promise<FigmaDesignIdentifier> =>
-		withAxiosErrorTranslation(async () => {
-			const url = new URL(
-				`/rest/designs/1.0/design/${designId.toAtlassianDesignId()}`,
-				connectInstallation.baseUrl,
-			);
-
-			await axios.delete(url.toString(), {
-				headers: new AxiosHeaders().setAuthorization(
-					this.buildAuthorizationHeader(url, 'DELETE', connectInstallation),
-				),
-			});
-
-			return designId;
 		});
 
 	/**
@@ -100,13 +75,13 @@ class JiraClient {
 	): Promise<GetIssueResponse> =>
 		withAxiosErrorTranslation(async () => {
 			const url = new URL(
-				`/rest/agile/1.0/issue/${issueIdOrKey}`,
+				`/rest/agile/1.0/issue/${encodeURIComponent(issueIdOrKey)}`,
 				connectInstallation.baseUrl,
 			);
 
 			const response = await axios.get<unknown>(url.toString(), {
 				headers: new AxiosHeaders().setAuthorization(
-					this.buildAuthorizationHeader(url, 'GET', connectInstallation),
+					this.buildAuthorizationHeader('GET', url, connectInstallation),
 				),
 			});
 
@@ -129,14 +104,16 @@ class JiraClient {
 	): Promise<GetIssuePropertyResponse> =>
 		withAxiosErrorTranslation(async () => {
 			const url = new URL(
-				`/rest/api/2/issue/${issueIdOrKey}/properties/${propertyKey}`,
+				`/rest/api/2/issue/${encodeURIComponent(
+					issueIdOrKey,
+				)}/properties/${encodeURIComponent(propertyKey)}`,
 				connectInstallation.baseUrl,
 			);
 
 			const response = await axios.get<unknown>(url.toString(), {
 				headers: new AxiosHeaders()
 					.setAuthorization(
-						this.buildAuthorizationHeader(url, 'GET', connectInstallation),
+						this.buildAuthorizationHeader('GET', url, connectInstallation),
 					)
 					.setAccept('application/json'),
 			});
@@ -164,14 +141,16 @@ class JiraClient {
 	): Promise<void> =>
 		withAxiosErrorTranslation(async () => {
 			const url = new URL(
-				`/rest/api/2/issue/${issueIdOrKey}/properties/${propertyKey}`,
+				`/rest/api/2/issue/${encodeURIComponent(
+					issueIdOrKey,
+				)}/properties/${encodeURIComponent(propertyKey)}`,
 				connectInstallation.baseUrl,
 			);
 
-			await axios.put(url.toString(), JSON.stringify(value), {
+			await axios.put<unknown>(url.toString(), JSON.stringify(value), {
 				headers: new AxiosHeaders()
 					.setAuthorization(
-						this.buildAuthorizationHeader(url, 'PUT', connectInstallation),
+						this.buildAuthorizationHeader('PUT', url, connectInstallation),
 					)
 					.setAccept('application/json')
 					.setContentType('application/json'),
@@ -192,13 +171,15 @@ class JiraClient {
 	): Promise<void> =>
 		withAxiosErrorTranslation(async () => {
 			const url = new URL(
-				`/rest/api/2/issue/${issueIdOrKey}/properties/${propertyKey}`,
+				`/rest/api/2/issue/${encodeURIComponent(
+					issueIdOrKey,
+				)}/properties/${encodeURIComponent(propertyKey)}`,
 				connectInstallation.baseUrl,
 			);
 
-			await axios.delete(url.toString(), {
+			await axios.delete<unknown>(url.toString(), {
 				headers: new AxiosHeaders().setAuthorization(
-					this.buildAuthorizationHeader(url, 'DELETE', connectInstallation),
+					this.buildAuthorizationHeader('DELETE', url, connectInstallation),
 				),
 			});
 		});
@@ -217,14 +198,16 @@ class JiraClient {
 	): Promise<void> =>
 		withAxiosErrorTranslation(async () => {
 			const url = new URL(
-				`/rest/atlassian-connect/1/addons/${connectInstallation.key}/properties/${propertyKey}`,
+				`/rest/atlassian-connect/1/addons/${encodeURIComponent(
+					connectInstallation.key,
+				)}/properties/${encodeURIComponent(propertyKey)}`,
 				connectInstallation.baseUrl,
 			);
 
-			await axios.put(url.toString(), JSON.stringify(value), {
+			await axios.put<unknown>(url.toString(), JSON.stringify(value), {
 				headers: new AxiosHeaders()
 					.setAuthorization(
-						this.buildAuthorizationHeader(url, 'PUT', connectInstallation),
+						this.buildAuthorizationHeader('PUT', url, connectInstallation),
 					)
 					.setAccept('application/json')
 					.setContentType('application/json'),
@@ -250,7 +233,7 @@ class JiraClient {
 
 			const response = await axios.post<unknown>(url.toString(), payload, {
 				headers: new AxiosHeaders().setAuthorization(
-					this.buildAuthorizationHeader(url, 'POST', connectInstallation),
+					this.buildAuthorizationHeader('POST', url, connectInstallation),
 				),
 			});
 
@@ -260,8 +243,8 @@ class JiraClient {
 		});
 
 	private buildAuthorizationHeader(
-		url: URL,
 		method: Method,
+		url: URL,
 		{
 			key: connectAppKey,
 			sharedSecret: connectSharedSecret,

--- a/src/infrastructure/jira/jira-service.test.ts
+++ b/src/infrastructure/jira/jira-service.test.ts
@@ -33,7 +33,6 @@ import {
 import {
 	generateAtlassianDesign,
 	generateConnectInstallation,
-	generateFigmaDesignIdentifier,
 	generateFigmaDesignUrl,
 	generateJiraIssue,
 	generateJiraIssueAri,
@@ -226,25 +225,6 @@ describe('JiraService', () => {
 
 			expect(jiraService.submitDesigns).toBeCalledWith(
 				[{ design, addAssociations, removeAssociations }],
-				connectInstallation,
-			);
-		});
-	});
-
-	describe('deleteDesign', () => {
-		it('should delete design', async () => {
-			const designId = generateFigmaDesignIdentifier();
-			const connectInstallation = generateConnectInstallation();
-			jest.spyOn(jiraClient, 'deleteDesign').mockResolvedValue(designId);
-
-			const result = await jiraService.deleteDesign(
-				designId,
-				connectInstallation,
-			);
-
-			expect(result).toBe(designId);
-			expect(jiraClient.deleteDesign).toHaveBeenCalledWith(
-				designId,
 				connectInstallation,
 			);
 		});

--- a/src/infrastructure/jira/jira-service.test.ts
+++ b/src/infrastructure/jira/jira-service.test.ts
@@ -271,10 +271,13 @@ describe('JiraService', () => {
 				connectInstallation,
 			);
 
+			const expectedValue = new URL(design.url);
+			expectedValue.pathname += `/${encodeURIComponent(design.displayName)}`;
+
 			expect(jiraClient.setIssueProperty).toHaveBeenCalledWith(
 				issueId,
 				issuePropertyKeys.ATTACHED_DESIGN_URL,
-				design.url,
+				expectedValue.toString(),
 				connectInstallation,
 			);
 		});
@@ -414,7 +417,6 @@ describe('JiraService', () => {
 			const designUrlInDifferentFormat = generateFigmaDesignUrl({
 				fileKey: FigmaDesignIdentifier.fromAtlassianDesignId(design.id).fileKey,
 				nodeId: FigmaDesignIdentifier.fromAtlassianDesignId(design.id).nodeId,
-				fileName: design.displayName,
 				mode: 'dev',
 			});
 			const otherDesignPropertyValue: AttachedDesignUrlV2IssuePropertyValue[] =
@@ -662,7 +664,6 @@ describe('JiraService', () => {
 			const designUrlInDifferentFormat = generateFigmaDesignUrl({
 				fileKey: FigmaDesignIdentifier.fromAtlassianDesignId(design.id).fileKey,
 				nodeId: FigmaDesignIdentifier.fromAtlassianDesignId(design.id).nodeId,
-				fileName: design.displayName,
 				mode: 'dev',
 			});
 

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -16,6 +16,7 @@ import {
 	SchemaValidationError,
 } from '../../common/schema-validation';
 import { ensureString } from '../../common/string-utils';
+import { appendToPathname } from '../../common/url-utils';
 import type {
 	AtlassianDesign,
 	ConnectInstallation,
@@ -209,7 +210,7 @@ class JiraService {
 	 */
 	setAttachedDesignUrlInIssuePropertiesIfMissing = async (
 		issueIdOrKey: string,
-		{ url }: AtlassianDesign,
+		{ url, displayName }: AtlassianDesign,
 		connectInstallation: ConnectInstallation,
 	): Promise<void> => {
 		try {
@@ -220,10 +221,16 @@ class JiraService {
 			);
 		} catch (error) {
 			if (error instanceof NotFoundHttpClientError) {
+				// Include Design name into the URL for compatibility with the existing "Jira" widget in Figma.
+				const urlWithFileName = appendToPathname(
+					new URL(url),
+					encodeURIComponent(displayName),
+				);
+
 				await jiraClient.setIssueProperty(
 					issueIdOrKey,
 					issuePropertyKeys.ATTACHED_DESIGN_URL,
-					url,
+					urlWithFileName.toString(),
 					connectInstallation,
 				);
 			} else {

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -53,7 +53,7 @@ export enum ConfigurationStatus {
 export const issuePropertyKeys = {
 	ATTACHED_DESIGN_URL: 'attached-design-url',
 	ATTACHED_DESIGN_URL_V2: 'attached-design-url-v2',
-	INGESTED_DESIGN_URLS: 'figma-for-jira:ingested-design-urls',
+	INGESTED_DESIGN_URLS: 'figma-for-jira_ingested-design-urls',
 };
 
 export const JIRA_ADMIN_GLOBAL_PERMISSION = 'ADMINISTER';
@@ -93,13 +93,6 @@ class JiraService {
 		);
 
 		this.throwIfSubmitDesignResponseHasErrors(response);
-	};
-
-	deleteDesign = async (
-		designId: FigmaDesignIdentifier,
-		connectInstallation: ConnectInstallation,
-	): Promise<FigmaDesignIdentifier> => {
-		return await jiraClient.deleteDesign(designId, connectInstallation);
 	};
 
 	getIssue = async (

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -221,7 +221,7 @@ class JiraService {
 			);
 		} catch (error) {
 			if (error instanceof NotFoundHttpClientError) {
-				// Include Design name into the URL for compatibility with the existing "Jira" widget in Figma.
+				// Include the design name into the URL for compatibility with the existing "Jira" widget in Figma.
 				const urlWithFileName = appendToPathname(
 					new URL(url),
 					encodeURIComponent(displayName),

--- a/src/web/routes/entities/integration.test.ts
+++ b/src/web/routes/entities/integration.test.ts
@@ -8,6 +8,7 @@ import type {
 } from './types';
 
 import app from '../../../app';
+import { appendToPathname } from '../../../common/url-utils';
 import { getConfig } from '../../../config';
 import type { ConnectInstallation } from '../../../domain/entities';
 import {
@@ -156,12 +157,10 @@ describe('/entities', () => {
 			const issueAri = generateJiraIssueAri({ issueId: issue.id });
 			const inputFigmaDesignUrl = generateFigmaDesignUrl({
 				fileKey,
-				fileName,
 				mode: 'dev',
 			});
 			const normalizedFigmaDesignUrl = generateFigmaDesignUrl({
 				fileKey,
-				fileName,
 			});
 			const fileMetaResponse = generateGetFileMetaResponse({
 				name: fileName,
@@ -227,7 +226,12 @@ describe('/entities', () => {
 				baseUrl: connectInstallation.baseUrl,
 				issueId: issue.id,
 				propertyKey: issuePropertyKeys.ATTACHED_DESIGN_URL,
-				request: JSON.stringify(normalizedFigmaDesignUrl),
+				request: JSON.stringify(
+					appendToPathname(
+						new URL(normalizedFigmaDesignUrl),
+						encodeURIComponent(atlassianDesign.displayName),
+					).toString(),
+				),
 			});
 			mockJiraGetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
@@ -302,13 +306,11 @@ describe('/entities', () => {
 			const issueAri = generateJiraIssueAri({ issueId: issue.id });
 			const inputFigmaDesignUrl = generateFigmaDesignUrl({
 				fileKey,
-				fileName,
 				nodeId,
 				mode: 'dev',
 			});
 			const normalizedFigmaDesignUrl = generateFigmaDesignUrl({
 				fileKey,
-				fileName,
 				nodeId,
 			});
 			const fileResponse = generateGetFileResponseWithNode({
@@ -378,7 +380,12 @@ describe('/entities', () => {
 				baseUrl: connectInstallation.baseUrl,
 				issueId: issue.id,
 				propertyKey: issuePropertyKeys.ATTACHED_DESIGN_URL,
-				request: JSON.stringify(normalizedFigmaDesignUrl),
+				request: JSON.stringify(
+					appendToPathname(
+						new URL(normalizedFigmaDesignUrl),
+						encodeURIComponent(atlassianDesign.displayName),
+					).toString(),
+				),
 			});
 			mockJiraGetIssuePropertyEndpoint({
 				baseUrl: connectInstallation.baseUrl,
@@ -497,7 +504,6 @@ describe('/entities', () => {
 			const issueAri = generateJiraIssueAri({ issueId });
 			const inputFigmaDesignUrl = generateFigmaDesignUrl({
 				fileKey,
-				fileName: generateFigmaFileName(),
 				mode: 'dev',
 			});
 
@@ -568,7 +574,6 @@ describe('/entities', () => {
 			const devResourceId = uuidv4();
 			const figmaDesignUrl = generateFigmaDesignUrl({
 				fileKey,
-				fileName,
 			});
 			const fileMetaResponse = generateGetFileMetaResponse({
 				name: fileName,
@@ -710,7 +715,6 @@ describe('/entities', () => {
 			const devResourceId = uuidv4();
 			const figmaDesignUrl = generateFigmaDesignUrl({
 				fileKey,
-				fileName,
 				nodeId,
 			});
 			const fileResponse = generateGetFileResponseWithNode({


### PR DESCRIPTION
## Changes

- **feat:** Exclude a Figma File name from the design URL as it is not required and is subject to change. The app still include File name in the URL written to the `attached-design-url` Issue Property for compatibility with "Jira" widget in Figma (which extracts a name from the URL).
- **feat:** Encode dynamic URL path parameters using `encodeURIComponent` when construct URLs (e.g., in API clients).
- **test:** Add unit tests for utility functions responsible for constructing Figma URLs.