### PR TITLE
[ci] Remove side effect of integration tests

### DIFF
--- a/scripts/start-sandbox.sh
+++ b/scripts/start-sandbox.sh
@@ -22,4 +22,4 @@ until [ "$(docker inspect -f '{{.State.Health.Status}}' "$DB_CONTAINER_NAME")" =
 done
 
 echo 'Running DB migrations...'
-dotenv -e "$ENV_FILE" -- prisma migrate dev
+dotenv -e "$ENV_FILE" -- prisma migrate deploy


### PR DESCRIPTION
We run integration tests in the CI pipeline before we build the docker container - [see the Github workflow](https://github.com/atlassian-labs/figma-for-jira/blob/0e831bb5de24d88fb31388cdfa3a090ba94777f8/.github/workflows/actions.yml#L30). The integration tests calls `scripts/start-sandbox.sh`. 

I notice that `prisma migrate dev` has a side-effect. Per [the Prisma docs](https://www.prisma.io/docs/concepts/components/prisma-migrate/migrate-development-production#:~:text=If%20it%20detects%20changes%20to,new%20migration%20from%20these%20changes): If `prisma migrate dev` detects a change to the Prisma schema, it generates a new migration file from these changes.

This resulted in some spooky behavior on our end:
- Our database schema is a bit different from the one in schema.prisma since it's managed by our database team.
- Running the integration tests generated a migration file, which said to drop some important tables.
- The docker build step copied the migration file to our staging / prod containers.

![image](https://github.com/atlassian-labs/figma-for-jira/assets/116598948/24b0beb3-495c-49e3-a511-81893511e54e)

This PR updates the integration test script to use `prisma migrate deploy` instead. That way, we won't automatically generate migration files as part of the build process. This reduces the risk of copying over auto-generated files in our staging / prod deploy process.

Note that we also use scripts/start-sandbox.sh for local development. This means there may be an extra step in local development if you make schema changes.