### PR TITLE
Update truncate string util to handle utf-16 / utf-8 strings

### DIFF
--- a/src/common/string-utils.test.ts
+++ b/src/common/string-utils.test.ts
@@ -1,4 +1,5 @@
 import { ensureString, isString, truncate } from './string-utils';
+import utf16Str from './testing/utf16-str';
 
 describe('stringUtils', () => {
 	describe('isString', () => {
@@ -35,6 +36,11 @@ describe('stringUtils', () => {
 			const string = 'hello there yay!';
 			const result = truncate(string, 10);
 			expect(result).toBe('hello the…');
+		});
+
+		it('accounts for utf16 characters', () => {
+			const result = truncate(utf16Str as string, 10);
+			expect(result).toBe('你好你…');
 		});
 	});
 });

--- a/src/common/string-utils.ts
+++ b/src/common/string-utils.ts
@@ -12,8 +12,9 @@ export const ensureString = (value: unknown) => {
 	);
 };
 
-export const truncate = (str: string, maxLength: number) => {
-	if (str.length <= maxLength) return str;
+export const truncate = (str: string, maxLength: number): string => {
+	const utf8Str = Buffer.from(str, 'utf-8');
+	if (utf8Str.length <= maxLength) return utf8Str.toString();
 
-	return `${str.slice(0, maxLength - 1)}…`;
+	return `${utf8Str.subarray(0, maxLength - 1).toString()}…`;
 };

--- a/src/common/testing/utf16-str.js
+++ b/src/common/testing/utf16-str.js
@@ -1,0 +1,4 @@
+// utf16-string.js
+const utf16String = '你好你好你好你好你好你好';
+
+module.exports = utf16String;


### PR DESCRIPTION
Some strings have a different length in utf-8 vs. utf-16 encoding. Javascript strings are utf-16, but Jira expects utf-8 strings. This PR fixes the truncate function to first encode JS strings as UTF8 before truncating.

I wrote a test that fails before the change and passes afterward. Test result against master for reference. 
![image](https://github.com/atlassian-labs/figma-for-jira/assets/116598948/0125faff-9f7a-4492-80f7-8ed7e86b8329)
