### PR TITLE
FABB-69 Remove Figma dependency from disassociate design use case

### DIFF
--- a/src/infrastructure/figma/figma-service.ts
+++ b/src/infrastructure/figma/figma-service.ts
@@ -219,24 +219,24 @@ export class FigmaService {
 		this.withErrorTranslation(async () => {
 			const { accessToken } = await figmaAuthService.getCredentials(user);
 
-			const { dev_resources } = await figmaClient.getDevResources({
-				fileKey: designId.fileKey,
-				nodeIds: [designId.nodeIdOrDefaultDocumentId],
-				accessToken,
-			});
-
-			const devResourceToDelete = dev_resources.find(
-				(devResource) => devResource.url === devResourceUrl,
-			);
-
-			if (!devResourceToDelete) {
-				getLogger().info(
-					`No matching dev resource found to delete for file ${designId.fileKey} and node ${designId.nodeId}`,
-				);
-				return;
-			}
-
 			try {
+				const { dev_resources } = await figmaClient.getDevResources({
+					fileKey: designId.fileKey,
+					nodeIds: [designId.nodeIdOrDefaultDocumentId],
+					accessToken,
+				});
+
+				const devResourceToDelete = dev_resources.find(
+					(devResource) => devResource.url === devResourceUrl,
+				);
+
+				if (!devResourceToDelete) {
+					getLogger().info(
+						`No matching dev resource found to delete for file ${designId.fileKey} and node ${designId.nodeId}`,
+					);
+					return;
+				}
+
 				await figmaClient.deleteDevResource({
 					fileKey: designId.fileKey,
 					devResourceId: devResourceToDelete.id,

--- a/src/usecases/disassociate-design-use-case.test.ts
+++ b/src/usecases/disassociate-design-use-case.test.ts
@@ -2,6 +2,8 @@ import type { DisassociateDesignUseCaseParams } from './disassociate-design-use-
 import { disassociateDesignUseCase } from './disassociate-design-use-case';
 import { generateDisassociateDesignUseCaseParams } from './testing';
 
+import * as configModule from '../config';
+import { mockConfig } from '../config/testing';
 import {
 	AtlassianAssociation,
 	AtlassianDesignStatus,
@@ -22,16 +24,25 @@ import {
 import { jiraService } from '../infrastructure/jira';
 import { associatedFigmaDesignRepository } from '../infrastructure/repositories';
 
+jest.mock('../config', () => {
+	return {
+		...jest.requireActual('../config'),
+		getConfig: jest.fn(),
+	};
+});
+
 describe('disassociateDesignUseCase', () => {
 	const currentDate = new Date();
 
 	beforeEach(() => {
+		(configModule.getConfig as jest.Mock).mockReturnValue(mockConfig);
 		jest
 			.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] })
 			.setSystemTime(currentDate);
 	});
 
 	afterEach(() => {
+		jest.restoreAllMocks();
 		jest.useRealTimers();
 	});
 


### PR DESCRIPTION
Uses a stub design with updateSequenceNumber = 0 to remove the issue association in the disassociate design use case. This removes the dependency on fetching the Figma design for the disassociate use case which fixes the bug when the design has been deleted.

In the future we would like to provide an API to allow removing the issue association without sending any design data which will allow removal of the design stub.