### PR TITLE
NONE: Exclude potentially sensitive information from HTTP request/response logs

### DIFF
--- a/src/web/middleware/http-logger-middleware.ts
+++ b/src/web/middleware/http-logger-middleware.ts
@@ -1,9 +1,24 @@
+import type { SerializedRequest, SerializedResponse } from 'pino';
 import { pinoHttp } from 'pino-http';
 
 import { getLogger } from '../../infrastructure';
 
 export const httpLoggerMiddleware = pinoHttp({
 	logger: getLogger(),
+	// Exclude potentially sensitive information from logs (e.g., HTTP headers, remote address, etc.).
+	// See for more detail:
+	// - https://github.com/pinojs/pino-http#custom-serializers
+	// - https://github.com/pinojs/pino-http/issues/5
+	serializers: {
+		req: (req: SerializedRequest) => ({
+			id: req.id,
+			method: req.method,
+			url: req.url,
+		}),
+		res: (res: SerializedResponse) => ({
+			statusCode: res.statusCode,
+		}),
+	},
 	autoLogging: {
 		ignore(req) {
 			return req.url === '/healthcheck';


### PR DESCRIPTION
## Changes

- **feat:** Exclude potentially sensitive information from HTTP request/response logs (e.g., HTTP headers, remote address, etc.).

## Remarks

The app will log the following information:

- Request
  - ID
  - HTTP method
  - URL
- Responses
  - HTTP Code
- Response time
- Thrown error (all fields)

An example of a successful `/atlassian-connect.json` request:

<img width="389" alt="image" src="https://github.com/atlassian-labs/figma-for-jira/assets/141381034/0e1e2d01-3af4-421e-994c-8f5f360b2039">

An example of an unsuccessful `/admin/teams/:teamId/connect` request:

<img width="1126" alt="image" src="https://github.com/atlassian-labs/figma-for-jira/assets/141381034/2d58e4c2-6143-40ce-b26a-b8b82903baf1">