### PR TITLE
AMS-26036: Update static routes to perform jwt validation

### DIFF
--- a/src/web/middleware/jira/index.ts
+++ b/src/web/middleware/jira/index.ts
@@ -2,3 +2,4 @@ export * from './jira-asymmetric-jwt-auth-middleware';
 export * from './jira-admin-only-auth-middleware';
 export * from './jira-context-symmetric-jwt-auth-middleware';
 export * from './jira-server-symmetric-jwt-auth-middleware';
+export * from './jira-query-symmetric-jwt-auth-middleware';

--- a/src/web/middleware/jira/index.ts
+++ b/src/web/middleware/jira/index.ts
@@ -2,4 +2,4 @@ export * from './jira-asymmetric-jwt-auth-middleware';
 export * from './jira-admin-only-auth-middleware';
 export * from './jira-context-symmetric-jwt-auth-middleware';
 export * from './jira-server-symmetric-jwt-auth-middleware';
-export * from './jira-query-symmetric-jwt-auth-middleware';
+export * from './jira-context-symmetric-jwt-from-query-auth-middleware';

--- a/src/web/middleware/jira/jira-context-symmetric-jwt-from-query-auth-middleware.ts
+++ b/src/web/middleware/jira/jira-context-symmetric-jwt-from-query-auth-middleware.ts
@@ -14,7 +14,7 @@ import { UnauthorizedResponseStatusError } from '../../errors';
  * @see https://developer.atlassian.com/cloud/jira/platform/understanding-jwt-for-connect-apps/#types-of-jwt-token
  * @see https://community.developer.atlassian.com/t/action-required-atlassian-connect-vulnerability-allows-bypass-of-app-qsh-verification-via-context-jwts/47072
  */
-export const jiraQuerySymmetricJwtAuthMiddleware: RequestHandler = (
+export const jiraContextSymmetricJwtFromQueryAuthMiddleware: RequestHandler = (
 	req: Request,
 	res: Response,
 	next: NextFunction,

--- a/src/web/middleware/jira/jira-query-symmetric-jwt-auth-middleware.ts
+++ b/src/web/middleware/jira/jira-query-symmetric-jwt-auth-middleware.ts
@@ -1,0 +1,38 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+
+import { jiraContextSymmetricJwtTokenVerifier } from '../../../infrastructure/jira/inbound-auth';
+import { UnauthorizedResponseStatusError } from '../../errors';
+
+/**
+ * Authenticates requests using a symmetric JWT token received in a query param.
+ *
+ * In case of successful authentication, `connectInstallation` and `atlassianUserId` are set in locals.
+ *
+ * @remarks
+ * Context JWT tokens are sent in a query param when loading an iframe
+ *
+ * @see https://developer.atlassian.com/cloud/jira/platform/understanding-jwt-for-connect-apps/#types-of-jwt-token
+ * @see https://community.developer.atlassian.com/t/action-required-atlassian-connect-vulnerability-allows-bypass-of-app-qsh-verification-via-context-jwts/47072
+ */
+export const jiraQuerySymmetricJwtAuthMiddleware: RequestHandler = (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+) => {
+	const token = req.params.jwt;
+
+	if (!token) {
+		return next(new UnauthorizedResponseStatusError('Missing JWT token.'));
+	}
+
+	void jiraContextSymmetricJwtTokenVerifier
+		.verify(token)
+		.then(({ connectInstallation, atlassianUserId }) => {
+			res.locals.connectInstallation = connectInstallation;
+			res.locals.atlassianUserId = atlassianUserId;
+			next();
+		})
+		.catch((e) =>
+			next(new UnauthorizedResponseStatusError('Unauthorized.', undefined, e)),
+		);
+};

--- a/src/web/routes/router.ts
+++ b/src/web/routes/router.ts
@@ -1,14 +1,13 @@
 import { HttpStatusCode } from 'axios';
 import type { Request, Response } from 'express';
-import { Router, static as Static } from 'express';
-
-import { join } from 'path';
+import { Router } from 'express';
 
 import { adminRouter } from './admin';
 import { authRouter } from './auth';
 import { entitiesRouter } from './entities';
 import { figmaRouter } from './figma';
 import { lifecycleEventsRouter } from './lifecycle-events';
+import { staticRouter } from './static';
 
 import { connectAppDescriptor } from '../../atlassian-connect';
 
@@ -25,8 +24,7 @@ rootRouter.get('/atlassian-connect.json', (_: Request, res: Response) => {
 });
 
 // Static resources
-rootRouter.use('/static/admin', Static(join(process.cwd(), 'admin/dist')));
-rootRouter.use('/static', Static(join(process.cwd(), 'static')));
+rootRouter.use('/static', staticRouter);
 
 // Connect lifecycle events
 rootRouter.use('/lifecycleEvents', lifecycleEventsRouter);

--- a/src/web/routes/static/index.ts
+++ b/src/web/routes/static/index.ts
@@ -1,0 +1,1 @@
+export * from './static-router';

--- a/src/web/routes/static/static-router.ts
+++ b/src/web/routes/static/static-router.ts
@@ -1,0 +1,25 @@
+import { Router, static as Static } from 'express';
+
+import { join } from 'path';
+
+import {
+	jiraAdminOnlyAuthMiddleware,
+	jiraQuerySymmetricJwtAuthMiddleware,
+} from '../../middleware/jira';
+
+export const staticRouter = Router();
+
+staticRouter.use(
+	'/admin/index.html',
+	jiraQuerySymmetricJwtAuthMiddleware,
+	jiraAdminOnlyAuthMiddleware,
+);
+
+staticRouter.use(
+	'/issue-panel/issue-panel.html',
+	jiraQuerySymmetricJwtAuthMiddleware,
+);
+
+// Static resources
+staticRouter.use('/admin', Static(join(process.cwd(), 'admin/dist')));
+staticRouter.use('/', Static(join(process.cwd(), 'static')));

--- a/src/web/routes/static/static-router.ts
+++ b/src/web/routes/static/static-router.ts
@@ -4,20 +4,20 @@ import { join } from 'path';
 
 import {
 	jiraAdminOnlyAuthMiddleware,
-	jiraQuerySymmetricJwtAuthMiddleware,
+	jiraContextSymmetricJwtFromQueryAuthMiddleware,
 } from '../../middleware/jira';
 
 export const staticRouter = Router();
 
 staticRouter.use(
 	'/admin/index.html',
-	jiraQuerySymmetricJwtAuthMiddleware,
+	jiraContextSymmetricJwtFromQueryAuthMiddleware,
 	jiraAdminOnlyAuthMiddleware,
 );
 
 staticRouter.use(
 	'/issue-panel/issue-panel.html',
-	jiraQuerySymmetricJwtAuthMiddleware,
+	jiraContextSymmetricJwtFromQueryAuthMiddleware,
 );
 
 // Static resources


### PR DESCRIPTION
We got a ticket from atlassian's security team RE: returning <400 status for https://figma-for-jira.figma.com/static/admin and https://figma-for-jira.figma.com/static/issue-panel/issue-panel.html when passed invalid jwts

This is a non-issue since we're not doing any server-side rendering on these routes and subsequent requests do perform JWT validation.

But it doesn't hurt to validate the token before serving these static html files

## Test Plan
- Assert that the legacy and admin config page still work
- Deploy on staging first and verify that everything still works before deploying to prod