### PR TITLE
NONE: Improve webhook reliability

### DIFF
--- a/src/common/predicates.test.ts
+++ b/src/common/predicates.test.ts
@@ -1,0 +1,17 @@
+import { isNotNullOrUndefined } from './predicates';
+import { isString } from './string-utils';
+
+describe('predicates', () => {
+	describe('isNotNullOrUndefined', () => {
+		it('should return `true` when value is not `null` or `undefined`', () => {
+			expect(isNotNullOrUndefined('test')).toBe(true);
+		});
+
+		it.each([undefined, null])(
+			'should return `false` when value is `%s`',
+			(value) => {
+				expect(isString(value)).toBe(false);
+			},
+		);
+	});
+});

--- a/src/common/predicates.ts
+++ b/src/common/predicates.ts
@@ -1,0 +1,8 @@
+/**
+ * Returns true of the value is not `null` or `undefined`.
+ */
+export const isNotNullOrUndefined = <T>(
+	value: T | null | undefined,
+): value is T => {
+	return value != null;
+};

--- a/src/infrastructure/figma/figma-service.test.ts
+++ b/src/infrastructure/figma/figma-service.test.ts
@@ -40,6 +40,7 @@ import {
 } from '../../domain/entities/testing';
 import {
 	ForbiddenHttpClientError,
+	HttpClientError,
 	NotFoundHttpClientError,
 } from '../http-client-errors';
 
@@ -193,6 +194,21 @@ describe('FigmaService', () => {
 			await expect(() =>
 				figmaService.getDesign(designId, MOCK_CONNECT_USER_INFO),
 			).rejects.toThrow();
+		});
+
+		it('should throw when a request to a Figma api fails', async () => {
+			const designId = generateFigmaDesignIdentifier();
+			const credentials = generateFigmaOAuth2UserCredentials();
+			const error = new HttpClientError('Figma API failed');
+
+			jest
+				.spyOn(figmaAuthService, 'getCredentials')
+				.mockResolvedValue(credentials);
+			jest.spyOn(figmaClient, 'getFileMeta').mockRejectedValue(error);
+
+			await expect(
+				figmaService.getDesign(designId, MOCK_CONNECT_USER_INFO),
+			).rejects.toStrictEqual(error);
 		});
 	});
 

--- a/src/infrastructure/figma/figma-service.test.ts
+++ b/src/infrastructure/figma/figma-service.test.ts
@@ -16,6 +16,7 @@ import {
 	generateFrameNode,
 	generateGetDevResourcesResponse,
 	generateGetFileMetaResponse,
+	generateGetFileResponse,
 	generateGetFileResponseWithNode,
 	generateGetFileResponseWithNodes,
 } from './figma-client/testing';
@@ -23,7 +24,7 @@ import { figmaService } from './figma-service';
 import {
 	transformFileMetaToAtlassianDesign,
 	transformFileToAtlassianDesign,
-	transformNodeToAtlassianDesign,
+	tryTransformNodeToAtlassianDesign,
 } from './transformers';
 
 import * as configModule from '../../config';
@@ -31,6 +32,7 @@ import { mockConfig } from '../../config/testing';
 import {
 	generateConnectUserInfo,
 	generateFigmaDesignIdentifier,
+	generateFigmaFileKey,
 	generateFigmaNodeId,
 	generateFigmaOAuth2UserCredentials,
 	generateJiraIssueKey,
@@ -165,7 +167,7 @@ describe('FigmaService', () => {
 				MOCK_CONNECT_USER_INFO,
 			);
 
-			const expectedEntity = transformNodeToAtlassianDesign({
+			const expectedEntity = tryTransformNodeToAtlassianDesign({
 				fileKey: designId.fileKey,
 				nodeId: designId.nodeId!,
 				fileResponse,
@@ -176,36 +178,37 @@ describe('FigmaService', () => {
 			});
 		});
 
-		it('should throw when a request to a figma api fails', async () => {
-			const designId = generateFigmaDesignIdentifier();
+		it('should throw when node is not found', async () => {
+			const designId = generateFigmaDesignIdentifier({
+				nodeId: generateFigmaNodeId(),
+			});
 			const credentials = generateFigmaOAuth2UserCredentials();
-			const error = new Error('Figma API failed');
+			const fileResponse = generateGetFileResponse();
 
 			jest
 				.spyOn(figmaAuthService, 'getCredentials')
 				.mockResolvedValue(credentials);
-			jest.spyOn(figmaClient, 'getFileMeta').mockRejectedValue(error);
+			jest.spyOn(figmaClient, 'getFile').mockResolvedValue(fileResponse);
 
-			await expect(
+			await expect(() =>
 				figmaService.getDesign(designId, MOCK_CONNECT_USER_INFO),
-			).rejects.toStrictEqual(error);
+			).rejects.toThrow();
 		});
 	});
 
-	describe('getDesignsFromSameFile', () => {
-		it('should return valid design entities for design ids with and without node ids', async () => {
-			const nodeId1 = generateFigmaNodeId();
-			const node1 = generateFrameNode({ id: nodeId1 });
-			const nodeId2 = generateFigmaNodeId();
-			const node2 = generateFrameNode({ id: nodeId2 });
-			const designIdWithoutNode = generateFigmaDesignIdentifier();
+	describe('getAvailableDesignsFromSameFile', () => {
+		it('should return designs for Figma file and nodes', async () => {
+			const node1 = generateFrameNode({ id: '1:1' });
+			const node2 = generateFrameNode({ id: '1:2' });
+			const fileKey = generateFigmaFileKey();
+			const designIdWithoutNode = generateFigmaDesignIdentifier({ fileKey });
 			const designIdWithNode1 = generateFigmaDesignIdentifier({
-				fileKey: designIdWithoutNode.fileKey,
-				nodeId: nodeId1,
+				fileKey,
+				nodeId: node1.id,
 			});
 			const designIdWithNode2 = generateFigmaDesignIdentifier({
-				fileKey: designIdWithoutNode.fileKey,
-				nodeId: nodeId2,
+				fileKey,
+				nodeId: node2.id,
 			});
 			const credentials = generateFigmaOAuth2UserCredentials();
 			const mockResponse = generateGetFileResponseWithNodes({
@@ -217,35 +220,92 @@ describe('FigmaService', () => {
 				.mockResolvedValue(credentials);
 			jest.spyOn(figmaClient, 'getFile').mockResolvedValue(mockResponse);
 
-			const result = await figmaService.getDesignsFromSameFile(
+			const result = await figmaService.getAvailableDesignsFromSameFile(
 				[designIdWithoutNode, designIdWithNode1, designIdWithNode2],
 				MOCK_CONNECT_USER_INFO,
 			);
 
-			const expectedResult = [
+			expect(result).toStrictEqual([
 				transformFileToAtlassianDesign({
 					fileKey: designIdWithoutNode.fileKey,
 					fileResponse: mockResponse,
 				}),
-				transformNodeToAtlassianDesign({
+				tryTransformNodeToAtlassianDesign({
 					fileKey: designIdWithNode1.fileKey,
 					nodeId: designIdWithNode1.nodeId!,
 					fileResponse: mockResponse,
 				}),
-				transformNodeToAtlassianDesign({
+				tryTransformNodeToAtlassianDesign({
 					fileKey: designIdWithNode2.fileKey,
 					nodeId: designIdWithNode2.nodeId!,
 					fileResponse: mockResponse,
 				}),
-			];
+			]);
+		});
 
-			expect(result).toStrictEqual(expectedResult);
+		it('should return empty array if Figma dile does not exist', async () => {
+			const designId = generateFigmaDesignIdentifier();
+			const credentials = generateFigmaOAuth2UserCredentials();
+			const error = new NotFoundHttpClientError('Figma API failed');
+
+			jest
+				.spyOn(figmaAuthService, 'getCredentials')
+				.mockResolvedValue(credentials);
+			jest.spyOn(figmaClient, 'getFile').mockRejectedValue(error);
+
+			const result = await figmaService.getAvailableDesignsFromSameFile(
+				[designId],
+				MOCK_CONNECT_USER_INFO,
+			);
+
+			expect(result).toEqual([]);
+		});
+
+		it('should return designs excluding designs for non-existent Figma nodes', async () => {
+			const node1 = generateFrameNode({ id: '1:1' });
+			const node2 = generateFrameNode({ id: '1:2' });
+			const fileKey = generateFigmaFileKey();
+			const designIdWithoutNode = generateFigmaDesignIdentifier({ fileKey });
+			const designIdWithNode1 = generateFigmaDesignIdentifier({
+				fileKey,
+				nodeId: node1.id,
+			});
+			const designIdWithNode2 = generateFigmaDesignIdentifier({
+				fileKey,
+				nodeId: node2.id,
+			});
+			const credentials = generateFigmaOAuth2UserCredentials();
+			const mockResponse = generateGetFileResponseWithNodes({
+				nodes: [node1],
+			});
+
+			jest
+				.spyOn(figmaAuthService, 'getCredentials')
+				.mockResolvedValue(credentials);
+			jest.spyOn(figmaClient, 'getFile').mockResolvedValue(mockResponse);
+
+			const result = await figmaService.getAvailableDesignsFromSameFile(
+				[designIdWithoutNode, designIdWithNode1, designIdWithNode2],
+				MOCK_CONNECT_USER_INFO,
+			);
+
+			expect(result).toStrictEqual([
+				transformFileToAtlassianDesign({
+					fileKey: designIdWithoutNode.fileKey,
+					fileResponse: mockResponse,
+				}),
+				tryTransformNodeToAtlassianDesign({
+					fileKey: designIdWithNode1.fileKey,
+					nodeId: designIdWithNode1.nodeId!,
+					fileResponse: mockResponse,
+				}),
+			]);
 		});
 
 		it('should immediately return an empty array if passed an empty design ids array', async () => {
 			jest.spyOn(figmaAuthService, 'getCredentials');
 
-			const result = await figmaService.getDesignsFromSameFile(
+			const result = await figmaService.getAvailableDesignsFromSameFile(
 				[],
 				MOCK_CONNECT_USER_INFO,
 			);
@@ -263,24 +323,12 @@ describe('FigmaService', () => {
 			jest.spyOn(figmaAuthService, 'getCredentials');
 
 			await expect(
-				figmaService.getDesignsFromSameFile(designIds, MOCK_CONNECT_USER_INFO),
+				figmaService.getAvailableDesignsFromSameFile(
+					designIds,
+					MOCK_CONNECT_USER_INFO,
+				),
 			).rejects.toThrow();
 			expect(figmaAuthService.getCredentials).not.toBeCalled();
-		});
-
-		it('should throw when a request to a figma api fails', async () => {
-			const designId = generateFigmaDesignIdentifier();
-			const credentials = generateFigmaOAuth2UserCredentials();
-			const mockError = new Error('Figma API failed');
-
-			jest
-				.spyOn(figmaAuthService, 'getCredentials')
-				.mockResolvedValue(credentials);
-			jest.spyOn(figmaClient, 'getFile').mockRejectedValue(mockError);
-
-			await expect(
-				figmaService.getDesignsFromSameFile([designId], MOCK_CONNECT_USER_INFO),
-			).rejects.toStrictEqual(mockError);
 		});
 	});
 

--- a/src/infrastructure/figma/transformers/figma-node-transformer.test.ts
+++ b/src/infrastructure/figma/transformers/figma-node-transformer.test.ts
@@ -1,8 +1,9 @@
 import {
-	getNodeDataFrom,
+	findNodeDataInFile,
 	mapNodeStatusToDevStatus,
 	mapNodeTypeToDesignType,
 	transformNodeToAtlassianDesign,
+	tryTransformNodeToAtlassianDesign,
 } from './figma-node-transformer';
 import {
 	buildDesignUrl,
@@ -40,6 +41,32 @@ describe('transformNodeToAtlassianDesign', () => {
 		jest.restoreAllMocks();
 	});
 
+	it('should throw null if node is not found', () => {
+		const fileKey = generateFigmaFileKey();
+		const fileResponse = generateGetFileResponse({
+			document: {
+				...MOCK_DOCUMENT,
+			},
+		});
+
+		expect(() =>
+			transformNodeToAtlassianDesign({
+				fileKey,
+				nodeId: '100:1',
+				fileResponse,
+			}),
+		).toThrow();
+	});
+});
+
+describe('tryTransformNodeToAtlassianDesign', () => {
+	beforeEach(() => {
+		(configModule.getConfig as jest.Mock).mockReturnValue(mockConfig);
+	});
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
 	it('should correctly map to atlassian design', () => {
 		const fileKey = generateFigmaFileKey();
 		const node = generateChildNode({ id: '100:1' });
@@ -67,7 +94,7 @@ describe('transformNodeToAtlassianDesign', () => {
 			lastModified: irrelevantLastModified,
 		});
 
-		const result = transformNodeToAtlassianDesign({
+		const result = tryTransformNodeToAtlassianDesign({
 			fileKey,
 			nodeId: node.id,
 			fileResponse,
@@ -99,9 +126,26 @@ describe('transformNodeToAtlassianDesign', () => {
 			),
 		});
 	});
+
+	it('should return null if node is not found', () => {
+		const fileKey = generateFigmaFileKey();
+		const fileResponse = generateGetFileResponse({
+			document: {
+				...MOCK_DOCUMENT,
+			},
+		});
+
+		const result = tryTransformNodeToAtlassianDesign({
+			fileKey,
+			nodeId: '100:1',
+			fileResponse,
+		});
+
+		expect(result).toBeNull();
+	});
 });
 
-describe('getNodeDataFrom', () => {
+describe('findNodeDataInFile', () => {
 	it('should return node with its lastModified if node has lastModified', () => {
 		const irrelevantLastModified = new Date('2023-06-15T00:00:00Z');
 		const targetNode = generateFrameNode({
@@ -127,7 +171,7 @@ describe('getNodeDataFrom', () => {
 			lastModified: irrelevantLastModified,
 		});
 
-		const result = getNodeDataFrom(fileResponse, targetNode.id);
+		const result = findNodeDataInFile(fileResponse, targetNode.id);
 
 		expect(result).toStrictEqual({
 			node: targetNode,
@@ -169,7 +213,7 @@ describe('getNodeDataFrom', () => {
 			lastModified: irrelevantLastModified,
 		});
 
-		const result = getNodeDataFrom(fileResponse, targetNode.id);
+		const result = findNodeDataInFile(fileResponse, targetNode.id);
 
 		expect(result).toStrictEqual({
 			node: targetNode,
@@ -193,7 +237,7 @@ describe('getNodeDataFrom', () => {
 			},
 		});
 
-		const result = getNodeDataFrom(fileResponse, targetNode.id);
+		const result = findNodeDataInFile(fileResponse, targetNode.id);
 
 		expect(result).toStrictEqual({
 			node: targetNode,
@@ -228,7 +272,7 @@ describe('getNodeDataFrom', () => {
 			},
 		});
 
-		const result = getNodeDataFrom(fileResponse, targetNode.id);
+		const result = findNodeDataInFile(fileResponse, targetNode.id);
 
 		expect(result).toStrictEqual({
 			node: targetNode,
@@ -271,7 +315,7 @@ describe('getNodeDataFrom', () => {
 			lastModified: expectedLastModified,
 		});
 
-		const result = getNodeDataFrom(fileResponse, targetNode.id);
+		const result = findNodeDataInFile(fileResponse, targetNode.id);
 
 		expect(result).toStrictEqual({
 			node: targetNode,
@@ -296,7 +340,7 @@ describe('getNodeDataFrom', () => {
 			},
 		});
 
-		const result = getNodeDataFrom(fileResponse, targetNode.id);
+		const result = findNodeDataInFile(fileResponse, targetNode.id);
 
 		expect(result).toStrictEqual({
 			node: targetNode,
@@ -306,7 +350,7 @@ describe('getNodeDataFrom', () => {
 		});
 	});
 
-	it('should throw if node is not found', () => {
+	it('should return null node is not found', () => {
 		const targetNode = generateChildNode();
 		const fileResponse = generateGetFileResponse({
 			document: {
@@ -315,7 +359,9 @@ describe('getNodeDataFrom', () => {
 			},
 		});
 
-		expect(() => getNodeDataFrom(fileResponse, targetNode.id)).toThrow();
+		const result = findNodeDataInFile(fileResponse, targetNode.id);
+
+		expect(result).toBeNull();
 	});
 });
 

--- a/src/infrastructure/figma/transformers/figma-node-transformer.ts
+++ b/src/infrastructure/figma/transformers/figma-node-transformer.ts
@@ -20,15 +20,44 @@ type TransformNodeToAtlassianDesignParams = {
 };
 
 /**
- * Transforms a Figma node with the given ID to {@link AtlassianDesign}.
+ * Returns a {@link AtlassianDesign} for the Node with the given ID if it is available in the File;
+ * otherwise -- throws an exception.
+ *
+ * @remarks
+ * Use with cautious since there is guarantee that Node is available in {@link GetFileResponse}
+ * Consider using {@link tryTransformNodeToAtlassianDesign} instead.
  */
 export const transformNodeToAtlassianDesign = ({
 	fileKey,
 	nodeId,
 	fileResponse,
 }: TransformNodeToAtlassianDesignParams): AtlassianDesign => {
+	const result = tryTransformNodeToAtlassianDesign({
+		fileKey,
+		nodeId,
+		fileResponse,
+	});
+
+	if (result === null) throw new Error('Node is not found in the given File.');
+
+	return result;
+};
+
+/**
+ * Returns a {@link AtlassianDesign} for the Node with the given ID if it is available in the File;
+ * otherwise -- `null`.
+ */
+export const tryTransformNodeToAtlassianDesign = ({
+	fileKey,
+	nodeId,
+	fileResponse,
+}: TransformNodeToAtlassianDesignParams): AtlassianDesign | null => {
 	const designId = new FigmaDesignIdentifier(fileKey, nodeId);
-	const { node, extra } = getNodeDataFrom(fileResponse, nodeId);
+	const nodeData = findNodeDataInFile(fileResponse, nodeId);
+
+	if (nodeData == null) return null;
+
+	const { node, extra } = nodeData;
 	const fileName = fileResponse.name;
 
 	return {
@@ -59,10 +88,14 @@ type NodeData = {
 };
 
 /**
- * Returns a node with the given ID and related information extracted from ancestor nodes:
+ * Returns {@link NodeData} for the Node with given ID from the given {@link GetFileResponse} if it is available;
+ * otherwise -- `null`.
  *
+ * In addition to the `node` field, the returned result includes `extra`:
  * - `lastModified`. Currently, Figma provides this field only for File and top-level nodes. Therefore, use
  * `lastModified` of the target node, its closest ancestor or a File respectively as the most accurate value for the node.
+ * - `devStatus`. Currently,  Figma provides this field only for some types of nodes (Section). Therefore, use `devStatus`
+ * of the target node or its closest ancestor.
  *
  * @remarks
  * The function uses depth-first search (DFS) for find a node in `fileResponse` (which contains a tree of nodes).
@@ -72,22 +105,18 @@ type NodeData = {
  * @internal
  * Visible for testing only.
  */
-export const getNodeDataFrom = (
+export const findNodeDataInFile = (
 	fileResponse: GetFileResponse,
 	nodeId: string,
-): NodeData => {
-	const result = findNodeDataUsingDfs(nodeId, fileResponse.document, {
+): NodeData | null => {
+	const result = findNodeDataInFileUsingDfs(nodeId, fileResponse.document, {
 		lastModified: fileResponse.lastModified,
 	});
-
-	if (result == null) {
-		throw new Error('Response does not contain the node with the given ID.');
-	}
 
 	return result;
 };
 
-const findNodeDataUsingDfs = (
+const findNodeDataInFileUsingDfs = (
 	targetNodeId: string,
 	currentNode: Node,
 	extra: NodeData['extra'],
@@ -107,7 +136,7 @@ const findNodeDataUsingDfs = (
 	if (!currentNode.children?.length) return null;
 
 	for (const childNode of currentNode.children) {
-		const result = findNodeDataUsingDfs(targetNodeId, childNode, extra);
+		const result = findNodeDataInFileUsingDfs(targetNodeId, childNode, extra);
 
 		if (result) return result;
 	}

--- a/src/usecases/handle-figma-file-update-event-use-case.test.ts
+++ b/src/usecases/handle-figma-file-update-event-use-case.test.ts
@@ -72,7 +72,7 @@ describe('handleFigmaFileUpdateEventUseCase', () => {
 				)
 				.mockResolvedValue(associatedFigmaDesigns);
 			jest
-				.spyOn(figmaService, 'getDesignsFromSameFile')
+				.spyOn(figmaService, 'getAvailableDesignsFromSameFile')
 				.mockResolvedValue(associatedAtlassianDesigns);
 			jest.spyOn(jiraService, 'submitDesigns').mockResolvedValue();
 
@@ -110,7 +110,7 @@ describe('handleFigmaFileUpdateEventUseCase', () => {
 				)
 				.mockResolvedValue(associatedFigmaDesigns);
 			jest
-				.spyOn(figmaService, 'getDesignsFromSameFile')
+				.spyOn(figmaService, 'getAvailableDesignsFromSameFile')
 				.mockResolvedValue(associatedAtlassianDesigns);
 			jest.spyOn(jiraService, 'submitDesigns').mockResolvedValue();
 
@@ -139,7 +139,7 @@ describe('handleFigmaFileUpdateEventUseCase', () => {
 				)
 				.mockResolvedValue(associatedFigmaDesigns);
 			jest
-				.spyOn(figmaService, 'getDesignsFromSameFile')
+				.spyOn(figmaService, 'getAvailableDesignsFromSameFile')
 				.mockRejectedValue(new UnauthorizedFigmaServiceError());
 			jest.spyOn(figmaTeamRepository, 'updateAuthStatus').mockResolvedValue();
 
@@ -163,7 +163,7 @@ describe('handleFigmaFileUpdateEventUseCase', () => {
 				)
 				.mockResolvedValue(associatedFigmaDesigns);
 			jest
-				.spyOn(figmaService, 'getDesignsFromSameFile')
+				.spyOn(figmaService, 'getAvailableDesignsFromSameFile')
 				.mockRejectedValue(error);
 			jest.spyOn(jiraService, 'submitDesigns');
 

--- a/src/usecases/handle-figma-file-update-event-use-case.ts
+++ b/src/usecases/handle-figma-file-update-event-use-case.ts
@@ -44,7 +44,7 @@ export const handleFigmaFileUpdateEventUseCase = {
 		let designs: AtlassianDesign[];
 
 		try {
-			designs = await figmaService.getDesignsFromSameFile(
+			designs = await figmaService.getAvailableDesignsFromSameFile(
 				associatedFigmaDesigns.map((design) => design.designId),
 				figmaTeam.adminInfo,
 			);
@@ -57,6 +57,8 @@ export const handleFigmaFileUpdateEventUseCase = {
 			}
 			throw e;
 		}
+
+		if (!designs.length) return;
 
 		await jiraService.submitDesigns(
 			designs.map((design) => ({ design })),

--- a/src/web/routes/figma/integration.test.ts
+++ b/src/web/routes/figma/integration.test.ts
@@ -11,6 +11,7 @@ import {
 import type { FigmaWebhookEventRequestBody } from './types';
 
 import app from '../../../app';
+import { isNotNullOrUndefined } from '../../../common/predicates';
 import { isString } from '../../../common/string-utils';
 import { getConfig } from '../../../config';
 import type {
@@ -28,7 +29,6 @@ import {
 	generateFigmaDesignIdentifier,
 	generateFigmaFileKey,
 	generateFigmaFileName,
-	generateFigmaNodeId,
 	generateFigmaOAuth2UserCredentialCreateParams,
 	generateFigmaTeamCreateParams,
 } from '../../../domain/entities/testing';
@@ -122,7 +122,7 @@ describe('/figma', () => {
 						generateAssociatedFigmaDesignCreateParams({
 							designId: generateFigmaDesignIdentifier({
 								fileKey,
-								nodeId: generateFigmaNodeId(),
+								nodeId: `1:${i}`,
 							}),
 							connectInstallationId: connectInstallation.id,
 						});
@@ -155,8 +155,8 @@ describe('/figma', () => {
 						connectInstallation.id,
 					);
 				const nodeIds = associatedFigmaDesigns
-					.map(({ designId }) => designId.nodeId!)
-					.filter(isString);
+					.map(({ designId }) => designId.nodeId)
+					.filter(isNotNullOrUndefined);
 				const fileResponse = generateGetFileResponseWithNodes({
 					nodes: nodeIds.map((nodeId) => generateChildNode({ id: nodeId })),
 				});
@@ -202,7 +202,7 @@ describe('/figma', () => {
 					.expect(HttpStatusCode.Ok);
 			});
 
-			it('should return a 200 if no associated designs are found for the file key', async () => {
+			it('should ignore if no associated designs are found for the file key', async () => {
 				const otherFileKey = generateFigmaFileKey();
 				const otherFilewebhookEventRequestBody =
 					generateFileUpdateWebhookEventRequestBody({
@@ -223,6 +223,99 @@ describe('/figma', () => {
 				await request(app)
 					.post(FIGMA_WEBHOOK_EVENT_ENDPOINT)
 					.send(otherFilewebhookEventRequestBody)
+					.expect(HttpStatusCode.Ok);
+			});
+
+			it('should ignore if Figma file is not found', async () => {
+				const associatedFigmaDesigns =
+					await associatedFigmaDesignRepository.findManyByFileKeyAndConnectInstallationId(
+						fileKey,
+						connectInstallation.id,
+					);
+				const nodeIds = associatedFigmaDesigns
+					.map(({ designId }) => designId.nodeId)
+					.filter(isNotNullOrUndefined);
+
+				mockFigmaGetTeamProjectsEndpoint({
+					baseUrl: getConfig().figma.apiBaseUrl,
+					teamId: figmaTeam.teamId,
+					response: generateGetTeamProjectsResponse({
+						name: figmaTeam.teamName,
+					}),
+				});
+				mockFigmaGetFileEndpoint({
+					baseUrl: getConfig().figma.apiBaseUrl,
+					accessToken: adminFigmaOAuth2UserCredentials.accessToken,
+					fileKey: fileKey,
+					query: {
+						ids: nodeIds.join(','),
+						depth: '0',
+						node_last_modified: 'true',
+					},
+					status: HttpStatusCode.NotFound,
+				});
+
+				await request(app)
+					.post(FIGMA_WEBHOOK_EVENT_ENDPOINT)
+					.send(webhookEventRequestBody)
+					.expect(HttpStatusCode.Ok);
+			});
+
+			it('should ingest designs for available Figma nodes and ignore deleted nodes', async () => {
+				const associatedFigmaDesigns =
+					await associatedFigmaDesignRepository.findManyByFileKeyAndConnectInstallationId(
+						fileKey,
+						connectInstallation.id,
+					);
+				const nodeIds = associatedFigmaDesigns
+					.map(({ designId }) => designId.nodeId)
+					.filter(isNotNullOrUndefined);
+				const fileResponse = generateGetFileResponseWithNodes({
+					nodes: [
+						...nodeIds.map((nodeId) => generateChildNode({ id: nodeId })),
+						generateChildNode({ id: `9999:1` }),
+						generateChildNode({ id: `9999:2` }),
+					],
+				});
+				const associatedAtlassianDesigns = associatedFigmaDesigns.map(
+					(design) =>
+						generateAtlassianDesignFromDesignIdAndFileResponse(
+							design.designId,
+							fileResponse,
+						),
+				);
+
+				mockFigmaGetTeamProjectsEndpoint({
+					baseUrl: getConfig().figma.apiBaseUrl,
+					teamId: figmaTeam.teamId,
+					response: generateGetTeamProjectsResponse({
+						name: figmaTeam.teamName,
+					}),
+				});
+				mockFigmaGetFileEndpoint({
+					baseUrl: getConfig().figma.apiBaseUrl,
+					accessToken: adminFigmaOAuth2UserCredentials.accessToken,
+					fileKey: fileKey,
+					query: {
+						ids: nodeIds.join(','),
+						depth: '0',
+						node_last_modified: 'true',
+					},
+					response: fileResponse,
+				});
+				mockJiraSubmitDesignsEndpoint({
+					baseUrl: connectInstallation.baseUrl,
+					request: generateSubmitDesignsRequest(associatedAtlassianDesigns),
+					response: generateSuccessfulSubmitDesignsResponse(
+						associatedAtlassianDesigns.map(
+							(atlassianDesign) => atlassianDesign.id,
+						),
+					),
+				});
+
+				await request(app)
+					.post(FIGMA_WEBHOOK_EVENT_ENDPOINT)
+					.send(webhookEventRequestBody)
 					.expect(HttpStatusCode.Ok);
 			});
 
@@ -297,7 +390,7 @@ describe('/figma', () => {
 				);
 			});
 
-			it('should return error if fetching Figma designs fails with non-auth error', async () => {
+			it('should return error if fetching Figma designs fails with unexpected error', async () => {
 				const associatedFigmaDesigns =
 					await associatedFigmaDesignRepository.findManyByFileKeyAndConnectInstallationId(
 						fileKey,

--- a/src/web/routes/figma/schemas.test.ts
+++ b/src/web/routes/figma/schemas.test.ts
@@ -1,5 +1,6 @@
 import { FIGMA_WEBHOOK_EVENT_REQUEST_SCHEMA } from './schemas';
 import {
+	generateFileDeleteWebhookEventRequestBody,
 	generateFileUpdateWebhookEventRequestBody,
 	generatePingWebhookEventRequestBody,
 } from './testing';
@@ -10,40 +11,65 @@ import {
 } from '../../../common/schema-validation';
 
 describe('FIGMA_WEBHOOK_PAYLOAD_SCHEMA', () => {
-	it('should validate a PING event request body', () => {
-		const body = generatePingWebhookEventRequestBody();
+	describe('PING', () => {
+		it('should validate a PING event request body', () => {
+			const body = generatePingWebhookEventRequestBody();
 
-		expect(() =>
-			assertSchema({ body }, FIGMA_WEBHOOK_EVENT_REQUEST_SCHEMA),
-		).not.toThrow();
+			expect(() =>
+				assertSchema({ body }, FIGMA_WEBHOOK_EVENT_REQUEST_SCHEMA),
+			).not.toThrow();
+		});
+
+		it('should throw if PING event request body does not have required field', () => {
+			const body = {
+				...generatePingWebhookEventRequestBody(),
+				passcode: undefined,
+			};
+			expect(() =>
+				assertSchema({ body }, FIGMA_WEBHOOK_EVENT_REQUEST_SCHEMA),
+			).toThrow();
+		});
 	});
 
-	it('should throw if PING event request body does not have required field', () => {
-		const body = {
-			...generatePingWebhookEventRequestBody(),
-			passcode: undefined,
-		};
-		expect(() =>
-			assertSchema({ body }, FIGMA_WEBHOOK_EVENT_REQUEST_SCHEMA),
-		).toThrow();
+	describe('FILE_UPDATE', () => {
+		it('should validate FILE_UPDATE event request body', () => {
+			const body = generateFileUpdateWebhookEventRequestBody();
+
+			expect(() =>
+				assertSchema({ body }, FIGMA_WEBHOOK_EVENT_REQUEST_SCHEMA),
+			).not.toThrow();
+		});
+
+		it('should throw an error if FILE_UPDATE event request body does not have required field', () => {
+			const body = {
+				...generateFileUpdateWebhookEventRequestBody(),
+				file_key: undefined,
+			};
+
+			expect(() =>
+				assertSchema({ body }, FIGMA_WEBHOOK_EVENT_REQUEST_SCHEMA),
+			).toThrow(SchemaValidationError);
+		});
 	});
 
-	it('should validate FILE_UPDATE event request body', () => {
-		const body = generateFileUpdateWebhookEventRequestBody();
+	describe('FILE_DELETE', () => {
+		it('should validate FILE_DELETE event request body', () => {
+			const body = generateFileDeleteWebhookEventRequestBody();
 
-		expect(() =>
-			assertSchema({ body }, FIGMA_WEBHOOK_EVENT_REQUEST_SCHEMA),
-		).not.toThrow();
-	});
+			expect(() =>
+				assertSchema({ body }, FIGMA_WEBHOOK_EVENT_REQUEST_SCHEMA),
+			).not.toThrow();
+		});
 
-	it('should throw an error if FILE_UPDATE event request body does not have required field', () => {
-		const body = {
-			...generateFileUpdateWebhookEventRequestBody(),
-			file_key: undefined,
-		};
+		it('should throw an error if FILE_DELETE event request body does not have required field', () => {
+			const body = {
+				...generateFileDeleteWebhookEventRequestBody(),
+				file_key: undefined,
+			};
 
-		expect(() =>
-			assertSchema({ body }, FIGMA_WEBHOOK_EVENT_REQUEST_SCHEMA),
-		).toThrow(SchemaValidationError);
+			expect(() =>
+				assertSchema({ body }, FIGMA_WEBHOOK_EVENT_REQUEST_SCHEMA),
+			).toThrow(SchemaValidationError);
+		});
 	});
 });

--- a/src/web/routes/figma/schemas.ts
+++ b/src/web/routes/figma/schemas.ts
@@ -40,6 +40,15 @@ export const FIGMA_WEBHOOK_EVENT_REQUEST_SCHEMA = {
 						'timestamp',
 					],
 				},
+				{
+					properties: {
+						event_type: { const: 'FILE_DELETE' },
+						webhook_id: { type: 'string' },
+						file_key: { type: 'string' },
+						passcode: { type: 'string' },
+					},
+					required: ['event_type', 'webhook_id', 'file_key', 'passcode'],
+				},
 			],
 		},
 	},

--- a/src/web/routes/figma/testing/mocks.ts
+++ b/src/web/routes/figma/testing/mocks.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import type {
+	FigmaFileDeleteWebhookEventRequestBody,
 	FigmaFileUpdateWebhookEventRequestBody,
 	FigmaPingWebhookEventRequestBody,
 } from '../types';
@@ -29,4 +30,15 @@ export const generateFileUpdateWebhookEventRequestBody = ({
 	passcode,
 	timestamp,
 	webhook_id,
+});
+
+export const generateFileDeleteWebhookEventRequestBody = ({
+	webhook_id = uuidv4(),
+	file_key = uuidv4(),
+	passcode = uuidv4(),
+}: Partial<FigmaFileDeleteWebhookEventRequestBody> = {}): FigmaFileDeleteWebhookEventRequestBody => ({
+	event_type: 'FILE_DELETE',
+	webhook_id,
+	file_key,
+	passcode,
 });

--- a/src/web/routes/figma/types.ts
+++ b/src/web/routes/figma/types.ts
@@ -18,9 +18,22 @@ export type FigmaFileUpdateWebhookEventRequestBody = {
 	readonly timestamp: string;
 };
 
+/**
+ * @remarks
+ * Currently, not handled but its sent within a subscription to `FILE_UPDATE` events.
+ * See for more detail: https://www.figma.com/developers/api#webhooks-v2-events
+ */
+export type FigmaFileDeleteWebhookEventRequestBody = {
+	readonly event_type: 'FILE_DELETE';
+	readonly webhook_id: string;
+	readonly file_key: string;
+	readonly passcode: string;
+};
+
 export type FigmaWebhookEventRequestBody =
 	| FigmaPingWebhookEventRequestBody
-	| FigmaFileUpdateWebhookEventRequestBody;
+	| FigmaFileUpdateWebhookEventRequestBody
+	| FigmaFileDeleteWebhookEventRequestBody;
 
 export type FigmaWebhookEventLocals = {
 	readonly figmaTeam: FigmaTeam;


### PR DESCRIPTION
## Changes

- **fix:** Skips Figma `FILE_UPDATE` event processing when Figma File is not found (an edge case when a Figma File is deleted right after a webhook is triggered) and return `HTTP 200`.
- **fix:** Does not fail Figma `FILE_UPDATE` event processing when a File does not contain some Nodes, previously linked to Jira issues. Skips event processing for these Nodes but processes the remaining. 
- **fix:** Returns `HTTP 200` for Figma `FILE_DELETE` event, which is delivered within the `FILE_UPDATE` subscription. According to Figma [docs](https://www.figma.com/developers/api#webhooks-v2-events), "If you subscribe to FILE_UPDATE, you automatically get these notifications.".