### PR TITLE
FABB-69: Return `HTTP 404` when associate a non-existent Figma File or Node

### DIFF
--- a/src/infrastructure/figma/transformers/figma-node-transformer.test.ts
+++ b/src/infrastructure/figma/transformers/figma-node-transformer.test.ts
@@ -1,5 +1,4 @@
 import {
-	DesignNodeNotFoundError,
 	findNodeDataInFile,
 	mapNodeStatusToDevStatus,
 	mapNodeTypeToDesignType,
@@ -56,7 +55,7 @@ describe('transformNodeToAtlassianDesign', () => {
 				nodeId: '100:1',
 				fileResponse,
 			}),
-		).toThrow(DesignNodeNotFoundError);
+		).toThrow();
 	});
 });
 

--- a/src/infrastructure/figma/transformers/figma-node-transformer.ts
+++ b/src/infrastructure/figma/transformers/figma-node-transformer.ts
@@ -5,7 +5,6 @@ import {
 	getUpdateSequenceNumberFrom,
 } from './utils';
 
-import { CauseAwareError } from '../../../common/errors';
 import type { AtlassianDesign } from '../../../domain/entities';
 import {
 	AtlassianDesignStatus,
@@ -39,8 +38,7 @@ export const transformNodeToAtlassianDesign = ({
 		fileResponse,
 	});
 
-	if (result === null)
-		throw new DesignNodeNotFoundError('Node is not found in the given File.');
+	if (result === null) throw new Error('Node is not found in the given File.');
 
 	return result;
 };
@@ -183,5 +181,3 @@ export const mapNodeTypeToDesignType = (type: string): AtlassianDesignType => {
 			return AtlassianDesignType.OTHER;
 	}
 };
-
-export class DesignNodeNotFoundError extends CauseAwareError {}

--- a/src/usecases/associate-design-use-case.test.ts
+++ b/src/usecases/associate-design-use-case.test.ts
@@ -1,5 +1,6 @@
 import type { AssociateDesignUseCaseParams } from './associate-design-use-case';
 import { associateDesignUseCase } from './associate-design-use-case';
+import { FigmaDesignNotFoundUseCaseResultError } from './errors';
 import { generateAssociateDesignUseCaseParams } from './testing';
 
 import type { AssociatedFigmaDesign } from '../domain/entities';
@@ -88,6 +89,24 @@ describe('associateDesignUseCase', () => {
 			associatedWithAri: params.associateWith.ari,
 			connectInstallationId: connectInstallation.id,
 		});
+	});
+
+	it('should throw FigmaDesignNotFoundUseCaseResultError when design is not found', async () => {
+		const connectInstallation = generateConnectInstallation();
+		const issue = generateJiraIssue();
+		const fileKey = generateFigmaFileKey();
+		const params: AssociateDesignUseCaseParams =
+			generateAssociateDesignUseCaseParams({
+				entityUrl: generateFigmaDesignUrl({ fileKey }),
+				issueId: issue.id,
+				connectInstallation,
+			});
+		jest.spyOn(figmaService, 'getDesignOrParent').mockResolvedValue(null);
+		jest.spyOn(jiraService, 'getIssue').mockResolvedValue(issue);
+
+		await expect(() =>
+			associateDesignUseCase.execute(params),
+		).rejects.toBeInstanceOf(FigmaDesignNotFoundUseCaseResultError);
 	});
 
 	it('should not save associated Figma design when design submission fails', async () => {

--- a/src/usecases/associate-design-use-case.ts
+++ b/src/usecases/associate-design-use-case.ts
@@ -1,4 +1,7 @@
-import { ForbiddenByFigmaUseCaseResultError } from './errors';
+import {
+	FigmaDesignNotFoundUseCaseResultError,
+	ForbiddenByFigmaUseCaseResultError,
+} from './errors';
 import type { AtlassianEntity } from './types';
 
 import type { AtlassianDesign, ConnectInstallation } from '../domain/entities';
@@ -45,6 +48,8 @@ export const associateDesignUseCase = {
 				}),
 				jiraService.getIssue(associateWith.id, connectInstallation),
 			]);
+
+			if (!design) throw new FigmaDesignNotFoundUseCaseResultError();
 
 			const designIssueAssociation =
 				AtlassianAssociation.createDesignIssueAssociation(associateWith.ari);

--- a/src/usecases/disassociate-design-use-case.ts
+++ b/src/usecases/disassociate-design-use-case.ts
@@ -1,4 +1,5 @@
 import {
+	FigmaDesignNotFoundUseCaseResultError,
 	ForbiddenByFigmaUseCaseResultError,
 	InvalidInputUseCaseResultError,
 } from './errors';
@@ -55,6 +56,9 @@ export const disassociateDesignUseCase = {
 				}),
 				jiraService.getIssue(disassociateFrom.id, connectInstallation),
 			]);
+
+			// TODO: Remove this once FABB-56 is resolved.
+			if (!design) throw new FigmaDesignNotFoundUseCaseResultError();
 
 			const designIssueAssociation =
 				AtlassianAssociation.createDesignIssueAssociation(disassociateFrom.ari);

--- a/src/usecases/errors.ts
+++ b/src/usecases/errors.ts
@@ -7,13 +7,19 @@ import { CauseAwareError } from '../common/errors';
 export class UseCaseResultError extends CauseAwareError {}
 
 export class ForbiddenByFigmaUseCaseResultError extends UseCaseResultError {
-	constructor(cause: Error) {
+	constructor(cause?: Error) {
 		super('Not authorized to access Figma API.', cause);
 	}
 }
 
+export class FigmaDesignNotFoundUseCaseResultError extends UseCaseResultError {
+	constructor(cause?: Error) {
+		super('Design is not found.', cause);
+	}
+}
+
 export class PaidFigmaPlanRequiredUseCaseResultError extends UseCaseResultError {
-	constructor(cause: Error) {
+	constructor(cause?: Error) {
 		super('You need a paid Figma plan to perform this operation.', cause);
 	}
 }

--- a/src/web/middleware/error-handler-middleware.ts
+++ b/src/web/middleware/error-handler-middleware.ts
@@ -2,6 +2,7 @@ import { HttpStatusCode } from 'axios';
 import type { NextFunction, Request, Response } from 'express';
 
 import {
+	FigmaDesignNotFoundUseCaseResultError,
 	ForbiddenByFigmaUseCaseResultError,
 	InvalidInputUseCaseResultError,
 	PaidFigmaPlanRequiredUseCaseResultError,
@@ -38,13 +39,18 @@ export const errorHandlerMiddleware = (
 			return next();
 		}
 
+		if (err instanceof PaidFigmaPlanRequiredUseCaseResultError) {
+			res.status(HttpStatusCode.PaymentRequired).send({ message: err.message });
+			return next();
+		}
+
 		if (err instanceof ForbiddenByFigmaUseCaseResultError) {
 			res.status(HttpStatusCode.Forbidden).send({ message: err.message });
 			return next();
 		}
 
-		if (err instanceof PaidFigmaPlanRequiredUseCaseResultError) {
-			res.status(HttpStatusCode.PaymentRequired).send({ message: err.message });
+		if (err instanceof FigmaDesignNotFoundUseCaseResultError) {
+			res.status(HttpStatusCode.NotFound).send({ message: err.message });
 			return next();
 		}
 	}


### PR DESCRIPTION
## Changes

- **feat:** Updates the `POST entities/associateEntity` endpoint to return `HTTP 404 Not Found` when a Figma File or Node does not exist.
- **refactor:** Applies minor improvements to `FigmaService`.