### PR TITLE
VULN-1137964 Update the base node image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bookworm-slim@sha256:b50c0b5628a4a10093a2b4b8b7a7060c10e5983abb8ea89a7892fc6ddb0730e3 as build
+FROM node:18-bookworm-slim@sha256:15cebc4ed172ec2c33eb5712f4fd98221369ae2343c72feed02bf6d730badf3e as build
 
 # Compile TS
 WORKDIR /app
@@ -10,7 +10,7 @@ RUN npm run db:generate
 COPY src ./src
 RUN npm run build
 
-FROM node:18-bookworm-slim@sha256:b50c0b5628a4a10093a2b4b8b7a7060c10e5983abb8ea89a7892fc6ddb0730e3 as app
+FROM node:18-bookworm-slim@sha256:15cebc4ed172ec2c33eb5712f4fd98221369ae2343c72feed02bf6d730badf3e as app
 
 RUN apt-get update -y && apt-get install -y openssl
 


### PR DESCRIPTION
Update the base node version for building the application to a newer version which includes a vuln patch for perl.

Current perl version with critical vuln: **5.36.0-7**
After updating the base image, the version will be: **5.36.0-7+deb12u1** which patches the vuln.