### PR TITLE
Fix 4xx error handling in the connect teams endpoint

### DIFF
--- a/src/infrastructure/figma/figma-service.test.ts
+++ b/src/infrastructure/figma/figma-service.test.ts
@@ -22,7 +22,7 @@ import {
 } from './figma-client/testing';
 import {
 	figmaService,
-	InvalidRequestFigmaServiceError,
+	InvalidInputFigmaServiceError,
 	PaidPlanRequiredFigmaServiceError,
 } from './figma-service';
 import {
@@ -902,7 +902,7 @@ describe('FigmaService', () => {
 		});
 	});
 
-	describe.only('getTeamName', () => {
+	describe('getTeamName', () => {
 		beforeEach(() => {
 			jest
 				.spyOn(figmaAuthService, 'getCredentials')
@@ -935,7 +935,7 @@ describe('FigmaService', () => {
 
 			await expect(
 				figmaService.getTeamName(teamId, MOCK_CONNECT_USER_INFO),
-			).rejects.toThrow(InvalidRequestFigmaServiceError);
+			).rejects.toThrow(InvalidInputFigmaServiceError);
 		});
 
 		it('should throw an error when the request fails', async () => {

--- a/src/infrastructure/figma/figma-service.test.ts
+++ b/src/infrastructure/figma/figma-service.test.ts
@@ -22,6 +22,7 @@ import {
 } from './figma-client/testing';
 import {
 	figmaService,
+	InvalidRequestFigmaServiceError,
 	PaidPlanRequiredFigmaServiceError,
 } from './figma-service';
 import {
@@ -901,7 +902,7 @@ describe('FigmaService', () => {
 		});
 	});
 
-	describe('getTeamName', () => {
+	describe.only('getTeamName', () => {
 		beforeEach(() => {
 			jest
 				.spyOn(figmaAuthService, 'getCredentials')
@@ -921,6 +922,32 @@ describe('FigmaService', () => {
 				MOCK_CONNECT_USER_INFO,
 			);
 			expect(result).toStrictEqual(teamName);
+		});
+
+		it('should throw an invalid request error when the team id is invalid', async () => {
+			const teamId = uuidv4();
+
+			jest.spyOn(figmaClient, 'getTeamProjects').mockRejectedValue(
+				new BadRequestHttpClientError('Failed', {
+					message: 'No such team',
+				}),
+			);
+
+			await expect(
+				figmaService.getTeamName(teamId, MOCK_CONNECT_USER_INFO),
+			).rejects.toThrow(InvalidRequestFigmaServiceError);
+		});
+
+		it('should throw an error when the request fails', async () => {
+			const teamId = uuidv4();
+
+			jest
+				.spyOn(figmaClient, 'getTeamProjects')
+				.mockRejectedValue(new NotFoundHttpClientError());
+
+			await expect(
+				figmaService.getTeamName(teamId, MOCK_CONNECT_USER_INFO),
+			).rejects.toThrow();
 		});
 	});
 });

--- a/src/infrastructure/figma/figma-service.ts
+++ b/src/infrastructure/figma/figma-service.ts
@@ -347,7 +347,7 @@ export class FigmaService {
 					e instanceof BadRequestHttpClientError &&
 					isOfSchema(e.response, ERROR_RESPONSE_SCHEMA)
 				) {
-					throw new InvalidRequestFigmaServiceError(e.response.message, e);
+					throw new InvalidInputFigmaServiceError(e.response.message, e);
 				}
 
 				throw e;
@@ -458,7 +458,6 @@ export class FigmaService {
 		try {
 			return await fn();
 		} catch (e: unknown) {
-			console.log('with error translation', e);
 			if (
 				e instanceof MissingOrInvalidCredentialsFigmaAuthServiceError ||
 				e instanceof UnauthorizedHttpClientError ||
@@ -481,4 +480,4 @@ export class UnauthorizedFigmaServiceError extends CauseAwareError {}
 
 export class PaidPlanRequiredFigmaServiceError extends CauseAwareError {}
 
-export class InvalidRequestFigmaServiceError extends CauseAwareError {}
+export class InvalidInputFigmaServiceError extends CauseAwareError {}

--- a/src/usecases/connect-figma-team-use-case.ts
+++ b/src/usecases/connect-figma-team-use-case.ts
@@ -10,7 +10,7 @@ import type { ConnectInstallation, FigmaTeamSummary } from '../domain/entities';
 import { FigmaTeamAuthStatus } from '../domain/entities';
 import {
 	figmaService,
-	InvalidRequestFigmaServiceError,
+	InvalidInputFigmaServiceError,
 	PaidPlanRequiredFigmaServiceError,
 	UnauthorizedFigmaServiceError,
 } from '../infrastructure/figma';
@@ -66,7 +66,7 @@ export const connectFigmaTeamUseCase = {
 				throw new PaidFigmaPlanRequiredUseCaseResultError(e);
 			}
 
-			if (e instanceof InvalidRequestFigmaServiceError) {
+			if (e instanceof InvalidInputFigmaServiceError) {
 				throw new InvalidInputUseCaseResultError(e.message, e);
 			}
 

--- a/src/usecases/connect-figma-team-use-case.ts
+++ b/src/usecases/connect-figma-team-use-case.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import {
 	ForbiddenByFigmaUseCaseResultError,
+	InvalidInputUseCaseResultError,
 	PaidFigmaPlanRequiredUseCaseResultError,
 } from './errors';
 
@@ -9,6 +10,7 @@ import type { ConnectInstallation, FigmaTeamSummary } from '../domain/entities';
 import { FigmaTeamAuthStatus } from '../domain/entities';
 import {
 	figmaService,
+	InvalidRequestFigmaServiceError,
 	PaidPlanRequiredFigmaServiceError,
 	UnauthorizedFigmaServiceError,
 } from '../infrastructure/figma';
@@ -62,6 +64,10 @@ export const connectFigmaTeamUseCase = {
 
 			if (e instanceof PaidPlanRequiredFigmaServiceError) {
 				throw new PaidFigmaPlanRequiredUseCaseResultError(e);
+			}
+
+			if (e instanceof InvalidRequestFigmaServiceError) {
+				throw new InvalidInputUseCaseResultError(e.message, e);
 			}
 
 			throw e;


### PR DESCRIPTION
Suppose you input an invalid team ID when you connect a team. 

Currently, we treat that as a 500 error in the POST /admin/teams/<team_id>/connect endpoint. This PR updates the logic to treat this error (and other similar errors) as 400 errors instead. Under the hood, the Figma REST API returns a 400 error in this case, and we're just bubbling up that error.

Note: In general, the Figma API returns a 400 error if there is no team, the team is deleted, or the user does not have access to the team. 

## Testing
- I added a unit test.
- I tested the behavior in app.

Note that I kept the UI the same. The existing UI message seems reasonable enough, but open to tweaking if need be in a separate PR.

before | after
--- | ---
<img width="600" alt="before" src="https://github.com/atlassian-labs/figma-for-jira/assets/116598948/4585ae24-2f46-409d-a848-7f9b2c21d004"> | <img width="600" alt="after" src="https://github.com/atlassian-labs/figma-for-jira/assets/116598948/1d148049-9246-47b7-a63c-1c9c076b3011">
