### PR TITLE
NONE: Update the `submitFullDesign` job not to handle associations

### DIFF
--- a/src/jobs/submit-full-design.test.ts
+++ b/src/jobs/submit-full-design.test.ts
@@ -2,13 +2,10 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { submitFullDesign } from './submit-full-design';
 
-import { AtlassianAssociation, JIRA_ISSUE_ATI } from '../domain/entities';
 import {
 	generateAtlassianDesign,
 	generateConnectInstallation,
 	generateFigmaDesignIdentifier,
-	generateJiraIssue,
-	generateJiraIssueAri,
 } from '../domain/entities/testing';
 import { figmaService } from '../infrastructure/figma';
 import { jiraService } from '../infrastructure/jira';
@@ -17,10 +14,7 @@ import { connectInstallationRepository } from '../infrastructure/repositories';
 describe('submitFullDesign', () => {
 	it('should submit design', async () => {
 		const connectInstallation = generateConnectInstallation();
-		const cloudId = uuidv4();
 		const atlassianUserId = uuidv4();
-		const issue = generateJiraIssue();
-		const issueAri = generateJiraIssueAri({ cloudId, issueId: issue.id });
 		const figmaDesignId = generateFigmaDesignIdentifier();
 		const atlassianDesign = generateAtlassianDesign({
 			id: figmaDesignId.toAtlassianDesignId(),
@@ -33,12 +27,6 @@ describe('submitFullDesign', () => {
 
 		await submitFullDesign({
 			figmaDesignId,
-			associateWith: {
-				ari: issueAri,
-				ati: JIRA_ISSUE_ATI,
-				id: issue.id,
-				cloudId,
-			},
 			atlassianUserId,
 			connectInstallationId: connectInstallation.id,
 		});
@@ -53,9 +41,6 @@ describe('submitFullDesign', () => {
 		expect(jiraService.submitDesign).toHaveBeenCalledWith(
 			{
 				design: atlassianDesign,
-				addAssociations: [
-					AtlassianAssociation.createDesignIssueAssociation(issueAri),
-				],
 			},
 			connectInstallation,
 		);
@@ -63,10 +48,7 @@ describe('submitFullDesign', () => {
 
 	it('should exit if design is not found', async () => {
 		const connectInstallation = generateConnectInstallation();
-		const cloudId = uuidv4();
 		const atlassianUserId = uuidv4();
-		const issue = generateJiraIssue();
-		const issueAri = generateJiraIssueAri({ cloudId, issueId: issue.id });
 		const figmaDesignId = generateFigmaDesignIdentifier();
 		jest
 			.spyOn(connectInstallationRepository, 'get')
@@ -76,12 +58,6 @@ describe('submitFullDesign', () => {
 
 		await submitFullDesign({
 			figmaDesignId,
-			associateWith: {
-				ari: issueAri,
-				ati: JIRA_ISSUE_ATI,
-				id: issue.id,
-				cloudId,
-			},
 			atlassianUserId,
 			connectInstallationId: connectInstallation.id,
 		});

--- a/src/jobs/submit-full-design.ts
+++ b/src/jobs/submit-full-design.ts
@@ -1,16 +1,13 @@
 import type { FigmaDesignIdentifier } from '../domain/entities';
-import { AtlassianAssociation } from '../domain/entities';
 import { eventBus, getLogger } from '../infrastructure';
 import { figmaService } from '../infrastructure/figma';
 import { jiraService } from '../infrastructure/jira';
 import { connectInstallationRepository } from '../infrastructure/repositories';
-import type { AtlassianEntity } from '../usecases/types';
 
 const JOB_NAME = 'submitFullDesign';
 
 export type SubmitFullDesignJobParams = {
 	readonly figmaDesignId: FigmaDesignIdentifier;
-	readonly associateWith: AtlassianEntity;
 	readonly atlassianUserId: string;
 	readonly connectInstallationId: string;
 };
@@ -26,7 +23,6 @@ export type SubmitFullDesignJobParams = {
  */
 export const submitFullDesign = async ({
 	figmaDesignId,
-	associateWith,
 	atlassianUserId,
 	connectInstallationId,
 }: SubmitFullDesignJobParams): Promise<void> => {
@@ -51,13 +47,9 @@ export const submitFullDesign = async ({
 			return;
 		}
 
-		const designIssueAssociation =
-			AtlassianAssociation.createDesignIssueAssociation(associateWith.ari);
-
 		await jiraService.submitDesign(
 			{
 				design,
-				addAssociations: [designIssueAssociation],
 			},
 			connectInstallation,
 		);
@@ -67,7 +59,6 @@ export const submitFullDesign = async ({
 		getLogger().error(e, 'Failed to submit a full design.', {
 			job: JOB_NAME,
 			figmaDesignId,
-			associateWith,
 			atlassianUserId,
 		});
 		eventBus.emit('job.submit-full-design.failed');

--- a/src/jobs/submit-full-design.ts
+++ b/src/jobs/submit-full-design.ts
@@ -55,8 +55,12 @@ export const submitFullDesign = async ({
 		);
 
 		eventBus.emit('job.submit-full-design.succeeded');
+		getLogger().info(
+			{ job: JOB_NAME, figmaDesignId },
+			'The job was successfully completed.',
+		);
 	} catch (e) {
-		getLogger().error(e, 'Failed to submit a full design.', {
+		getLogger().error(e, 'The job failed.', {
 			job: JOB_NAME,
 			figmaDesignId,
 			atlassianUserId,

--- a/src/usecases/backfill-design-use-case.test.ts
+++ b/src/usecases/backfill-design-use-case.test.ts
@@ -99,7 +99,6 @@ describe('backfillDesignUseCase', () => {
 		await flushMacrotaskQueue();
 		expect(submitFullDesign).toHaveBeenCalledWith({
 			figmaDesignId: designId,
-			associateWith: params.associateWith,
 			atlassianUserId: params.atlassianUserId,
 			connectInstallationId: connectInstallation.id,
 		});

--- a/src/usecases/backfill-design-use-case.ts
+++ b/src/usecases/backfill-design-use-case.ts
@@ -98,7 +98,6 @@ export const backfillDesignUseCase = {
 				() =>
 					void submitFullDesign({
 						figmaDesignId,
-						associateWith,
 						atlassianUserId,
 						connectInstallationId: connectInstallation.id,
 					}),

--- a/src/web/routes/entities/integration.test.ts
+++ b/src/web/routes/entities/integration.test.ts
@@ -704,18 +704,7 @@ describe('/entities', () => {
 			});
 			mockJiraSubmitDesignsEndpoint({
 				baseUrl: connectInstallation.baseUrl,
-				request: generateSubmitDesignsRequest([
-					{
-						...atlassianDesign,
-						addAssociations: [
-							// Nock does not correctly match a request body when provide an instance of a class
-							// (e.g., as `AtlassianAssociation`). Therefore, pass an object instead.
-							{
-								...AtlassianAssociation.createDesignIssueAssociation(issueAri),
-							},
-						],
-					},
-				]),
+				request: generateSubmitDesignsRequest([atlassianDesign]),
 			});
 
 			await request(app)
@@ -867,16 +856,7 @@ describe('/entities', () => {
 			});
 			mockJiraSubmitDesignsEndpoint({
 				baseUrl: connectInstallation.baseUrl,
-				request: generateSubmitDesignsRequest([
-					{
-						...atlassianDesign,
-						addAssociations: [
-							{
-								...AtlassianAssociation.createDesignIssueAssociation(issueAri),
-							},
-						],
-					},
-				]),
+				request: generateSubmitDesignsRequest([atlassianDesign]),
 			});
 
 			await request(app)


### PR DESCRIPTION
## Changes

- **refactor:** Updates the `submitFullDesign` job not to handle associations. The job is responsible only for design metadata submission -- an association is submitted exclusively by the caller (e.g., `backfillDesignUseCase`). The change allows to simplify the job and avoid race conditions in edge cases.