### PR TITLE
FABB-2: Handle when users connect Figma teams with no paid plan

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,5 @@
 /**/*.js
-prestart.ts
-postinstall.ts
+admin
 node_modules
 scripts
 jest.config.**

--- a/admin/jest.config.ts
+++ b/admin/jest.config.ts
@@ -5,9 +5,7 @@ const config: Config = {
 	testEnvironment: 'node',
 	maxWorkers: 4,
 	rootDir: '.',
-	roots: ['<rootDir>/src'],
-	testRegex: '(\\.|/)(test|spec)\\.tsx?$',
-	setupFiles: ['dotenv-expand/config'],
+	testRegex: '(\\.|/)test\\.tsx?$',
 	clearMocks: true,
 };
 

--- a/admin/package.json
+++ b/admin/package.json
@@ -5,7 +5,8 @@
 	"scripts": {
 		"start": "vite build --mode development --watch",
 		"build": "vite build",
-		"preview": "vite preview"
+		"preview": "vite preview",
+		"test": "jest"
 	},
 	"dependencies": {
 		"@atlaskit/button": "^16.11.0",
@@ -32,9 +33,11 @@
 	"devDependencies": {
 		"@emotion/babel-plugin": "^11.11.0",
 		"@types/atlassian-connect-js": "^5.2.14",
+		"@types/jest": "^29.5.8",
 		"@types/react": "^18.2.28",
 		"@types/react-dom": "^18.2.13",
 		"@vitejs/plugin-react": "^4.1.0",
+		"jest": "^29.6.2",
 		"typescript": "^5.2.2",
 		"vite": "^4.4.11"
 	}

--- a/admin/src/pages/auth/auth-page.tsx
+++ b/admin/src/pages/auth/auth-page.tsx
@@ -69,7 +69,7 @@ export function AuthPage({ authorizationEndpoint }: AuthPageProps) {
 								flexDirection: 'column',
 							})}
 						>
-							<span>Admin permissions for a Figma team</span>
+							<span>Admin permissions for a paid Figma team</span>
 							<FigmaPermissionsPopup>
 								How to check Figma permissions
 							</FigmaPermissionsPopup>

--- a/admin/src/pages/teams/figma-teams-connector.tsx
+++ b/admin/src/pages/teams/figma-teams-connector.tsx
@@ -20,6 +20,7 @@ import {
 	Page,
 } from '../../components';
 import { openInBrowser, parseTeamIdFromFigmaUrl } from '../../utils';
+import { HttpStatusCode } from 'axios';
 
 type ConnectTeamProps = {
 	authorizationEndpoint: string;
@@ -27,8 +28,6 @@ type ConnectTeamProps = {
 	onClose?: () => void;
 	site: string;
 };
-
-const WEBHOOK_UPGRADE_ERROR = 'Upgrade to professional team to enable webhooks';
 
 type ConnectTeamsError = AxiosError & {
 	response: {
@@ -69,7 +68,7 @@ export function FigmaTeamConnector({
 			return queryClient.invalidateQueries({ queryKey: ['teams'] });
 		},
 		onError: (error: ConnectTeamsError) => {
-			if (error.response?.data?.detail === WEBHOOK_UPGRADE_ERROR) {
+			if (error.response?.status === HttpStatusCode.PaymentRequired) {
 				setShowUnauthorizedError(false);
 				setValidationError('You need a paid Figma plan to add teams to Jira');
 			} else {

--- a/admin/src/utils/parseTeamIdFromFigmaUrl.test.ts
+++ b/admin/src/utils/parseTeamIdFromFigmaUrl.test.ts
@@ -1,7 +1,6 @@
 import { parseTeamIdFromFigmaUrl } from './parseTeamIdFromFigmaUrl';
 
 describe('parseTeamIdFromFigmaUrl', () => {
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 	it('throws an error if the URL is not a Figma URL', () => {
 		const url = 'https://foo.com';
 		expect(() => parseTeamIdFromFigmaUrl(url)).toThrowError(
@@ -9,13 +8,11 @@ describe('parseTeamIdFromFigmaUrl', () => {
 		);
 	});
 
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 	it('returns the team ID for a starter team', () => {
 		const url = 'https://www.figma.com/files/team/123/Project-Name';
 		expect(parseTeamIdFromFigmaUrl(url)).toEqual('123');
 	});
 
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 	it('returns the team ID for an org team', () => {
 		const url =
 			'https://www.figma.com/files/456/team/123/another-cool-team?fuid=678';

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,9 +83,11 @@
 			"devDependencies": {
 				"@emotion/babel-plugin": "^11.11.0",
 				"@types/atlassian-connect-js": "^5.2.14",
+				"@types/jest": "^29.5.8",
 				"@types/react": "^18.2.28",
 				"@types/react-dom": "^18.2.13",
 				"@vitejs/plugin-react": "^4.1.0",
+				"jest": "^29.6.2",
 				"typescript": "^5.2.2",
 				"vite": "^4.4.11"
 			}
@@ -2807,9 +2809,10 @@
 			}
 		},
 		"node_modules/@types/jest": {
-			"version": "29.5.3",
+			"version": "29.5.8",
+			"resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/jest/-/jest-29.5.8.tgz",
+			"integrity": "sha512-fXEFTxMV2Co8ZF5aYFJv+YeA08RTYJfhtN5c9JSv/mFEMe+xxjufCb+PHL+bJcMs/ebPUsBu+UNTEz+ydXrR6g==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"expect": "^29.0.0",
 				"pretty-format": "^29.0.0"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"scripts": {
 		"admin:build": "cd admin && npm run build",
 		"admin:start": "cd admin && npm start",
+		"admin:test": "cd admin && npm run test",
 		"build": "run-s build:app admin:build",
 		"build:app": "rimraf build && tsc --project ./tsconfig.build.json",
 		"db:generate": "prisma generate",
@@ -26,7 +27,7 @@
 		"start:tunnel": "./scripts/make-tunnel.sh",
 		"stop:sandbox": "./scripts/stop-sandbox.sh docker-compose.yml",
 		"stop:sandbox:test": "./scripts/stop-sandbox.sh docker-compose.integration.yml",
-		"test": "run-s test:unit test:it",
+		"test": "run-s test:unit test:it admin:test",
 		"test:it": "(dotenv -e .env.test -- prisma migrate reset -f) && (DOTENV_CONFIG_PATH=.env.test jest -c jest.config.integration.ts --runInBand)",
 		"test:it:ci": "run-s start:sandbox:test test:it stop:sandbox:test",
 		"test:unit": "jest -c jest.config.unit.ts"

--- a/src/common/schema-validation.test.ts
+++ b/src/common/schema-validation.test.ts
@@ -1,5 +1,6 @@
 import {
 	assertSchema,
+	isOfSchema,
 	type JSONSchemaTypeWithId,
 	parseJsonOfSchema,
 	SchemaValidationError,
@@ -22,7 +23,7 @@ const TEST_SCHEMA: JSONSchemaTypeWithId<TestObject> = {
 };
 
 describe('schema-validation', () => {
-	describe('assertSchema', () => {
+	describe('validateSchema', () => {
 		it('should return result indicating input is valid when validating a valid object', () => {
 			const validObject: unknown = { value: 'test' };
 
@@ -32,9 +33,9 @@ describe('schema-validation', () => {
 		});
 
 		it('should return result indicating input is invalid when validating a non-conforming object', () => {
-			const validObject: unknown = { value: 123 };
+			const invalidObject: unknown = { value: 123 };
 
-			const result = validateSchema(validObject, TEST_SCHEMA);
+			const result = validateSchema(invalidObject, TEST_SCHEMA);
 
 			expect(result).toStrictEqual({
 				valid: false,
@@ -56,6 +57,24 @@ describe('schema-validation', () => {
 			expect(() => {
 				assertSchema(validObject, TEST_SCHEMA);
 			}).toThrow(SchemaValidationError);
+		});
+	});
+
+	describe('isOfSchema', () => {
+		it('should return true when input matches schema', () => {
+			const validObject: unknown = { value: 'test' };
+
+			const result = isOfSchema(validObject, TEST_SCHEMA);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when input does not match schema', () => {
+			const invalidObject: unknown = { value: 123 };
+
+			const result = isOfSchema(invalidObject, TEST_SCHEMA);
+
+			expect(result).toBe(false);
 		});
 	});
 

--- a/src/common/schema-validation.ts
+++ b/src/common/schema-validation.ts
@@ -59,6 +59,15 @@ export function assertSchema<T>(
 	}
 }
 
+export function isOfSchema<T>(
+	value: unknown,
+	schema: JSONSchemaTypeWithId<T>,
+): value is T {
+	const { valid } = validateSchema(value, schema);
+
+	return valid;
+}
+
 /**
  * @throws {SchemaValidationError} The given value is not of the expected schema.
  */

--- a/src/infrastructure/axios-utils.ts
+++ b/src/infrastructure/axios-utils.ts
@@ -23,16 +23,28 @@ const translateAxiosError = (error: unknown): unknown => {
 		case HttpStatusCode.BadRequest:
 			return new BadRequestHttpClientError(
 				error.message,
-				error,
 				error.response.data,
+				error,
 			);
 		case HttpStatusCode.Unauthorized:
-			return new UnauthorizedHttpClientError(error.message, error);
+			return new UnauthorizedHttpClientError(
+				error.message,
+				error.response.data,
+				error,
+			);
 		case HttpStatusCode.Forbidden:
-			return new ForbiddenHttpClientError(error.message, error);
+			return new ForbiddenHttpClientError(
+				error.message,
+				error.response.data,
+				error,
+			);
 		case HttpStatusCode.NotFound:
-			return new NotFoundHttpClientError(error.message, error);
+			return new NotFoundHttpClientError(
+				error.message,
+				error.response.data,
+				error,
+			);
 		default:
-			return new HttpClientError(error.message, error);
+			return new HttpClientError(error.message, error.response?.data, error);
 	}
 };

--- a/src/infrastructure/figma/figma-client/schemas.ts
+++ b/src/infrastructure/figma/figma-client/schemas.ts
@@ -6,6 +6,7 @@ import type {
 	CreateDevResourcesResponse,
 	CreateWebhookResponse,
 	DevResource,
+	ErrorResponse,
 	GetDevResourcesResponse,
 	GetFileMetaResponse,
 	GetFileResponse,
@@ -204,3 +205,13 @@ export const GET_TEAM_PROJECTS_RESPONSE_SCHEMA: JSONSchemaTypeWithId<GetTeamProj
 		},
 		required: ['name', 'projects'],
 	};
+
+export const ERROR_RESPONSE_SCHEMA: JSONSchemaTypeWithId<ErrorResponse> = {
+	$id: 'figma-api:error:response',
+	type: 'object',
+	properties: {
+		message: { type: 'string' },
+		reason: { type: 'string', nullable: true },
+	},
+	required: ['message'],
+};

--- a/src/infrastructure/figma/figma-client/types.ts
+++ b/src/infrastructure/figma/figma-client/types.ts
@@ -127,3 +127,8 @@ export type GetTeamProjectsResponse = {
 		readonly name: string;
 	}[];
 };
+
+export type ErrorResponse = {
+	readonly message: string;
+	readonly reason?: string;
+};

--- a/src/infrastructure/figma/figma-service.ts
+++ b/src/infrastructure/figma/figma-service.ts
@@ -4,6 +4,7 @@ import {
 } from './figma-auth-service';
 import type { CreateWebhookRequest, GetFileResponse } from './figma-client';
 import { figmaClient } from './figma-client';
+import { ERROR_RESPONSE_SCHEMA } from './figma-client/schemas';
 import {
 	transformFileMetaToAtlassianDesign,
 	transformFileToAtlassianDesign,
@@ -13,6 +14,7 @@ import {
 
 import { CauseAwareError } from '../../common/errors';
 import { isNotNullOrUndefined } from '../../common/predicates';
+import { isOfSchema } from '../../common/schema-validation';
 import { isString } from '../../common/string-utils';
 import { getConfig } from '../../config';
 import type {
@@ -223,6 +225,7 @@ export class FigmaService {
 
 	/**
 	 * @throws {UnauthorizedFigmaServiceError} Not authorized to access Figma.
+	 * @throws {PaidPlanRequiredFigmaServiceError} A Figma paid plan is required to perform this operation.
 	 */
 	createFileUpdateWebhook = async (
 		teamId: string,
@@ -240,8 +243,26 @@ export class FigmaService {
 				description: 'Figma for Jira Cloud',
 			};
 
-			const result = await figmaClient.createWebhook(request, accessToken);
-			return { webhookId: result.id, teamId: result.team_id };
+			try {
+				const result = await figmaClient.createWebhook(request, accessToken);
+				return { webhookId: result.id, teamId: result.team_id };
+			} catch (e: unknown) {
+				if (
+					e instanceof BadRequestHttpClientError &&
+					isOfSchema(e.response, ERROR_RESPONSE_SCHEMA)
+				) {
+					// Figma allows to create webhooks only on paid plans.
+					// See https://www.figma.com/pricing/.
+					if (e.response.message == 'Access Denied') {
+						throw new PaidPlanRequiredFigmaServiceError(
+							'A Figma paid plan is required to perform this operation.',
+							e,
+						);
+					}
+				}
+
+				throw e;
+			}
 		});
 
 	/**
@@ -354,8 +375,7 @@ export class FigmaService {
 			if (
 				e instanceof MissingOrInvalidCredentialsFigmaAuthServiceError ||
 				e instanceof UnauthorizedHttpClientError ||
-				e instanceof ForbiddenHttpClientError ||
-				e instanceof BadRequestHttpClientError
+				e instanceof ForbiddenHttpClientError
 			) {
 				throw new UnauthorizedFigmaServiceError(
 					'Not allowed to perform the operation.',
@@ -371,3 +391,5 @@ export class FigmaService {
 export const figmaService = new FigmaService();
 
 export class UnauthorizedFigmaServiceError extends CauseAwareError {}
+
+export class PaidPlanRequiredFigmaServiceError extends CauseAwareError {}

--- a/src/infrastructure/http-client-errors.ts
+++ b/src/infrastructure/http-client-errors.ts
@@ -1,13 +1,10 @@
 import { CauseAwareError } from '../common/errors';
 
-export type ResponseDetails = {
-	reason: string;
-};
 export class HttpClientError extends CauseAwareError {
 	constructor(
 		message?: string,
-		cause?: Error,
 		readonly response?: unknown,
+		cause?: Error,
 	) {
 		super(message, cause);
 	}

--- a/src/usecases/errors.ts
+++ b/src/usecases/errors.ts
@@ -12,6 +12,12 @@ export class ForbiddenByFigmaUseCaseResultError extends UseCaseResultError {
 	}
 }
 
+export class PaidFigmaPlanRequiredUseCaseResultError extends UseCaseResultError {
+	constructor(cause: Error) {
+		super('You need a paid Figma plan to perform this operation.', cause);
+	}
+}
+
 export class InvalidInputUseCaseResultError extends UseCaseResultError {
 	constructor(
 		readonly detail: string,

--- a/src/web/middleware/error-handler-middleware.ts
+++ b/src/web/middleware/error-handler-middleware.ts
@@ -4,6 +4,7 @@ import type { NextFunction, Request, Response } from 'express';
 import {
 	ForbiddenByFigmaUseCaseResultError,
 	InvalidInputUseCaseResultError,
+	PaidFigmaPlanRequiredUseCaseResultError,
 	UseCaseResultError,
 } from '../../usecases';
 import { ResponseStatusError } from '../errors';
@@ -39,6 +40,11 @@ export const errorHandlerMiddleware = (
 
 		if (err instanceof ForbiddenByFigmaUseCaseResultError) {
 			res.status(HttpStatusCode.Forbidden).send({ message: err.message });
+			return next();
+		}
+
+		if (err instanceof PaidFigmaPlanRequiredUseCaseResultError) {
+			res.status(HttpStatusCode.PaymentRequired).send({ message: err.message });
 			return next();
 		}
 	}

--- a/src/web/testing/figma-api-mocks.ts
+++ b/src/web/testing/figma-api-mocks.ts
@@ -8,6 +8,7 @@ import type {
 	CreateDevResourcesResponse,
 	CreateWebhookRequest,
 	CreateWebhookResponse,
+	ErrorResponse,
 	GetDevResourcesResponse,
 	GetFileMetaResponse,
 	GetFileResponse,
@@ -143,7 +144,7 @@ export const mockFigmaCreateWebhookEndpoint = ({
 	webhookId?: string;
 	teamId?: string;
 	request?: CreateWebhookRequest | RequestBodyMatcher;
-	response?: CreateWebhookResponse;
+	response?: CreateWebhookResponse | ErrorResponse;
 	status?: HttpStatusCode;
 }) => {
 	nock(baseUrl).post('/v2/webhooks', request).reply(status, response);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
 		"outDir": "build",
 		"baseUrl": "."
 	},
-	"include": ["src/**/*", "test/**/*"]
+	"include": ["src/**/*"]
 }


### PR DESCRIPTION
The PR addresses comments in https://github.com/atlassian-labs/figma-for-jira/pull/153.

## Changes

- **refactor:** Handles paid plan-related `HTTP 400` errors from Figma API in `FigmaService.createFileUpdateWebhook` instead of `connectFigmaTeamUseCase`. See here for more detail: https://github.com/atlassian-labs/figma-for-jira/pull/153#discussion_r1398662659.
- **refactor:** Returns [HTTP 402 Payment Required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/402) when a user connects Figma teams with no paid plan. This allows the frontend to easily distinguish plan-related errors from others.
- **feat:** Updates UI messages according to the latest requirements. 
- **test:** Adds additional unit and integration tests.