### PR TITLE
FABB-75: Add error handling for the isAdmin method

### DIFF
--- a/src/infrastructure/jira/jira-service.test.ts
+++ b/src/infrastructure/jira/jira-service.test.ts
@@ -957,7 +957,7 @@ describe('JiraService', () => {
 			expect(result).toBe(false);
 		});
 
-		it('should return false if user has ADMINISTER permission', async () => {
+		it('should return true if user has ADMINISTER permission', async () => {
 			const atlassianUserId = uuidv4();
 			const connectInstallation = generateConnectInstallation();
 			jest.spyOn(jiraClient, 'checkPermissions').mockResolvedValue(
@@ -972,6 +972,19 @@ describe('JiraService', () => {
 			);
 
 			expect(result).toBe(true);
+		});
+
+		it('should return false if the method throws an error', async () => {
+			const atlassianUserId = uuidv4();
+			const connectInstallation = generateConnectInstallation();
+			jest.spyOn(jiraClient, 'checkPermissions').mockRejectedValue(new Error());
+
+			const result = await jiraService.isAdmin(
+				atlassianUserId,
+				connectInstallation,
+			);
+
+			expect(result).toBe(false);
 		});
 	});
 

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -152,15 +152,18 @@ export class JiraService {
 		atlassianUserId: string,
 		connectInstallation: ConnectInstallation,
 	): Promise<boolean> => {
-		const response = await jiraClient.checkPermissions(
-			{
-				accountId: atlassianUserId,
-				globalPermissions: [JIRA_ADMIN_GLOBAL_PERMISSION],
-			},
-			connectInstallation,
-		);
-
-		return response.globalPermissions.includes(JIRA_ADMIN_GLOBAL_PERMISSION);
+		try {
+			const response = await jiraClient.checkPermissions(
+				{
+					accountId: atlassianUserId,
+					globalPermissions: [JIRA_ADMIN_GLOBAL_PERMISSION],
+				},
+				connectInstallation,
+			);
+			return response.globalPermissions.includes(JIRA_ADMIN_GLOBAL_PERMISSION);
+		} catch (err) {
+			return false;
+		}
 	};
 
 	/**

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -23,7 +23,10 @@ import {
 	AtlassianAssociation,
 	FigmaDesignIdentifier,
 } from '../../domain/entities';
-import { NotFoundHttpClientError } from '../http-client-errors';
+import {
+	ForbiddenHttpClientError,
+	NotFoundHttpClientError,
+} from '../http-client-errors';
 import { getLogger } from '../logger';
 
 type SubmitDesignParams = {
@@ -162,7 +165,10 @@ export class JiraService {
 			);
 			return response.globalPermissions.includes(JIRA_ADMIN_GLOBAL_PERMISSION);
 		} catch (err) {
-			return false;
+			if (err instanceof ForbiddenHttpClientError) {
+				throw new ForbiddenByJiraServiceError();
+			}
+			throw err;
 		}
 	};
 
@@ -481,3 +487,5 @@ export class SubmitDesignJiraServiceError extends CauseAwareError {
 		});
 	}
 }
+
+export class ForbiddenByJiraServiceError extends CauseAwareError {}

--- a/src/web/middleware/jira/jira-admin-only-auth-middleware.ts
+++ b/src/web/middleware/jira/jira-admin-only-auth-middleware.ts
@@ -1,7 +1,10 @@
 import type { NextFunction, Request, Response } from 'express';
 
 import type { ConnectInstallation } from '../../../domain/entities';
-import { jiraService } from '../../../infrastructure/jira';
+import {
+	ForbiddenByJiraServiceError,
+	jiraService,
+} from '../../../infrastructure/jira';
 import { UnauthorizedResponseStatusError } from '../../errors';
 
 export const jiraAdminOnlyAuthMiddleware = (
@@ -27,5 +30,14 @@ export const jiraAdminOnlyAuthMiddleware = (
 
 			next();
 		})
-		.catch(next);
+		.catch((err) => {
+			if (err instanceof ForbiddenByJiraServiceError) {
+				return next(
+					new UnauthorizedResponseStatusError(
+						'Unauthorized. The resource is available only for admins.',
+					),
+				);
+			}
+			next(err);
+		});
 };


### PR DESCRIPTION
See: https://figlassian.atlassian.net/browse/FABB-75

We see some number of 500 errors in the GET /admin endpoint. The root cause is a 403 error in the jira-service isAdmin check.

![image](https://github.com/atlassian-labs/figma-for-jira/assets/116598948/23d55ba1-6701-49dc-b3ea-13bc1d56358e)

This PR adds error handling for the isAdmin check. That way, if there's a 403 error, we can map that to a 401 error in the top-level endpoint.

## Testing
- I added unit tests.