### PR TITLE
FABB-50: Improve compatibility with the "Jira" widget in Figma

### DIFF
--- a/src/infrastructure/figma/transformers/figma-file-meta-transformer.test.ts
+++ b/src/infrastructure/figma/transformers/figma-file-meta-transformer.test.ts
@@ -42,18 +42,9 @@ describe('transformFileMetaToAtlassianDesign', () => {
 		expect(result).toStrictEqual({
 			id: fileKey,
 			displayName: fileMetaResponse.file.name,
-			url: buildDesignUrl({
-				fileKey,
-				fileName: fileMetaResponse.file.name,
-			}),
-			liveEmbedUrl: buildLiveEmbedUrl({
-				fileKey,
-				fileName: fileMetaResponse.file.name,
-			}),
-			inspectUrl: buildInspectUrl({
-				fileKey,
-				fileName: fileMetaResponse.file.name,
-			}),
+			url: buildDesignUrl({ fileKey }),
+			liveEmbedUrl: buildLiveEmbedUrl({ fileKey }),
+			inspectUrl: buildInspectUrl({ fileKey }),
 			status: AtlassianDesignStatus.NONE,
 			type: AtlassianDesignType.FILE,
 			lastUpdated: fileMetaResponse.file.last_touched_at,

--- a/src/infrastructure/figma/transformers/figma-file-meta-transformer.ts
+++ b/src/infrastructure/figma/transformers/figma-file-meta-transformer.ts
@@ -26,14 +26,13 @@ export const transformFileMetaToAtlassianDesign = ({
 	fileMetaResponse,
 }: TransformFileMetaToAtlassianDesignParams): AtlassianDesign => {
 	const designId = new FigmaDesignIdentifier(fileKey);
-	const fileName = fileMetaResponse.file.name;
 
 	return {
 		id: designId.toAtlassianDesignId(),
 		displayName: fileMetaResponse.file.name,
-		url: buildDesignUrl({ fileKey, fileName }),
-		liveEmbedUrl: buildLiveEmbedUrl({ fileKey, fileName }),
-		inspectUrl: buildInspectUrl({ fileKey, fileName }),
+		url: buildDesignUrl({ fileKey }),
+		liveEmbedUrl: buildLiveEmbedUrl({ fileKey }),
+		inspectUrl: buildInspectUrl({ fileKey }),
 		status: AtlassianDesignStatus.NONE,
 		type: AtlassianDesignType.FILE,
 		lastUpdated: fileMetaResponse.file.last_touched_at,

--- a/src/infrastructure/figma/transformers/figma-file-transformer.test.ts
+++ b/src/infrastructure/figma/transformers/figma-file-transformer.test.ts
@@ -44,15 +44,12 @@ describe('transformFileToAtlassianDesign', () => {
 			displayName: fileResponse.name,
 			url: buildDesignUrl({
 				fileKey,
-				fileName: fileResponse.name,
 			}),
 			liveEmbedUrl: buildLiveEmbedUrl({
 				fileKey,
-				fileName: fileResponse.name,
 			}),
 			inspectUrl: buildInspectUrl({
 				fileKey,
-				fileName: fileResponse.name,
 			}),
 			status: AtlassianDesignStatus.NONE,
 			type: AtlassianDesignType.FILE,

--- a/src/infrastructure/figma/transformers/figma-file-transformer.ts
+++ b/src/infrastructure/figma/transformers/figma-file-transformer.ts
@@ -26,14 +26,13 @@ export const transformFileToAtlassianDesign = ({
 	fileResponse,
 }: TransformFileToAtlassianDesignParams): AtlassianDesign => {
 	const designId = new FigmaDesignIdentifier(fileKey);
-	const fileName = fileResponse.name;
 
 	return {
 		id: designId.toAtlassianDesignId(),
 		displayName: fileResponse.name,
-		url: buildDesignUrl({ fileKey, fileName }),
-		liveEmbedUrl: buildLiveEmbedUrl({ fileKey, fileName }),
-		inspectUrl: buildInspectUrl({ fileKey, fileName }),
+		url: buildDesignUrl({ fileKey }),
+		liveEmbedUrl: buildLiveEmbedUrl({ fileKey }),
+		inspectUrl: buildInspectUrl({ fileKey }),
 		status: AtlassianDesignStatus.NONE,
 		type: AtlassianDesignType.FILE,
 		lastUpdated: fileResponse.lastModified,

--- a/src/infrastructure/figma/transformers/figma-node-transformer.test.ts
+++ b/src/infrastructure/figma/transformers/figma-node-transformer.test.ts
@@ -105,17 +105,14 @@ describe('tryTransformNodeToAtlassianDesign', () => {
 			displayName: `${fileResponse.name} - ${node.name}`,
 			url: buildDesignUrl({
 				fileKey,
-				fileName: fileResponse.name,
 				nodeId: node.id,
 			}),
 			liveEmbedUrl: buildLiveEmbedUrl({
 				fileKey,
-				fileName: fileResponse.name,
 				nodeId: node.id,
 			}),
 			inspectUrl: buildInspectUrl({
 				fileKey,
-				fileName: fileResponse.name,
 				nodeId: node.id,
 			}),
 			status: AtlassianDesignStatus.NONE,

--- a/src/infrastructure/figma/transformers/figma-node-transformer.ts
+++ b/src/infrastructure/figma/transformers/figma-node-transformer.ts
@@ -63,9 +63,9 @@ export const tryTransformNodeToAtlassianDesign = ({
 	return {
 		id: designId.toAtlassianDesignId(),
 		displayName: `${fileName} - ${node.name}`,
-		url: buildDesignUrl({ fileKey, fileName, nodeId }),
-		liveEmbedUrl: buildLiveEmbedUrl({ fileKey, fileName, nodeId }),
-		inspectUrl: buildInspectUrl({ fileKey, fileName, nodeId }),
+		url: buildDesignUrl({ fileKey, nodeId }),
+		liveEmbedUrl: buildLiveEmbedUrl({ fileKey, nodeId }),
+		inspectUrl: buildInspectUrl({ fileKey, nodeId }),
 		status: extra.devStatus
 			? mapNodeStatusToDevStatus(extra.devStatus)
 			: AtlassianDesignStatus.NONE,

--- a/src/infrastructure/figma/transformers/utils.test.ts
+++ b/src/infrastructure/figma/transformers/utils.test.ts
@@ -10,7 +10,6 @@ import { mockConfig } from '../../../config/testing';
 import {
 	generateFigmaDesignUrl,
 	generateFigmaFileKey,
-	generateFigmaFileName,
 	generateFigmaNodeId,
 } from '../../../domain/entities/testing';
 
@@ -40,10 +39,7 @@ describe('utils', () => {
 		it('should return a url for Figma file', () => {
 			const fileKey = generateFigmaFileKey();
 
-			const result = buildDesignUrl({
-				fileKey,
-				fileName: 'Test Design',
-			});
+			const result = buildDesignUrl({ fileKey });
 
 			expect(result).toEqual(`https://www.figma.com/file/${fileKey}`);
 		});
@@ -52,11 +48,7 @@ describe('utils', () => {
 			const fileKey = generateFigmaFileKey();
 			const nodeId = '1:3';
 
-			const result = buildDesignUrl({
-				fileKey,
-				fileName: 'Test Design',
-				nodeId,
-			});
+			const result = buildDesignUrl({ fileKey, nodeId });
 
 			expect(result).toEqual(
 				`https://www.figma.com/file/${fileKey}?node-id=1%3A3`,
@@ -68,10 +60,7 @@ describe('utils', () => {
 		it('should return a url for Figma file', () => {
 			const fileKey = generateFigmaFileKey();
 
-			const result = buildInspectUrl({
-				fileKey,
-				fileName: 'Test Design',
-			});
+			const result = buildInspectUrl({ fileKey });
 
 			expect(result).toEqual(`https://www.figma.com/file/${fileKey}?mode=dev`);
 		});
@@ -80,11 +69,7 @@ describe('utils', () => {
 			const fileKey = generateFigmaFileKey();
 			const nodeId = '1:3';
 
-			const result = buildInspectUrl({
-				fileKey,
-				fileName: 'Test Design',
-				nodeId,
-			});
+			const result = buildInspectUrl({ fileKey, nodeId });
 
 			expect(result).toEqual(
 				`https://www.figma.com/file/${fileKey}?node-id=1%3A3&mode=dev`,
@@ -103,14 +88,9 @@ describe('utils', () => {
 
 		it('should return a url', () => {
 			const fileKey = generateFigmaFileKey();
-			const fileName = generateFigmaFileName();
 			const nodeId = generateFigmaNodeId();
 
-			const result = buildLiveEmbedUrl({
-				fileKey,
-				fileName,
-				nodeId,
-			});
+			const result = buildLiveEmbedUrl({ fileKey, nodeId });
 
 			const expected = new URL('https://www.figma.com/embed');
 			expected.search = new URLSearchParams({

--- a/src/infrastructure/figma/transformers/utils.ts
+++ b/src/infrastructure/figma/transformers/utils.ts
@@ -9,7 +9,6 @@ export const buildDesignUrl = ({
 	nodeId,
 }: {
 	fileKey: string;
-	fileName: string;
 	nodeId?: string;
 }): string => {
 	const url = new URL(
@@ -30,7 +29,6 @@ export const buildInspectUrl = ({
 	nodeId,
 }: {
 	fileKey: string;
-	fileName: string;
 	nodeId?: string;
 }): string => {
 	const url = new URL(
@@ -51,14 +49,12 @@ export const buildInspectUrl = ({
  */
 export const buildLiveEmbedUrl = ({
 	fileKey,
-	fileName,
 	nodeId,
 }: {
 	fileKey: string;
-	fileName: string;
 	nodeId?: string;
 }): string => {
-	const inspectUrl = buildInspectUrl({ fileKey, fileName, nodeId });
+	const inspectUrl = buildInspectUrl({ fileKey, nodeId });
 	const url = new URL(`/embed`, getConfig().figma.webBaseUrl);
 	url.searchParams.append('embed_host', 'figma-jira-add-on');
 	url.searchParams.append('url', inspectUrl);

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -222,13 +222,10 @@ class JiraService {
 		} catch (error) {
 			if (error instanceof NotFoundHttpClientError) {
 				// Include the design name into the URL for compatibility with the existing "Jira" widget in Figma.
-				const encodedDisplayName = encodeURIComponent(displayName)
+				const encodedFileName = encodeURIComponent(displayName)
 					// A "Jira" widget treat '-' as a space, so encode it as well.
 					.replaceAll('-', '%2D');
-				const urlWithFileName = appendToPathname(
-					new URL(url),
-					encodedDisplayName,
-				);
+				const urlWithFileName = appendToPathname(new URL(url), encodedFileName);
 
 				await jiraClient.setIssueProperty(
 					issueIdOrKey,

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -222,9 +222,11 @@ class JiraService {
 		} catch (error) {
 			if (error instanceof NotFoundHttpClientError) {
 				// Include the design name into the URL for compatibility with the existing "Jira" widget in Figma.
-				const encodedFileName = encodeURIComponent(displayName)
-					// A "Jira" widget in Figma treats '-' as a space, so encode it as well to make it display the name correctly.
-					.replaceAll('-', '%2D');
+				// A "Jira" widget in Figma treats '-' as a space, so encode it as well to make it display the name correctly.
+				const encodedFileName = encodeURIComponent(displayName).replaceAll(
+					'-',
+					'%2D',
+				);
 				const urlWithFileName = appendToPathname(new URL(url), encodedFileName);
 
 				await jiraClient.setIssueProperty(

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -223,7 +223,7 @@ class JiraService {
 			if (error instanceof NotFoundHttpClientError) {
 				// Include the design name into the URL for compatibility with the existing "Jira" widget in Figma.
 				const encodedFileName = encodeURIComponent(displayName)
-					// A "Jira" widget treat '-' as a space, so encode it as well.
+					// A "Jira" widget in Figma treats '-' as a space, so encode it as well to make it display the name correctly.
 					.replaceAll('-', '%2D');
 				const urlWithFileName = appendToPathname(new URL(url), encodedFileName);
 

--- a/src/web/routes/entities/integration.test.ts
+++ b/src/web/routes/entities/integration.test.ts
@@ -229,7 +229,10 @@ describe('/entities', () => {
 				request: JSON.stringify(
 					appendToPathname(
 						new URL(normalizedFigmaDesignUrl),
-						encodeURIComponent(atlassianDesign.displayName),
+						encodeURIComponent(atlassianDesign.displayName).replaceAll(
+							'-',
+							'%2D',
+						),
 					).toString(),
 				),
 			});
@@ -384,7 +387,10 @@ describe('/entities', () => {
 				request: JSON.stringify(
 					appendToPathname(
 						new URL(normalizedFigmaDesignUrl),
-						encodeURIComponent(atlassianDesign.displayName),
+						encodeURIComponent(atlassianDesign.displayName).replaceAll(
+							'-',
+							'%2D',
+						),
 					).toString(),
 				),
 			});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"target": "ES2020",
+		"target": "ES2021",
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"resolveJsonModule": true,


### PR DESCRIPTION
## Changes

- **fix:** Resolves the issue with the "Jira" widget showing an already unlinked design.
- **fix:** Resolves the issue with the "Jira" widget showing some special symbols in a design name incorrectly.
  ![image](https://github.com/atlassian-labs/figma-for-jira/assets/141381034/f0789178-68d7-4b77-826b-2e14097d19e5)
  <img width="1363" alt="image" src="https://github.com/atlassian-labs/figma-for-jira/assets/141381034/00e05ace-3719-46b5-b781-4172afee228e">
- **refactor:** Removes unused parameter from Figma design transformation utilities.
