### PR TITLE
[jira-service] Truncate long display names

### DIFF
--- a/src/common/string-utils.test.ts
+++ b/src/common/string-utils.test.ts
@@ -1,4 +1,4 @@
-import { ensureString, isString } from './string-utils';
+import { ensureString, isString, truncate } from './string-utils';
 
 describe('stringUtils', () => {
 	describe('isString', () => {
@@ -21,6 +21,20 @@ describe('stringUtils', () => {
 					'The provided value is not of the correct type. Expected string, but received: number',
 				),
 			);
+		});
+	});
+
+	describe('truncate', () => {
+		it('does nothing when the string is less than the max length', () => {
+			const string = 'hello there yay!';
+			const result = truncate(string, 100);
+			expect(result).toBe(string);
+		});
+
+		it('truncates strings greater than the max length', () => {
+			const string = 'hello there yay!';
+			const result = truncate(string, 10);
+			expect(result).toBe('hello the…');
 		});
 	});
 });

--- a/src/common/string-utils.ts
+++ b/src/common/string-utils.ts
@@ -11,3 +11,9 @@ export const ensureString = (value: unknown) => {
 		`The provided value is not of the correct type. Expected string, but received: ${typeof value}`,
 	);
 };
+
+export const truncate = (str: string, maxLength: number) => {
+	if (str.length <= maxLength) return str;
+
+	return `${str.slice(0, maxLength - 1)}…`;
+};

--- a/src/infrastructure/jira/jira-service.test.ts
+++ b/src/infrastructure/jira/jira-service.test.ts
@@ -106,7 +106,7 @@ describe('JiraService', () => {
 					designs: [
 						{
 							...design,
-							displayName: 'a'.repeat(255),
+							displayName: 'a'.repeat(254) + '…',
 							addAssociations: null,
 							removeAssociations: null,
 							associationsLastUpdated: currentDate.toISOString(),

--- a/src/infrastructure/jira/jira-service.test.ts
+++ b/src/infrastructure/jira/jira-service.test.ts
@@ -87,6 +87,37 @@ describe('JiraService', () => {
 			);
 		});
 
+		it('should truncate the display name if it is too long', async () => {
+			const connectInstallation = generateConnectInstallation();
+			const design = generateAtlassianDesign({
+				displayName: 'a'.repeat(256),
+			});
+			const submitDesignsResponse = generateSuccessfulSubmitDesignsResponse([
+				design.id,
+			]);
+			jest
+				.spyOn(jiraClient, 'submitDesigns')
+				.mockResolvedValue(submitDesignsResponse);
+
+			await jiraService.submitDesigns([{ design }], connectInstallation);
+
+			expect(jiraClient.submitDesigns).toHaveBeenCalledWith(
+				{
+					designs: [
+						{
+							...design,
+							displayName: 'a'.repeat(255),
+							addAssociations: null,
+							removeAssociations: null,
+							associationsLastUpdated: currentDate.toISOString(),
+							associationsUpdateSequenceNumber: currentDate.valueOf(),
+						},
+					],
+				},
+				connectInstallation,
+			);
+		});
+
 		it('should submit design and add/remove associations', async () => {
 			const connectInstallation = generateConnectInstallation();
 			const design1 = generateAtlassianDesign();

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -12,7 +12,7 @@ import {
 	parseJsonOfSchema,
 	SchemaValidationError,
 } from '../../common/schema-validation';
-import { ensureString, isString } from '../../common/string-utils';
+import { ensureString, isString, truncate } from '../../common/string-utils';
 import { appendToPathname } from '../../common/url-utils';
 import type {
 	AtlassianDesign,
@@ -83,7 +83,7 @@ export class JiraService {
 				designs: designs.map(
 					({ design, addAssociations, removeAssociations }) => ({
 						...design,
-						displayName: design.displayName.slice(0, MAX_DISPLAY_NAME_LENGTH),
+						displayName: truncate(design.displayName, MAX_DISPLAY_NAME_LENGTH),
 						addAssociations: addAssociations ?? null,
 						removeAssociations: removeAssociations ?? null,
 						associationsLastUpdated: associationsLastUpdated.toISOString(),

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -75,11 +75,15 @@ export class JiraService {
 		connectInstallation: ConnectInstallation,
 	): Promise<void> => {
 		const associationsLastUpdated = new Date();
+
+		// Jira does not allow display names longer than 255 characters.
+		const MAX_DISPLAY_NAME_LENGTH = 255;
 		const response = await jiraClient.submitDesigns(
 			{
 				designs: designs.map(
 					({ design, addAssociations, removeAssociations }) => ({
 						...design,
+						displayName: design.displayName.slice(0, MAX_DISPLAY_NAME_LENGTH),
 						addAssociations: addAssociations ?? null,
 						removeAssociations: removeAssociations ?? null,
 						associationsLastUpdated: associationsLastUpdated.toISOString(),


### PR DESCRIPTION
We are getting some 500 errors in the endpoint POST /entities/associateEntity. It looks like sometimes, the display name is too long, and we get a validation error. See stack trace.
![image](https://github.com/atlassian-labs/figma-for-jira/assets/116598948/c1d050d5-d1fd-4c46-96ca-91fd17d8e909)

I think in this case, it's better for us to handle the error gracefully vs. returning a 400 response code. 

The other option here would be to handle the truncation / displayName length validation on the Jira side in the submitDesigns method.


## Testing
- I added a unit test for this case.