### PR TITLE
MDTZ-1095 Use Jira platform API instead of JSW API

### DIFF
--- a/src/infrastructure/jira/jira-client/jira-client.test.ts
+++ b/src/infrastructure/jira/jira-client/jira-client.test.ts
@@ -86,7 +86,7 @@ describe('JiraClient', () => {
 
 			expect(result).toBe(response);
 			expect(axios.get).toHaveBeenCalledWith(
-				`${connectInstallation.baseUrl}/rest/agile/1.0/issue/${issueKey}`,
+				`${connectInstallation.baseUrl}/rest/api/3/issue/${issueKey}`,
 				defaultExpectedRequestHeaders(),
 			);
 		});

--- a/src/infrastructure/jira/jira-client/jira-client.ts
+++ b/src/infrastructure/jira/jira-client/jira-client.ts
@@ -75,7 +75,7 @@ class JiraClient {
 	): Promise<GetIssueResponse> =>
 		withAxiosErrorTranslation(async () => {
 			const url = new URL(
-				`/rest/agile/1.0/issue/${encodeURIComponent(issueIdOrKey)}`,
+				`/rest/api/3/issue/${encodeURIComponent(issueIdOrKey)}`,
 				connectInstallation.baseUrl,
 			);
 

--- a/src/infrastructure/jira/jira-client/schemas.ts
+++ b/src/infrastructure/jira/jira-client/schemas.ts
@@ -81,7 +81,7 @@ export const SUBMIT_DESIGNS_RESPONSE_SCHEMA: JSONSchemaTypeWithId<SubmitDesignsR
 
 export const GET_ISSUE_RESPONSE_SCHEMA: JSONSchemaTypeWithId<GetIssueResponse> =
 	{
-		$id: 'jira-software-cloud-api:get:/rest/agile/1.0/issue/$issueIdOrKey:response',
+		$id: 'jira-software-cloud-api:get:/rest/api/3/issue/$issueIdOrKey:response',
 		type: 'object',
 		properties: {
 			id: { type: 'string' },

--- a/src/infrastructure/jira/jira-client/testing/mocks.ts
+++ b/src/infrastructure/jira/jira-client/testing/mocks.ts
@@ -22,7 +22,7 @@ import type {
 export const MOCK_JWT_TOKEN_PARAMS: JwtTokenParams = {
 	request: {
 		method: 'GET',
-		pathname: `/rest/agile/1.0/issue/${uuidv4()}`,
+		pathname: `/rest/api/3/issue/${uuidv4()}`,
 		query: {
 			param1: uuidv4,
 		},

--- a/src/web/testing/jira-api-mocks.ts
+++ b/src/web/testing/jira-api-mocks.ts
@@ -42,7 +42,7 @@ export const mockJiraGetIssueEndpoint = ({
 	status?: HttpStatusCode;
 	response?: Record<string, unknown>;
 }) => {
-	nock(baseUrl).get(`/rest/agile/1.0/issue/${issueId}`).reply(status, response);
+	nock(baseUrl).get(`/rest/api/3/issue/${issueId}`).reply(status, response);
 };
 
 export const mockJiraGetIssuePropertyEndpoint = ({


### PR DESCRIPTION
Adds support for JSM & JWM

Jira Software Cloud (JSW) APIs do not support Jira Service Management (JSM) or Jira Work Management (JWM): https://developer.atlassian.com/cloud/jira/software/rest/api-group-issue/#api-rest-agile-1-0-issue-issueidorkey-get

Jira Cloud Platform APIs support all flavours of Jira: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-issueidorkey-get

This PR changes the API used to fetch the Jira issue so that associating a Figma design works in JSM and JWM.

Previously attempting to associate a design resulted in an error with a 403 response from the Jira issue API:

<img width="449" alt="Screenshot 2023-11-20 at 6 55 46 pm" src="https://github.com/atlassian-labs/figma-for-jira/assets/11870896/9a0a4409-9c5c-46cc-a218-ef6910cd51fe">

With this change we are able to associate a design in JSM and JWM:

https://www.loom.com/share/23cdaf21b66f4a4a81e876476af8dc64