### PR TITLE
Reset app configuration state on install/uninstall

### DIFF
--- a/src/infrastructure/jira/jira-client/jira-client.test.ts
+++ b/src/infrastructure/jira/jira-client/jira-client.test.ts
@@ -259,6 +259,22 @@ describe('JiraClient', () => {
 		});
 	});
 
+	describe('deleteAppProperty', () => {
+		const propertyKey = 'property-key';
+		it('should delete app property', async () => {
+			jest.spyOn(axios, 'delete').mockResolvedValue({
+				status: HttpStatusCode.NoContent,
+			});
+
+			await jiraClient.deleteAppProperty(propertyKey, connectInstallation);
+
+			expect(axios.delete).toHaveBeenCalledWith(
+				`${connectInstallation.baseUrl}/rest/atlassian-connect/1/addons/${connectInstallation.key}/properties/${propertyKey}`,
+				defaultExpectedRequestHeaders(),
+			);
+		});
+	});
+
 	describe('checkPermissions', () => {
 		it('should check permissions', async () => {
 			const request: CheckPermissionsRequest =

--- a/src/infrastructure/jira/jira-client/jira-client.ts
+++ b/src/infrastructure/jira/jira-client/jira-client.ts
@@ -215,6 +215,32 @@ class JiraClient {
 		});
 
 	/**
+	 * Deletes a connect app property.
+	 *
+	 * @see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-app-properties/#api-rest-atlassian-connect-1-addons-addonkey-properties-propertykey-delete
+	 *
+	 * @throws {HttpClientError} An error associated with specific HTTP response status codes.
+	 */
+	deleteAppProperty = async (
+		propertyKey: string,
+		connectInstallation: ConnectInstallation,
+	): Promise<void> =>
+		withAxiosErrorTranslation(async () => {
+			const url = new URL(
+				`/rest/atlassian-connect/1/addons/${encodeURIComponent(
+					connectInstallation.key,
+				)}/properties/${encodeURIComponent(propertyKey)}`,
+				connectInstallation.baseUrl,
+			);
+
+			await axios.delete(url.toString(), {
+				headers: new AxiosHeaders().setAuthorization(
+					this.buildAuthorizationHeader('DELETE', url, connectInstallation),
+				),
+			});
+		});
+
+	/**
 	 * Returns a list of requested global and project permissions.
 	 *
 	 * @see https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-permissions/#api-rest-api-3-permissions-check-post

--- a/src/infrastructure/jira/jira-service.test.ts
+++ b/src/infrastructure/jira/jira-service.test.ts
@@ -943,6 +943,47 @@ describe('JiraService', () => {
 		});
 	});
 
+	describe('deleteAppConfigurationState', () => {
+		let connectInstallation: ConnectInstallation;
+
+		beforeEach(() => {
+			connectInstallation = generateConnectInstallation();
+		});
+
+		it('should delete the configuration state in app properties', async () => {
+			jest.spyOn(jiraClient, 'deleteAppProperty').mockResolvedValue(undefined);
+
+			await jiraService.deleteAppConfigurationState(connectInstallation);
+
+			expect(jiraClient.deleteAppProperty).toHaveBeenCalledWith(
+				'is-configured',
+				connectInstallation,
+			);
+		});
+
+		it('should not rethrow NotFoundHttpClientError errors', async () => {
+			const notFoundError = new NotFoundHttpClientError();
+			jest
+				.spyOn(jiraClient, 'deleteAppProperty')
+				.mockRejectedValue(notFoundError);
+
+			await expect(
+				jiraService.deleteAppConfigurationState(connectInstallation),
+			).resolves.not.toThrow(notFoundError);
+		});
+
+		it('should rethrow unexpected errors', async () => {
+			const unexpectedError = new ForbiddenHttpClientError();
+			jest
+				.spyOn(jiraClient, 'deleteAppProperty')
+				.mockRejectedValue(unexpectedError);
+
+			await expect(
+				jiraService.deleteAppConfigurationState(connectInstallation),
+			).rejects.toThrow(unexpectedError);
+		});
+	});
+
 	describe('isAdmin', () => {
 		it('should return false if user does not have ADMINISTER permission', async () => {
 			const atlassianUserId = uuidv4();

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -151,6 +151,23 @@ export class JiraService {
 		);
 	};
 
+	deleteAppConfigurationState = async (
+		connectInstallation: ConnectInstallation,
+	): Promise<void> => {
+		try {
+			return await jiraClient.deleteAppProperty(
+				appPropertyKeys.CONFIGURATION_STATE,
+				connectInstallation,
+			);
+		} catch (error) {
+			if (error instanceof NotFoundHttpClientError) {
+				return; // Swallow not found errors
+			} else {
+				throw error;
+			}
+		}
+	};
+
 	isAdmin = async (
 		atlassianUserId: string,
 		connectInstallation: ConnectInstallation,

--- a/src/usecases/installed-use-case.test.ts
+++ b/src/usecases/installed-use-case.test.ts
@@ -2,7 +2,6 @@ import { installedUseCase } from './installed-use-case';
 
 import { generateNumericStringId } from '../common/testing/utils';
 import { generateConnectInstallationCreateParams } from '../domain/entities/testing';
-import { jiraService } from '../infrastructure/jira';
 import { connectInstallationRepository } from '../infrastructure/repositories';
 
 describe('installedUseCase', () => {
@@ -15,17 +14,11 @@ describe('installedUseCase', () => {
 		jest
 			.spyOn(connectInstallationRepository, 'upsert')
 			.mockResolvedValue(connectInstallation);
-		jest
-			.spyOn(jiraService, 'deleteAppConfigurationState')
-			.mockResolvedValue(undefined);
 
 		await installedUseCase.execute(installationCreateParams);
 
 		expect(connectInstallationRepository.upsert).toHaveBeenCalledWith(
 			installationCreateParams,
-		);
-		expect(jiraService.deleteAppConfigurationState).toHaveBeenCalledWith(
-			connectInstallation,
 		);
 	});
 });

--- a/src/usecases/installed-use-case.test.ts
+++ b/src/usecases/installed-use-case.test.ts
@@ -2,20 +2,30 @@ import { installedUseCase } from './installed-use-case';
 
 import { generateNumericStringId } from '../common/testing/utils';
 import { generateConnectInstallationCreateParams } from '../domain/entities/testing';
+import { jiraService } from '../infrastructure/jira';
 import { connectInstallationRepository } from '../infrastructure/repositories';
 
 describe('installedUseCase', () => {
 	it('should call repository layer upsert', async () => {
 		const installationCreateParams = generateConnectInstallationCreateParams();
-		jest.spyOn(connectInstallationRepository, 'upsert').mockResolvedValue({
+		const connectInstallation = {
 			...installationCreateParams,
 			id: generateNumericStringId(),
-		});
+		};
+		jest
+			.spyOn(connectInstallationRepository, 'upsert')
+			.mockResolvedValue(connectInstallation);
+		jest
+			.spyOn(jiraService, 'deleteAppConfigurationState')
+			.mockResolvedValue(undefined);
 
 		await installedUseCase.execute(installationCreateParams);
 
 		expect(connectInstallationRepository.upsert).toHaveBeenCalledWith(
 			installationCreateParams,
+		);
+		expect(jiraService.deleteAppConfigurationState).toHaveBeenCalledWith(
+			connectInstallation,
 		);
 	});
 });

--- a/src/usecases/installed-use-case.ts
+++ b/src/usecases/installed-use-case.ts
@@ -1,8 +1,12 @@
 import type { ConnectInstallationCreateParams } from '../domain/entities';
+import { jiraService } from '../infrastructure/jira';
 import { connectInstallationRepository } from '../infrastructure/repositories';
 
 export const installedUseCase = {
 	execute: async (installation: ConnectInstallationCreateParams) => {
-		await connectInstallationRepository.upsert(installation);
+		const connectInstallation =
+			await connectInstallationRepository.upsert(installation);
+		// Ensure the configuration state for any prior installation is unset
+		await jiraService.deleteAppConfigurationState(connectInstallation);
 	},
 };

--- a/src/usecases/installed-use-case.ts
+++ b/src/usecases/installed-use-case.ts
@@ -1,12 +1,8 @@
 import type { ConnectInstallationCreateParams } from '../domain/entities';
-import { jiraService } from '../infrastructure/jira';
 import { connectInstallationRepository } from '../infrastructure/repositories';
 
 export const installedUseCase = {
 	execute: async (installation: ConnectInstallationCreateParams) => {
-		const connectInstallation =
-			await connectInstallationRepository.upsert(installation);
-		// Ensure the configuration state for any prior installation is unset
-		await jiraService.deleteAppConfigurationState(connectInstallation);
+		await connectInstallationRepository.upsert(installation);
 	},
 };

--- a/src/usecases/uninstalled-use-case.test.ts
+++ b/src/usecases/uninstalled-use-case.test.ts
@@ -5,6 +5,7 @@ import {
 	generateFigmaTeam,
 } from '../domain/entities/testing';
 import { figmaService } from '../infrastructure/figma';
+import { jiraService } from '../infrastructure/jira';
 import {
 	connectInstallationRepository,
 	figmaTeamRepository,
@@ -31,6 +32,9 @@ describe('uninstalledUseCase', () => {
 		jest
 			.spyOn(connectInstallationRepository, 'deleteByClientKey')
 			.mockResolvedValue(connectInstallation);
+		jest
+			.spyOn(jiraService, 'deleteAppConfigurationState')
+			.mockResolvedValue(undefined);
 
 		await uninstalledUseCase.execute(connectInstallation.clientKey);
 
@@ -46,5 +50,8 @@ describe('uninstalledUseCase', () => {
 		expect(
 			connectInstallationRepository.deleteByClientKey,
 		).toHaveBeenCalledWith(connectInstallation.clientKey);
+		expect(jiraService.deleteAppConfigurationState).toHaveBeenCalledWith(
+			connectInstallation,
+		);
 	});
 });

--- a/src/usecases/uninstalled-use-case.ts
+++ b/src/usecases/uninstalled-use-case.ts
@@ -1,4 +1,5 @@
 import { figmaService } from '../infrastructure/figma';
+import { jiraService } from '../infrastructure/jira';
 import {
 	connectInstallationRepository,
 	figmaTeamRepository,
@@ -27,6 +28,8 @@ export const uninstalledUseCase = {
 				figmaService.tryDeleteWebhook(figmaTeam.webhookId, figmaTeam.adminInfo),
 			),
 		);
+		// Delete the configuration state of the app since it is being uninstalled
+		await jiraService.deleteAppConfigurationState(connectInstallation);
 		// The `ConnectInstallation` deletion causes cascading deletion of all the related records.
 		await connectInstallationRepository.deleteByClientKey(clientKey);
 	},

--- a/src/usecases/uninstalled-use-case.ts
+++ b/src/usecases/uninstalled-use-case.ts
@@ -28,9 +28,9 @@ export const uninstalledUseCase = {
 				figmaService.tryDeleteWebhook(figmaTeam.webhookId, figmaTeam.adminInfo),
 			),
 		);
-		// Delete the configuration state of the app since it is being uninstalled
-		await jiraService.deleteAppConfigurationState(connectInstallation);
 		// The `ConnectInstallation` deletion causes cascading deletion of all the related records.
 		await connectInstallationRepository.deleteByClientKey(clientKey);
+		// Delete the configuration state of the app since it is being uninstalled
+		await jiraService.deleteAppConfigurationState(connectInstallation);
 	},
 };

--- a/src/web/routes/lifecycle-events/integration.test.ts
+++ b/src/web/routes/lifecycle-events/integration.test.ts
@@ -25,6 +25,7 @@ import {
 	generateJiraAsymmetricJwtToken,
 	mockConnectGetKeyEndpoint,
 	mockFigmaDeleteWebhookEndpoint,
+	mockJiraDeleteAppPropertyEndpoint,
 } from '../../testing';
 
 describe('/lifecycleEvents', () => {
@@ -53,12 +54,18 @@ describe('/lifecycleEvents', () => {
 				response: publicKey,
 				status: HttpStatusCode.Ok,
 			});
+			mockJiraDeleteAppPropertyEndpoint({
+				baseUrl: installedRequest.baseUrl,
+				appKey: installedRequest.key,
+				propertyKey: 'is-configured',
+			});
 
 			await request(app)
 				.post('/lifecycleEvents/installed')
 				.set('Authorization', `JWT ${jwtToken}`)
 				.send(installedRequest)
 				.expect(HttpStatusCode.NoContent);
+
 			expect(
 				await connectInstallationRepository.getByClientKey(clientKey),
 			).toEqual({
@@ -205,6 +212,11 @@ describe('/lifecycleEvents', () => {
 				webhookId: targetFigmaTeam2.webhookId,
 				accessToken: targetFigmaOAuth2UserCredentials2.accessToken,
 				status: HttpStatusCode.Ok,
+			});
+			mockJiraDeleteAppPropertyEndpoint({
+				baseUrl: targetConnectInstallation.baseUrl,
+				appKey: targetConnectInstallation.key,
+				propertyKey: 'is-configured',
 			});
 
 			await request(app)

--- a/src/web/routes/lifecycle-events/integration.test.ts
+++ b/src/web/routes/lifecycle-events/integration.test.ts
@@ -54,11 +54,6 @@ describe('/lifecycleEvents', () => {
 				response: publicKey,
 				status: HttpStatusCode.Ok,
 			});
-			mockJiraDeleteAppPropertyEndpoint({
-				baseUrl: installedRequest.baseUrl,
-				appKey: installedRequest.key,
-				propertyKey: 'is-configured',
-			});
 
 			await request(app)
 				.post('/lifecycleEvents/installed')

--- a/src/web/testing/jira-api-mocks.ts
+++ b/src/web/testing/jira-api-mocks.ts
@@ -118,6 +118,24 @@ export const mockJiraSetAppPropertyEndpoint = ({
 		.reply(status);
 };
 
+export const mockJiraDeleteAppPropertyEndpoint = ({
+	baseUrl,
+	appKey,
+	propertyKey,
+	status = HttpStatusCode.NoContent,
+}: {
+	baseUrl: string;
+	appKey: string;
+	propertyKey: string;
+	status?: HttpStatusCode;
+}) => {
+	nock(baseUrl)
+		.delete(
+			`/rest/atlassian-connect/1/addons/${appKey}/properties/${propertyKey}`,
+		)
+		.reply(status);
+};
+
 export const mockJiraCheckPermissionsEndpoint = ({
 	baseUrl,
 	request,


### PR DESCRIPTION
Delete the 'is-configured' app property key in jira cloud when the f4j app is uninstalled

This is to set the configured state to 'NOT_SET' when a user uninstalls so the state does not persist across installations

The complexity to add this to the /install flow is not worth it. If the app property deletion fails on uninstall I imagine this would be quite rare and could be dealt with in future if it does become a problem.