### PR TITLE
NONE: Update ngrok to v3.x

### DIFF
--- a/scripts/make-tunnel.sh
+++ b/scripts/make-tunnel.sh
@@ -7,4 +7,10 @@ set -o allexport
 source "$SCRIPT_DIR"/../.env set
 set +o allexport
 
-docker run --init --rm --publish='4040:4040' 'wernight/ngrok' ngrok http -log stdout -hostname=$NGROK_DOMAIN --authtoken "$NGROK_AUTHTOKEN" host.docker.internal:"$SERVER_PORT"
+docker run --init \
+  --rm \
+  -e NGROK_AUTHTOKEN=$NGROK_AUTHTOKEN \
+  'ngrok/ngrok:latest' http \
+    --log stdout \
+    --domain=$NGROK_DOMAIN \
+    host.docker.internal:"$SERVER_PORT"

--- a/scripts/make-tunnel.sh
+++ b/scripts/make-tunnel.sh
@@ -13,4 +13,4 @@ docker run --init \
   'ngrok/ngrok:latest' http \
     --log stdout \
     --domain=$NGROK_DOMAIN \
-    host.docker.internal:"$SERVER_PORT"
+    host.docker.internal:$SERVER_PORT


### PR DESCRIPTION
## Changes

- **chore:** Update ngrok from 2.x to 3.x to resolve a connection issue. According to the [ngrok docs](https://ngrok.com/blog-post/deprecation-agent-version-3-1), "Free accounts using agents running on 3.1 or older will no longer connect to ngrok".
  - Update the setup to use the official [ngrok/ngrok](https://ngrok.com/docs/using-ngrok-with/docker/) Docker container instead of unmaintained [wernight/ngrok](https://github.com/wernight/docker-ngrok).