### PR TITLE
FABB-62 Associate design use case fallback

### DIFF
--- a/src/infrastructure/figma/transformers/figma-node-transformer.test.ts
+++ b/src/infrastructure/figma/transformers/figma-node-transformer.test.ts
@@ -1,4 +1,5 @@
 import {
+	DesignNodeNotFoundError,
 	findNodeDataInFile,
 	mapNodeStatusToDevStatus,
 	mapNodeTypeToDesignType,
@@ -41,7 +42,7 @@ describe('transformNodeToAtlassianDesign', () => {
 		jest.restoreAllMocks();
 	});
 
-	it('should throw null if node is not found', () => {
+	it('should throw error if node is not found', () => {
 		const fileKey = generateFigmaFileKey();
 		const fileResponse = generateGetFileResponse({
 			document: {
@@ -55,7 +56,7 @@ describe('transformNodeToAtlassianDesign', () => {
 				nodeId: '100:1',
 				fileResponse,
 			}),
-		).toThrow();
+		).toThrow(DesignNodeNotFoundError);
 	});
 });
 

--- a/src/infrastructure/figma/transformers/figma-node-transformer.ts
+++ b/src/infrastructure/figma/transformers/figma-node-transformer.ts
@@ -5,6 +5,7 @@ import {
 	getUpdateSequenceNumberFrom,
 } from './utils';
 
+import { CauseAwareError } from '../../../common/errors';
 import type { AtlassianDesign } from '../../../domain/entities';
 import {
 	AtlassianDesignStatus,
@@ -38,7 +39,8 @@ export const transformNodeToAtlassianDesign = ({
 		fileResponse,
 	});
 
-	if (result === null) throw new Error('Node is not found in the given File.');
+	if (result === null)
+		throw new DesignNodeNotFoundError('Node is not found in the given File.');
 
 	return result;
 };
@@ -181,3 +183,5 @@ export const mapNodeTypeToDesignType = (type: string): AtlassianDesignType => {
 			return AtlassianDesignType.OTHER;
 	}
 };
+
+export class DesignNodeNotFoundError extends CauseAwareError {}

--- a/src/usecases/associate-design-use-case.test.ts
+++ b/src/usecases/associate-design-use-case.test.ts
@@ -33,7 +33,9 @@ describe('associateDesignUseCase', () => {
 				issueId: issue.id,
 				connectInstallation,
 			});
-		jest.spyOn(figmaService, 'getDesign').mockResolvedValue(atlassianDesign);
+		jest
+			.spyOn(figmaService, 'getDesignOrParent')
+			.mockResolvedValue(atlassianDesign);
 		jest.spyOn(jiraService, 'getIssue').mockResolvedValue(issue);
 		jest.spyOn(jiraService, 'submitDesign').mockResolvedValue();
 		jest
@@ -48,7 +50,7 @@ describe('associateDesignUseCase', () => {
 
 		await associateDesignUseCase.execute(params);
 
-		expect(figmaService.getDesign).toHaveBeenCalledWith(designId, {
+		expect(figmaService.getDesignOrParent).toHaveBeenCalledWith(designId, {
 			atlassianUserId: params.atlassianUserId,
 			connectInstallationId: params.connectInstallation.id,
 		});
@@ -101,7 +103,9 @@ describe('associateDesignUseCase', () => {
 				issueId: issue.id,
 				connectInstallation,
 			});
-		jest.spyOn(figmaService, 'getDesign').mockResolvedValue(atlassianDesign);
+		jest
+			.spyOn(figmaService, 'getDesignOrParent')
+			.mockResolvedValue(atlassianDesign);
 		jest.spyOn(jiraService, 'getIssue').mockResolvedValue(issue);
 		jest.spyOn(jiraService, 'submitDesign').mockRejectedValue(new Error());
 		jest

--- a/src/usecases/associate-design-use-case.ts
+++ b/src/usecases/associate-design-use-case.ts
@@ -39,7 +39,7 @@ export const associateDesignUseCase = {
 			);
 
 			const [design, issue] = await Promise.all([
-				figmaService.getDesign(figmaDesignId, {
+				figmaService.getDesignOrParent(figmaDesignId, {
 					atlassianUserId,
 					connectInstallationId: connectInstallation.id,
 				}),


### PR DESCRIPTION
This fixes the issue identified by Reid during the Blitz where the backfill fails when a design URL from the issue property points to a node in Figma that no longer exists: [https://figlassian.atlassian.net/browse/FABB-62](https://figlassian.atlassian.net/browse/FABB-62)

With this change: when associating a design, the app will associate the file if the node doesn't exist.

We discussed returning more meaningful errors when this occurs and this work is still necessary for other scenarios e.g. when the file doesn't exist, however after speaking with Andrea we decided that the fallback Reid suggested in the ticket was a better outcome for users and appropriate because:

1. Figma defaults to the file when pasting the link the browser
2. The live embed in the old experience renders the file when then node doesn't exist