### PR TITLE
MDTZ-1186: Exclude unnecessary child nodes from Figma API response

### DIFF
--- a/src/infrastructure/figma/figma-client/types.ts
+++ b/src/infrastructure/figma/figma-client/types.ts
@@ -15,6 +15,13 @@ export type GetMeResponse = {
 };
 
 export type GetFileParams = {
+	/**
+	 * @remarks
+	 * `0` is not documented but a fully supported value when used with the `ids` parameter. If `depth` is:
+	 * - >= 1, it is interpreted relative to the document root.
+	 * - 0, it is interpreted as relative to the target node(s) with IDs from the `ids` parameter. Consider using 0,
+	 * 	when you need to exclude the children of the target nodes.
+	 */
 	readonly depth?: number;
 	readonly ids?: string[];
 	readonly node_last_modified?: boolean;

--- a/src/infrastructure/figma/figma-service.ts
+++ b/src/infrastructure/figma/figma-service.ts
@@ -99,6 +99,7 @@ export class FigmaService {
 				fileKey,
 				{
 					ids: designIds.map((id) => id.nodeId).filter(isString),
+					depth: 0, // Exclude children of the target nodes(s) to avoid a massive response payload and high network latency.
 					node_last_modified: true,
 				},
 				accessToken,
@@ -315,6 +316,7 @@ export class FigmaService {
 			fileKey,
 			{
 				ids: [nodeId],
+				depth: 0, // Exclude children of the target node to avoid a massive response payload and high network latency.
 				node_last_modified: true,
 			},
 			credentials.accessToken,

--- a/src/web/routes/entities/integration.test.ts
+++ b/src/web/routes/entities/integration.test.ts
@@ -339,6 +339,7 @@ describe('/entities', () => {
 				accessToken: figmaUserCredentials.accessToken,
 				query: {
 					ids: nodeId,
+					depth: '0',
 					node_last_modified: 'true',
 				},
 				response: fileResponse,
@@ -746,7 +747,11 @@ describe('/entities', () => {
 				baseUrl: getConfig().figma.apiBaseUrl,
 				fileKey,
 				accessToken: figmaUserCredentials.accessToken,
-				query: { ids: nodeId, node_last_modified: 'true' },
+				query: {
+					ids: nodeId,
+					depth: '0',
+					node_last_modified: 'true',
+				},
 				response: fileResponse,
 			});
 			mockJiraGetIssueEndpoint({
@@ -869,7 +874,6 @@ describe('/entities', () => {
 				baseUrl: getConfig().figma.apiBaseUrl,
 				fileKey,
 				accessToken: figmaUserCredentials.accessToken,
-				query: { depth: '1' },
 				response: fileMetaResponse,
 			});
 			mockJiraGetIssueEndpoint({

--- a/src/web/routes/figma/integration.test.ts
+++ b/src/web/routes/figma/integration.test.ts
@@ -181,6 +181,7 @@ describe('/figma', () => {
 					fileKey: fileKey,
 					query: {
 						ids: nodeIds.join(','),
+						depth: '0',
 						node_last_modified: 'true',
 					},
 					response: fileResponse,
@@ -255,6 +256,7 @@ describe('/figma', () => {
 					fileKey: fileKey,
 					query: {
 						ids: nodeIds.join(','),
+						depth: '0',
 						node_last_modified: 'true',
 					},
 					response: fileResponse,
@@ -318,6 +320,7 @@ describe('/figma', () => {
 					fileKey: fileKey,
 					query: {
 						ids: nodeIds.join(','),
+						depth: '0',
 						node_last_modified: 'true',
 					},
 					status: HttpStatusCode.InternalServerError,
@@ -352,6 +355,7 @@ describe('/figma', () => {
 					fileKey: fileKey,
 					query: {
 						ids: nodeIds.join(','),
+						depth: '0',
 						node_last_modified: 'true',
 					},
 					status: HttpStatusCode.Unauthorized,
@@ -408,6 +412,7 @@ describe('/figma', () => {
 					fileKey: fileKey,
 					query: {
 						ids: nodeIds.join(','),
+						depth: '0',
 						node_last_modified: 'true',
 					},
 					status: HttpStatusCode.InternalServerError,


### PR DESCRIPTION
## Changes

- **feat:** Use the `depth=0` query parameter with the `GET /v1/files/:key` endpoint to exclude unnecessary child nodes, and therefore, reduce a response payload and network latency.