### PR TITLE
NONE: Handle expected errors from Jira API

### DIFF
--- a/src/infrastructure/figma-app-backward-integration-service.ts
+++ b/src/infrastructure/figma-app-backward-integration-service.ts
@@ -1,0 +1,76 @@
+import { figmaService, UnauthorizedFigmaServiceError } from './figma';
+import {
+	ForbiddenByJiraServiceError,
+	IssueNotFoundJiraServiceError,
+	jiraService,
+} from './jira';
+import { getLogger } from './logger';
+
+import type { AtlassianDesign, ConnectInstallation } from '../domain/entities';
+import { buildJiraIssueUrl, FigmaDesignIdentifier } from '../domain/entities';
+
+export class FigmaAppBackwardIntegrationService {
+	/**
+	 * Handles the backward integration with the "Jira" Widget and Plugin in Figma:
+	 * - Sets the Figma design URL to Jira Issue Properties
+	 * - Creates a Dev Resource for the Figma File/Node.
+	 *
+	 * Makes the best effort to perform the operation: it swallows expected errors (e.g., lack of permissions
+	 * to access Jira Issue) and throws only unexpected ones.
+	 */
+	tryHandleLinkedDesign = async ({
+		originalFigmaDesignId,
+		design,
+		issueId,
+		atlassianUserId,
+		connectInstallation,
+	}: {
+		readonly originalFigmaDesignId: FigmaDesignIdentifier;
+		readonly design: AtlassianDesign;
+		readonly issueId: string;
+		readonly atlassianUserId: string;
+		readonly connectInstallation: ConnectInstallation;
+	}) => {
+		try {
+			const issue = await jiraService.getIssue(issueId, connectInstallation);
+
+			await Promise.all([
+				jiraService.saveDesignUrlInIssueProperties(
+					issueId,
+					originalFigmaDesignId,
+					design,
+					connectInstallation,
+				),
+				figmaService.tryCreateDevResourceForJiraIssue({
+					designId: FigmaDesignIdentifier.fromAtlassianDesignId(design.id),
+					issue: {
+						url: buildJiraIssueUrl(connectInstallation.baseUrl, issue.key),
+						key: issue.key,
+						title: issue.fields.summary,
+					},
+					user: {
+						atlassianUserId,
+						connectInstallationId: connectInstallation.id,
+					},
+				}),
+			]);
+		} catch (e) {
+			if (
+				e instanceof ForbiddenByJiraServiceError ||
+				e instanceof IssueNotFoundJiraServiceError ||
+				e instanceof UnauthorizedFigmaServiceError
+			) {
+				getLogger().warn(
+					'Skipping handling backward integration with Figma due to the expected error.',
+					e,
+				);
+				return;
+			}
+
+			throw e;
+		}
+	};
+}
+
+export const figmaAppBackwardIntegrationService =
+	new FigmaAppBackwardIntegrationService();

--- a/src/usecases/backfill-design-use-case.ts
+++ b/src/usecases/backfill-design-use-case.ts
@@ -7,14 +7,11 @@ import type { AtlassianEntity } from './types';
 import type { AtlassianDesign, ConnectInstallation } from '../domain/entities';
 import {
 	AtlassianAssociation,
-	buildJiraIssueUrl,
 	FigmaDesignIdentifier,
 } from '../domain/entities';
-import {
-	figmaService,
-	UnauthorizedFigmaServiceError,
-} from '../infrastructure/figma';
+import { UnauthorizedFigmaServiceError } from '../infrastructure/figma';
 import { figmaBackfillService } from '../infrastructure/figma/figma-backfill-service';
+import { figmaAppBackwardIntegrationService } from '../infrastructure/figma-app-backward-integration-service';
 import { jiraService } from '../infrastructure/jira';
 import { associatedFigmaDesignRepository } from '../infrastructure/repositories';
 import { submitFullDesign } from '../jobs';
@@ -50,41 +47,26 @@ export const backfillDesignUseCase = {
 
 		try {
 			const design = figmaBackfillService.buildMinimalDesignFromUrl(designUrl);
-			const issue = await jiraService.getIssue(
-				associateWith.id,
-				connectInstallation,
-			);
 
 			const designIssueAssociation =
 				AtlassianAssociation.createDesignIssueAssociation(associateWith.ari);
 
-			await Promise.all([
-				jiraService.submitDesign(
-					{
-						design,
-						addAssociations: [designIssueAssociation],
-					},
-					connectInstallation,
-				),
-				jiraService.saveDesignUrlInIssueProperties(
-					issue.id,
-					figmaDesignId,
+			// Makes the best effort to provide the backward integration with the "Jira" Widget and Plugin in Figma.
+			await figmaAppBackwardIntegrationService.tryHandleLinkedDesign({
+				originalFigmaDesignId: figmaDesignId,
+				design,
+				issueId: associateWith.id,
+				atlassianUserId,
+				connectInstallation,
+			});
+
+			await jiraService.submitDesign(
+				{
 					design,
-					connectInstallation,
-				),
-				figmaService.tryCreateDevResourceForJiraIssue({
-					designId: figmaDesignId,
-					issue: {
-						url: buildJiraIssueUrl(connectInstallation.baseUrl, issue.key),
-						key: issue.key,
-						title: issue.fields.summary,
-					},
-					user: {
-						atlassianUserId,
-						connectInstallationId: connectInstallation.id,
-					},
-				}),
-			]);
+					addAssociations: [designIssueAssociation],
+				},
+				connectInstallation,
+			);
 
 			await associatedFigmaDesignRepository.upsert({
 				designId: figmaDesignId,


### PR DESCRIPTION
**⚠️  WARNING:** The changes represent the proof of concept and have not been tested.

### Changes

- Handles expected errors from Jira API for the "Associate Design" and "Backfill Design" use cases.
  - `HTTP 403` when the app does not have permissions to set Jira Issue Properties.
  - `HTTP 404` when the app does not have permissions to view a Jira Issue.

### Notes

- The PR needs additional work:
  - Investigate whether similar changes are needed for the "Disassociate Design".
  - Add unit and, possibly, integration tests.
  - Test the changes manually.