### PR TITLE
NONE: Use a feature flag to control the availability of old panel and admin UI

### DIFF
--- a/src/atlassian-connect.ts
+++ b/src/atlassian-connect.ts
@@ -89,17 +89,35 @@ export const connectAppDescriptor = {
 					value: APP_NAME,
 				},
 				location: 'admin_plugins_menu',
+				conditions: [
+					{
+						condition: 'feature_flag_service_flag',
+						params: {
+							featureKey: 'issue-view-designs-panel',
+						},
+					},
+				],
 			},
 		],
 		adminPages: [
 			{
-				key: 'figma-admin-configure',
+				key: 'figma-addon-admin-section-configure',
 				name: {
 					value: 'Configure',
 				},
 				location: 'admin_plugins_menu/figma-addon-admin-section',
 				url: '/static/admin',
-				conditions: [{ condition: 'user_is_admin' }],
+				conditions: [
+					{
+						condition: 'user_is_admin',
+					},
+					{
+						condition: 'feature_flag_service_flag',
+						params: {
+							featureKey: 'issue-view-designs-panel',
+						},
+					},
+				],
 			},
 		],
 		/**
@@ -119,8 +137,9 @@ export const connectAppDescriptor = {
 				conditions: [
 					{
 						condition: 'feature_flag_service_flag',
+						invert: true,
 						params: {
-							featureKey: 'figma-for-jira-upgrade-test',
+							featureKey: 'issue-view-designs-panel',
 						},
 					},
 				],


### PR DESCRIPTION
## Changes

- **feat:** Use the `issue-view-designs-panel` feature flag to manage the transition from the old to new experience.
- **feat:** Do not show admin UI when the `issue-view-designs-panel` feature is disabled.
