### PR TITLE
FABB-72: Fix error handling for invalid file URLs

### DIFF
--- a/src/domain/entities/figma-design-identifier.test.ts
+++ b/src/domain/entities/figma-design-identifier.test.ts
@@ -6,8 +6,6 @@ import {
 	generateFigmaNodeId,
 } from './testing';
 
-import { InvalidInputUseCaseResultError } from '../../usecases/errors';
-
 describe('FigmaDesignIdentifier', () => {
 	describe('constructor', () => {
 		it('should throw when fileKey is empty string', () => {
@@ -124,9 +122,7 @@ describe('FigmaDesignIdentifier', () => {
 				`https://www.figma.com/files/project/176167247/Team-project?fuid=1166427116484924636`,
 			),
 		])('should throw when URL has an unexpected format', (input: URL) => {
-			expect(() => FigmaDesignIdentifier.fromFigmaDesignUrl(input)).toThrow(
-				InvalidInputUseCaseResultError,
-			);
+			expect(() => FigmaDesignIdentifier.fromFigmaDesignUrl(input)).toThrow();
 		});
 	});
 

--- a/src/domain/entities/figma-design-identifier.test.ts
+++ b/src/domain/entities/figma-design-identifier.test.ts
@@ -6,6 +6,8 @@ import {
 	generateFigmaNodeId,
 } from './testing';
 
+import { InvalidInputUseCaseResultError } from '../../usecases/errors';
+
 describe('FigmaDesignIdentifier', () => {
 	describe('constructor', () => {
 		it('should throw when fileKey is empty string', () => {
@@ -118,8 +120,13 @@ describe('FigmaDesignIdentifier', () => {
 			new URL(`https://www.figma.com/proto`),
 			new URL(`https://www.figma.com?param=file%2Fsome-id`),
 			new URL(`https://www.figma.com?param=proto%2Fsome-id`),
+			new URL(
+				`https://www.figma.com/files/project/176167247/Team-project?fuid=1166427116484924636`,
+			),
 		])('should throw when URL has an unexpected format', (input: URL) => {
-			expect(() => FigmaDesignIdentifier.fromFigmaDesignUrl(input)).toThrow();
+			expect(() => FigmaDesignIdentifier.fromFigmaDesignUrl(input)).toThrow(
+				InvalidInputUseCaseResultError,
+			);
 		});
 	});
 

--- a/src/domain/entities/figma-design-identifier.ts
+++ b/src/domain/entities/figma-design-identifier.ts
@@ -1,5 +1,3 @@
-import { InvalidInputUseCaseResultError } from '../../usecases/errors';
-
 const FIGMA_DOCUMENT_NODE_ID = '0:0';
 
 /**
@@ -45,9 +43,7 @@ export class FigmaDesignIdentifier {
 		const nodeId = url.searchParams.get('node-id')?.replace('-', ':');
 
 		if (!fileKey)
-			throw new InvalidInputUseCaseResultError(
-				`Received invalid Figma URL: ${url.toString()}`,
-			);
+			throw new Error(`Received invalid Figma URL: ${url.toString()}`);
 
 		return new FigmaDesignIdentifier(fileKey, nodeId);
 	};

--- a/src/domain/entities/figma-design-identifier.ts
+++ b/src/domain/entities/figma-design-identifier.ts
@@ -1,3 +1,5 @@
+import { InvalidInputUseCaseResultError } from '../../usecases/errors';
+
 const FIGMA_DOCUMENT_NODE_ID = '0:0';
 
 /**
@@ -43,7 +45,9 @@ export class FigmaDesignIdentifier {
 		const nodeId = url.searchParams.get('node-id')?.replace('-', ':');
 
 		if (!fileKey)
-			throw new Error(`Received invalid Figma URL: ${url.toString()}`);
+			throw new InvalidInputUseCaseResultError(
+				`Received invalid Figma URL: ${url.toString()}`,
+			);
 
 		return new FigmaDesignIdentifier(fileKey, nodeId);
 	};

--- a/src/usecases/associate-design-use-case.ts
+++ b/src/usecases/associate-design-use-case.ts
@@ -28,6 +28,7 @@ export type AssociateDesignUseCaseParams = {
 export const associateDesignUseCase = {
 	/**
 	 * @throws {ForbiddenByFigmaUseCaseResultError} Not authorized to access Figma.
+	 * @throws {InvalidInputUseCaseResultError} The given design URL is invalid.
 	 */
 	execute: async ({
 		designUrl,

--- a/src/usecases/associate-design-use-case.ts
+++ b/src/usecases/associate-design-use-case.ts
@@ -35,9 +35,16 @@ export const associateDesignUseCase = {
 		atlassianUserId,
 		connectInstallation,
 	}: AssociateDesignUseCaseParams): Promise<AtlassianDesign> => {
+		let figmaDesignId: FigmaDesignIdentifier;
 		try {
-			const figmaDesignId = FigmaDesignIdentifier.fromFigmaDesignUrl(designUrl);
+			figmaDesignId = FigmaDesignIdentifier.fromFigmaDesignUrl(designUrl);
+		} catch (e) {
+			throw new InvalidInputUseCaseResultError(
+				'The given design URL is invalid',
+			);
+		}
 
+		try {
 			const [design, issue] = await Promise.all([
 				figmaService.getDesignOrParent(figmaDesignId, {
 					atlassianUserId,
@@ -90,9 +97,6 @@ export const associateDesignUseCase = {
 		} catch (e) {
 			if (e instanceof UnauthorizedFigmaServiceError) {
 				throw new ForbiddenByFigmaUseCaseResultError(e);
-			}
-			if (e instanceof InvalidInputUseCaseResultError) {
-				throw new InvalidInputUseCaseResultError(e.message, e);
 			}
 
 			throw e;

--- a/src/usecases/associate-design-use-case.ts
+++ b/src/usecases/associate-design-use-case.ts
@@ -1,6 +1,7 @@
 import {
 	FigmaDesignNotFoundUseCaseResultError,
 	ForbiddenByFigmaUseCaseResultError,
+	InvalidInputUseCaseResultError,
 } from './errors';
 import type { AtlassianEntity } from './types';
 
@@ -89,6 +90,9 @@ export const associateDesignUseCase = {
 		} catch (e) {
 			if (e instanceof UnauthorizedFigmaServiceError) {
 				throw new ForbiddenByFigmaUseCaseResultError(e);
+			}
+			if (e instanceof InvalidInputUseCaseResultError) {
+				throw new InvalidInputUseCaseResultError(e.message, e);
 			}
 
 			throw e;

--- a/src/usecases/backfill-design-use-case.test.ts
+++ b/src/usecases/backfill-design-use-case.test.ts
@@ -1,5 +1,6 @@
 import type { BackfillDesignUseCaseParams } from './backfill-design-use-case';
 import { backfillDesignUseCase } from './backfill-design-use-case';
+import { InvalidInputUseCaseResultError } from './errors';
 import { generateBackfillDesignUseCaseParams } from './testing';
 
 import type { AssociatedFigmaDesign } from '../domain/entities';
@@ -192,6 +193,26 @@ describe('backfillDesignUseCase', () => {
 		jest.spyOn(associatedFigmaDesignRepository, 'upsert');
 
 		await expect(() => backfillDesignUseCase.execute(params)).rejects.toThrow();
+		expect(associatedFigmaDesignRepository.upsert).not.toHaveBeenCalled();
+	});
+
+	it('should throw InvalidInputUseCaseResultError when the file is not valid', async () => {
+		const connectInstallation = generateConnectInstallation();
+		const issue = generateJiraIssue();
+
+		const params: BackfillDesignUseCaseParams =
+			generateBackfillDesignUseCaseParams({
+				// This URL is not valid because it does not contain a file key.
+				designUrl: new URL(
+					'https://www.figma.com/files/project/176167247/Team-project?fuid=1166427116484924636',
+				),
+				issueId: issue.id,
+				connectInstallation,
+			});
+
+		await expect(() => backfillDesignUseCase.execute(params)).rejects.toThrow(
+			InvalidInputUseCaseResultError,
+		);
 		expect(associatedFigmaDesignRepository.upsert).not.toHaveBeenCalled();
 	});
 });

--- a/src/usecases/backfill-design-use-case.ts
+++ b/src/usecases/backfill-design-use-case.ts
@@ -1,4 +1,7 @@
-import { ForbiddenByFigmaUseCaseResultError } from './errors';
+import {
+	ForbiddenByFigmaUseCaseResultError,
+	InvalidInputUseCaseResultError,
+} from './errors';
 import type { AtlassianEntity } from './types';
 
 import type { AtlassianDesign, ConnectInstallation } from '../domain/entities';
@@ -34,9 +37,16 @@ export const backfillDesignUseCase = {
 		atlassianUserId,
 		connectInstallation,
 	}: BackfillDesignUseCaseParams): Promise<AtlassianDesign> => {
+		let figmaDesignId: FigmaDesignIdentifier;
 		try {
-			const figmaDesignId = FigmaDesignIdentifier.fromFigmaDesignUrl(designUrl);
+			figmaDesignId = FigmaDesignIdentifier.fromFigmaDesignUrl(designUrl);
+		} catch (e) {
+			throw new InvalidInputUseCaseResultError(
+				'The given design URL is invalid',
+			);
+		}
 
+		try {
 			// eslint-disable-next-line prefer-const
 			let [design, issue] = await Promise.all([
 				figmaService.getDesignOrParent(figmaDesignId, {

--- a/src/usecases/backfill-design-use-case.ts
+++ b/src/usecases/backfill-design-use-case.ts
@@ -30,6 +30,7 @@ export const backfillDesignUseCase = {
 	 * Backfills designs created via the old "Figma for Jira" experience or the "Jira" widget in Figma.
 	 *
 	 * @throws {ForbiddenByFigmaUseCaseResultError} Not authorized to access Figma.
+	 * @throws {InvalidInputUseCaseResultError} The given design URL is invalid.
 	 */
 	execute: async ({
 		designUrl,


### PR DESCRIPTION
Suppose you have a project URL like https://www.figma.com/files/project/176167247/Team-project?fuid=1166427116484924636

Suppose you go to a Jira issue > Link a design URL. Currently, this causes a 500 error in POST /entities/associateEntity.

This PR updates the error handling so we correctly log it as a 400 error.

Ticket: https://figlassian.atlassian.net/browse/FABB-72

## Testing
- I added unit tests
- I tested locally

before | after
--- | ---
![image](https://github.com/atlassian-labs/figma-for-jira/assets/116598948/c32d3e27-6d16-4739-b9dc-522f791617bd) | ![image](https://github.com/atlassian-labs/figma-for-jira/assets/116598948/df2657ad-1bf3-4bd2-9b0a-fae4b61e48a3)
