### PR TITLE
FABB-73: Add error handling for Jira getIssue 404

### DIFF
--- a/src/infrastructure/jira/jira-service.test.ts
+++ b/src/infrastructure/jira/jira-service.test.ts
@@ -13,9 +13,10 @@ import {
 import type { AttachedDesignUrlV2IssuePropertyValue } from './jira-service';
 import {
 	ConfigurationState,
+	IssueNotFoundJiraServiceError,
 	issuePropertyKeys,
-	JiraService,
 	jiraService,
+	JiraService,
 	SubmitDesignJiraServiceError,
 } from './jira-service';
 
@@ -246,6 +247,18 @@ describe('JiraService', () => {
 				jiraIssue.key,
 				connectInstallation,
 			);
+		});
+
+		it('should throw an error if issue is not found', async () => {
+			const connectInstallation = generateConnectInstallation();
+			const jiraIssue = generateJiraIssue();
+			jest
+				.spyOn(jiraClient, 'getIssue')
+				.mockRejectedValue(new NotFoundHttpClientError());
+
+			await expect(() =>
+				jiraService.getIssue(jiraIssue.key, connectInstallation),
+			).rejects.toThrow(IssueNotFoundJiraServiceError);
 		});
 	});
 

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -94,7 +94,14 @@ export class JiraService {
 		issueIdOrKey: string,
 		connectInstallation: ConnectInstallation,
 	): Promise<JiraIssue> => {
-		return await jiraClient.getIssue(issueIdOrKey, connectInstallation);
+		try {
+			return await jiraClient.getIssue(issueIdOrKey, connectInstallation);
+		} catch (err) {
+			if (err instanceof NotFoundHttpClientError) {
+				throw new IssueNotFoundJiraServiceError('Issue not found');
+			}
+			throw err;
+		}
 	};
 
 	saveDesignUrlInIssueProperties = async (
@@ -426,6 +433,8 @@ export class JiraService {
 }
 
 export const jiraService = new JiraService();
+
+export class IssueNotFoundJiraServiceError extends CauseAwareError {}
 
 export class SubmitDesignJiraServiceError extends CauseAwareError {
 	designId?: string;

--- a/src/usecases/associate-design-use-case.ts
+++ b/src/usecases/associate-design-use-case.ts
@@ -2,6 +2,7 @@ import {
 	FigmaDesignNotFoundUseCaseResultError,
 	ForbiddenByFigmaUseCaseResultError,
 	InvalidInputUseCaseResultError,
+	JiraIssueNotFoundUseCaseResultError,
 } from './errors';
 import type { AtlassianEntity } from './types';
 
@@ -15,7 +16,10 @@ import {
 	figmaService,
 	UnauthorizedFigmaServiceError,
 } from '../infrastructure/figma';
-import { jiraService } from '../infrastructure/jira';
+import {
+	IssueNotFoundJiraServiceError,
+	jiraService,
+} from '../infrastructure/jira';
 import { associatedFigmaDesignRepository } from '../infrastructure/repositories';
 
 export type AssociateDesignUseCaseParams = {
@@ -98,6 +102,9 @@ export const associateDesignUseCase = {
 		} catch (e) {
 			if (e instanceof UnauthorizedFigmaServiceError) {
 				throw new ForbiddenByFigmaUseCaseResultError(e);
+			}
+			if (e instanceof IssueNotFoundJiraServiceError) {
+				throw new JiraIssueNotFoundUseCaseResultError(e);
 			}
 
 			throw e;

--- a/src/usecases/backfill-design-use-case.ts
+++ b/src/usecases/backfill-design-use-case.ts
@@ -1,6 +1,7 @@
 import {
 	ForbiddenByFigmaUseCaseResultError,
 	InvalidInputUseCaseResultError,
+	JiraIssueNotFoundUseCaseResultError,
 } from './errors';
 import type { AtlassianEntity } from './types';
 
@@ -15,7 +16,10 @@ import {
 	UnauthorizedFigmaServiceError,
 } from '../infrastructure/figma';
 import { figmaBackfillService } from '../infrastructure/figma/figma-backfill-service';
-import { jiraService } from '../infrastructure/jira';
+import {
+	IssueNotFoundJiraServiceError,
+	jiraService,
+} from '../infrastructure/jira';
 import { associatedFigmaDesignRepository } from '../infrastructure/repositories';
 
 export type BackfillDesignUseCaseParams = {
@@ -104,6 +108,9 @@ export const backfillDesignUseCase = {
 		} catch (e) {
 			if (e instanceof UnauthorizedFigmaServiceError) {
 				throw new ForbiddenByFigmaUseCaseResultError(e);
+			}
+			if (e instanceof IssueNotFoundJiraServiceError) {
+				throw new JiraIssueNotFoundUseCaseResultError(e);
 			}
 
 			throw e;

--- a/src/usecases/errors.ts
+++ b/src/usecases/errors.ts
@@ -12,6 +12,12 @@ export class ForbiddenByFigmaUseCaseResultError extends UseCaseResultError {
 	}
 }
 
+export class JiraIssueNotFoundUseCaseResultError extends UseCaseResultError {
+	constructor(cause?: Error) {
+		super('Issue is not found.', cause);
+	}
+}
+
 export class FigmaDesignNotFoundUseCaseResultError extends UseCaseResultError {
 	constructor(cause?: Error) {
 		super('Design is not found.', cause);

--- a/src/web/middleware/error-handler-middleware.ts
+++ b/src/web/middleware/error-handler-middleware.ts
@@ -5,6 +5,7 @@ import {
 	FigmaDesignNotFoundUseCaseResultError,
 	ForbiddenByFigmaUseCaseResultError,
 	InvalidInputUseCaseResultError,
+	JiraIssueNotFoundUseCaseResultError,
 	PaidFigmaPlanRequiredUseCaseResultError,
 	UseCaseResultError,
 } from '../../usecases';
@@ -49,7 +50,10 @@ export const errorHandlerMiddleware = (
 			return next();
 		}
 
-		if (err instanceof FigmaDesignNotFoundUseCaseResultError) {
+		if (
+			err instanceof FigmaDesignNotFoundUseCaseResultError ||
+			err instanceof JiraIssueNotFoundUseCaseResultError
+		) {
 			res.status(HttpStatusCode.NotFound).send({ message: err.message });
 			return next();
 		}


### PR DESCRIPTION
Suppose you do not have permissions to access a particular Jira issue. Then, the Jira getIssue request gives you a 404. 

Right now, we're mapping this to 500 errors in associateEntity. However, since this is an expected case, this PR tweaks the error handling to map these to 404 errors in the endpoint.

Ticket: https://figlassian.atlassian.net/browse/FABB-73