### PR TITLE
FABB-42: Fix admin success screen long team name

### DIFF
--- a/admin/src/pages/teams/connect-teams-success-screen.tsx
+++ b/admin/src/pages/teams/connect-teams-success-screen.tsx
@@ -47,7 +47,7 @@ export function ConnectTeamSuccessScreen({
 				css={css`
 					display: flex;
 					width: 580px;
-					padding: 32px 0px;
+					padding: 32px;
 					flex-direction: column;
 					align-items: center;
 					gap: 24px;
@@ -70,6 +70,7 @@ export function ConnectTeamSuccessScreen({
 							color: ${token('color.text')};
 							font-size: 16px;
 							font-weight: 600;
+							text-align: center;
 						`}
 					>
 						It's time to let {teamName} know that Figma for Jira is connected


### PR DESCRIPTION
The success screen looked bad when people connected teams with long names. This PR fixes that

Before: 
![image](https://github.com/atlassian-labs/figma-for-jira/assets/6136959/82e40bb3-e063-40a6-8069-e4845b1b0a04)

After:
![image](https://github.com/atlassian-labs/figma-for-jira/assets/6136959/33702dc3-8bc5-4a52-adef-fcf66afc267b)
