### PR TITLE
Fix 500 error in dev_resources due to Url already exists

### DIFF
--- a/src/infrastructure/figma/figma-service.test.ts
+++ b/src/infrastructure/figma/figma-service.test.ts
@@ -603,6 +603,33 @@ describe('FigmaService', () => {
 				}),
 			).rejects.toThrow(expectedError);
 		});
+
+		it('should throw when the dev_resource url already exists', async () => {
+			const issueKey = generateJiraIssueKey();
+			const issueUrl = generateJiraIssueUrl();
+			const issueTitle = uuidv4();
+			const designId = generateFigmaDesignIdentifier();
+			const expectedError = new InvalidInputFigmaServiceError(
+				'Url already exists',
+			);
+			jest.spyOn(figmaClient, 'createDevResources').mockResolvedValue({
+				errors: [
+					{ error: 'Url already exists', file_key: '1234', node_id: '1:1' },
+				],
+			} as CreateDevResourcesResponse);
+
+			await expect(() =>
+				figmaService.tryCreateDevResourceForJiraIssue({
+					designId,
+					issue: {
+						url: issueUrl,
+						key: issueKey,
+						title: issueTitle,
+					},
+					user: MOCK_CONNECT_USER_INFO,
+				}),
+			).rejects.toThrow(expectedError);
+		});
 	});
 
 	describe('tryDeleteDevResource', () => {

--- a/src/infrastructure/figma/figma-service.ts
+++ b/src/infrastructure/figma/figma-service.ts
@@ -201,6 +201,11 @@ export class FigmaService {
 					{ errors: response.errors },
 					'Failed to create Figma dev resources.',
 				);
+
+				const { error } = response.errors[0];
+				if (error === 'Url already exists') {
+					throw new InvalidInputFigmaServiceError(error);
+				}
 			}
 		});
 

--- a/src/usecases/associate-design-use-case.ts
+++ b/src/usecases/associate-design-use-case.ts
@@ -13,6 +13,7 @@ import {
 } from '../domain/entities';
 import {
 	figmaService,
+	InvalidInputFigmaServiceError,
 	UnauthorizedFigmaServiceError,
 } from '../infrastructure/figma';
 import { jiraService } from '../infrastructure/jira';
@@ -98,6 +99,10 @@ export const associateDesignUseCase = {
 		} catch (e) {
 			if (e instanceof UnauthorizedFigmaServiceError) {
 				throw new ForbiddenByFigmaUseCaseResultError(e);
+			}
+
+			if (e instanceof InvalidInputFigmaServiceError) {
+				throw new InvalidInputUseCaseResultError(e.message, e);
 			}
 
 			throw e;

--- a/src/usecases/backfill-design-use-case.ts
+++ b/src/usecases/backfill-design-use-case.ts
@@ -12,6 +12,7 @@ import {
 } from '../domain/entities';
 import {
 	figmaService,
+	InvalidInputFigmaServiceError,
 	UnauthorizedFigmaServiceError,
 } from '../infrastructure/figma';
 import { figmaBackfillService } from '../infrastructure/figma/figma-backfill-service';
@@ -104,6 +105,10 @@ export const backfillDesignUseCase = {
 		} catch (e) {
 			if (e instanceof UnauthorizedFigmaServiceError) {
 				throw new ForbiddenByFigmaUseCaseResultError(e);
+			}
+
+			if (e instanceof InvalidInputFigmaServiceError) {
+				throw new InvalidInputUseCaseResultError(e.message, e);
 			}
 
 			throw e;


### PR DESCRIPTION
In the past month, we got 865 errors with response code 500 in the endpoint POST /entities/associateEntity. ~200 of those errors are due to an error in the Figma POST /dev_resources endpoint.

If the dev_resource URL already exists, then the /dev_resources endpoint returns an error message: 'Url already exists' and a 400 status code. This PR updates the error handling so we treat these errors as a 400.

![image](https://github.com/atlassian-labs/figma-for-jira/assets/116598948/53c3237f-548c-49d3-8265-cdbda787244a)
