### PR TITLE
MDTZ-1571: Resolve the issue with an inconsistent `AtlassianDesign.displayName` truncation

### DIFF
--- a/src/common/string-utils.test.ts
+++ b/src/common/string-utils.test.ts
@@ -1,5 +1,4 @@
 import { ensureString, isString, truncate } from './string-utils';
-import utf16Str from './testing/utf16-str';
 
 describe('stringUtils', () => {
 	describe('isString', () => {
@@ -26,21 +25,37 @@ describe('stringUtils', () => {
 	});
 
 	describe('truncate', () => {
-		it('does nothing when the string is less than the max length', () => {
+		it('should do nothing if string is empty', () => {
+			const result = truncate('', 100);
+
+			expect(result).toBe('');
+		});
+
+		it('should do nothing when the string is less than the max length', () => {
 			const string = 'hello there yay!';
-			const result = truncate(string, 100);
+
+			const result = truncate('hello there yay!', 100);
+
 			expect(result).toBe(string);
 		});
 
-		it('truncates strings greater than the max length', () => {
-			const string = 'hello there yay!';
-			const result = truncate(string, 10);
+		it('should truncate strings greater than the given length', () => {
+			const result = truncate('hello there yay!', 10);
+
 			expect(result).toBe('hello the…');
 		});
 
-		it('accounts for utf16 characters', () => {
-			const result = truncate(utf16Str as string, 10);
-			expect(result).toBe('你好你…');
-		});
+		it.each([
+			{ input: '🐱🐱🐱🐱🐱', maxLength: 1, expected: '…' },
+			{ input: '🐱🐱🐱🐱🐱', maxLength: 2, expected: '…' },
+			{ input: '🐱🐱🐱🐱🐱', maxLength: 3, expected: '🐱…' },
+		])(
+			'should exclude a lone surrogate from the end of the string (%o)',
+			({ input, maxLength, expected }) => {
+				const result = truncate(input, maxLength);
+
+				expect(result).toBe(expected);
+			},
+		);
 	});
 });

--- a/src/common/string-utils.test.ts
+++ b/src/common/string-utils.test.ts
@@ -46,11 +46,11 @@ describe('stringUtils', () => {
 		});
 
 		it.each([
-			{ input: '🐱🐱🐱🐱🐱', maxLength: 1, expected: '…' },
-			{ input: '🐱🐱🐱🐱🐱', maxLength: 2, expected: '…' },
-			{ input: '🐱🐱🐱🐱🐱', maxLength: 3, expected: '🐱…' },
+			{ input: '🐱🐱🐱', maxLength: 1, expected: '…' },
+			{ input: '🐱🐱🐱', maxLength: 2, expected: '…' },
+			{ input: '🐱🐱🐱', maxLength: 3, expected: '🐱…' },
 		])(
-			'should exclude a lone surrogate from the end of the string (%o)',
+			'should return well-formed string with no lone surrogates (%p)',
 			({ input, maxLength, expected }) => {
 				const result = truncate(input, maxLength);
 

--- a/src/common/testing/utf16-str.js
+++ b/src/common/testing/utf16-str.js
@@ -1,4 +1,0 @@
-// utf16-string.js
-const utf16String = '你好你好你好你好你好你好';
-
-module.exports = utf16String;

--- a/src/domain/entities/atlassian-design.ts
+++ b/src/domain/entities/atlassian-design.ts
@@ -31,6 +31,10 @@ export class AtlassianAssociation {
  */
 export type AtlassianDesign = {
 	readonly id: string;
+	/**
+	 * The name of the design.
+	 * Should not exceed 255 characters.
+	 */
 	readonly displayName: string;
 	readonly url: string;
 	readonly liveEmbedUrl: string;

--- a/src/infrastructure/figma/figma-backfill-service.test.ts
+++ b/src/infrastructure/figma/figma-backfill-service.test.ts
@@ -3,6 +3,7 @@ import {
 	buildDesignUrl,
 	buildInspectUrl,
 	buildLiveEmbedUrl,
+	truncateDisplayName,
 } from './transformers/utils';
 
 import {
@@ -93,6 +94,17 @@ describe('FigmaBackfillService', () => {
 			);
 
 			expect(result.displayName).toStrictEqual('Test / Design 1');
+		});
+
+		it('should truncate `displayName` if it is too long', () => {
+			const fileKey = generateFigmaFileKey();
+			const fileName = 'a'.repeat(1000);
+
+			const result = figmaBackfillService.buildMinimalDesignFromUrl(
+				new URL(`https://www.figma.com/file/${fileKey}/${fileName}`),
+			);
+
+			expect(result?.displayName).toStrictEqual(truncateDisplayName(fileName));
 		});
 	});
 });

--- a/src/infrastructure/figma/figma-backfill-service.ts
+++ b/src/infrastructure/figma/figma-backfill-service.ts
@@ -2,6 +2,7 @@ import {
 	buildDesignUrl,
 	buildInspectUrl,
 	buildLiveEmbedUrl,
+	truncateDisplayName,
 } from './transformers/utils';
 
 import type { AtlassianDesign } from '../../domain/entities';
@@ -37,7 +38,7 @@ export class FigmaBackfillService {
 
 		return {
 			id: designId.toAtlassianDesignId(),
-			displayName,
+			displayName: truncateDisplayName(displayName),
 			url: buildDesignUrl(designId).toString(),
 			liveEmbedUrl: buildLiveEmbedUrl(designId).toString(),
 			inspectUrl: buildInspectUrl(designId).toString(),

--- a/src/infrastructure/figma/figma-client/testing/mocks.ts
+++ b/src/infrastructure/figma/figma-client/testing/mocks.ts
@@ -32,17 +32,19 @@ export const MOCK_DOCUMENT: Node = {
 
 export const generateFrameNode = ({
 	id = generateFigmaNodeId(),
+	name = `Test Frame ${id}`,
 	lastModified,
 	devStatus,
 	children = [],
 }: {
 	id?: string;
+	name?: string;
 	lastModified?: Date;
 	devStatus?: NodeDevStatus;
 	children?: Node[];
 } = {}): Node => ({
 	id,
-	name: `Test Frame ${id}`,
+	name,
 	type: 'FRAME',
 	devStatus: devStatus,
 	lastModified: lastModified?.toISOString(),
@@ -51,9 +53,10 @@ export const generateFrameNode = ({
 
 export const generateChildNode = ({
 	id = generateFigmaNodeId(),
+	name = `Test Rectangle ${id}`,
 } = {}): Node => ({
 	id,
-	name: `Test Rectangle ${id}`,
+	name,
 	type: 'RECTANGLE',
 });
 

--- a/src/infrastructure/figma/transformers/figma-file-meta-transformer.test.ts
+++ b/src/infrastructure/figma/transformers/figma-file-meta-transformer.test.ts
@@ -4,6 +4,7 @@ import {
 	buildInspectUrl,
 	buildLiveEmbedUrl,
 	getUpdateSequenceNumberFrom,
+	truncateDisplayName,
 } from './utils';
 
 import {
@@ -36,5 +37,21 @@ describe('transformFileMetaToAtlassianDesign', () => {
 				fileMetaResponse.file.last_touched_at,
 			),
 		});
+	});
+
+	it('should truncate `displayName` if it is too long', () => {
+		const fileKey = generateFigmaFileKey();
+		const fileMetaResponse = generateGetFileMetaResponse({
+			name: 'a'.repeat(1000),
+		});
+
+		const result = transformFileMetaToAtlassianDesign({
+			fileKey,
+			fileMetaResponse,
+		});
+
+		expect(result.displayName).toStrictEqual(
+			truncateDisplayName(fileMetaResponse.file.name),
+		);
 	});
 });

--- a/src/infrastructure/figma/transformers/figma-file-meta-transformer.ts
+++ b/src/infrastructure/figma/transformers/figma-file-meta-transformer.ts
@@ -3,6 +3,7 @@ import {
 	buildInspectUrl,
 	buildLiveEmbedUrl,
 	getUpdateSequenceNumberFrom,
+	truncateDisplayName,
 } from './utils';
 
 import type { AtlassianDesign } from '../../../domain/entities';
@@ -29,7 +30,7 @@ export const transformFileMetaToAtlassianDesign = ({
 
 	return {
 		id: designId.toAtlassianDesignId(),
-		displayName: fileMetaResponse.file.name,
+		displayName: truncateDisplayName(fileMetaResponse.file.name),
 		url: buildDesignUrl({ fileKey }).toString(),
 		liveEmbedUrl: buildLiveEmbedUrl({ fileKey }).toString(),
 		inspectUrl: buildInspectUrl({ fileKey }).toString(),

--- a/src/infrastructure/figma/transformers/figma-file-transformer.test.ts
+++ b/src/infrastructure/figma/transformers/figma-file-transformer.test.ts
@@ -4,6 +4,7 @@ import {
 	buildInspectUrl,
 	buildLiveEmbedUrl,
 	getUpdateSequenceNumberFrom,
+	truncateDisplayName,
 } from './utils';
 
 import {
@@ -42,5 +43,19 @@ describe('transformFileToAtlassianDesign', () => {
 				fileResponse.lastModified,
 			),
 		});
+	});
+
+	it('should truncate `displayName` if it is too long', () => {
+		const fileKey = generateFigmaFileKey();
+		const fileResponse = generateGetFileResponse({ name: 'a'.repeat(1000) });
+
+		const result = transformFileToAtlassianDesign({
+			fileKey,
+			fileResponse,
+		});
+
+		expect(result.displayName).toStrictEqual(
+			truncateDisplayName(fileResponse.name),
+		);
 	});
 });

--- a/src/infrastructure/figma/transformers/figma-file-transformer.ts
+++ b/src/infrastructure/figma/transformers/figma-file-transformer.ts
@@ -3,6 +3,7 @@ import {
 	buildInspectUrl,
 	buildLiveEmbedUrl,
 	getUpdateSequenceNumberFrom,
+	truncateDisplayName,
 } from './utils';
 
 import type { AtlassianDesign } from '../../../domain/entities';
@@ -29,7 +30,7 @@ export const transformFileToAtlassianDesign = ({
 
 	return {
 		id: designId.toAtlassianDesignId(),
-		displayName: fileResponse.name,
+		displayName: truncateDisplayName(fileResponse.name),
 		url: buildDesignUrl({ fileKey }).toString(),
 		liveEmbedUrl: buildLiveEmbedUrl({ fileKey }).toString(),
 		inspectUrl: buildInspectUrl({ fileKey }).toString(),

--- a/src/infrastructure/figma/transformers/figma-node-transformer.test.ts
+++ b/src/infrastructure/figma/transformers/figma-node-transformer.test.ts
@@ -10,6 +10,7 @@ import {
 	buildInspectUrl,
 	buildLiveEmbedUrl,
 	getUpdateSequenceNumberFrom,
+	truncateDisplayName,
 } from './utils';
 
 import {
@@ -116,6 +117,28 @@ describe('tryTransformNodeToAtlassianDesign', () => {
 		});
 
 		expect(result).toBeNull();
+	});
+
+	it('should truncate `displayName` if it is too long', () => {
+		const fileKey = generateFigmaFileKey();
+		const node = generateChildNode({ id: '100:1', name: 'b'.repeat(250) });
+		const fileResponse = generateGetFileResponse({
+			name: 'a'.repeat(250),
+			document: {
+				...MOCK_DOCUMENT,
+				children: [node],
+			},
+		});
+
+		const result = tryTransformNodeToAtlassianDesign({
+			fileKey,
+			nodeId: node.id,
+			fileResponse,
+		});
+
+		expect(result?.displayName).toStrictEqual(
+			truncateDisplayName(`${fileResponse.name} - ${node.name}`),
+		);
 	});
 });
 

--- a/src/infrastructure/figma/transformers/figma-node-transformer.ts
+++ b/src/infrastructure/figma/transformers/figma-node-transformer.ts
@@ -3,6 +3,7 @@ import {
 	buildInspectUrl,
 	buildLiveEmbedUrl,
 	getUpdateSequenceNumberFrom,
+	truncateDisplayName,
 } from './utils';
 
 import type { AtlassianDesign } from '../../../domain/entities';
@@ -62,7 +63,7 @@ export const tryTransformNodeToAtlassianDesign = ({
 
 	return {
 		id: designId.toAtlassianDesignId(),
-		displayName: `${fileName} - ${node.name}`,
+		displayName: truncateDisplayName(`${fileName} - ${node.name}`),
 		url: buildDesignUrl({ fileKey, nodeId }).toString(),
 		liveEmbedUrl: buildLiveEmbedUrl({ fileKey, nodeId }).toString(),
 		inspectUrl: buildInspectUrl({ fileKey, nodeId }).toString(),

--- a/src/infrastructure/figma/transformers/utils.test.ts
+++ b/src/infrastructure/figma/transformers/utils.test.ts
@@ -3,6 +3,7 @@ import {
 	buildInspectUrl,
 	buildLiveEmbedUrl,
 	getUpdateSequenceNumberFrom,
+	truncateDisplayName,
 } from './utils';
 
 import { getConfig } from '../../../config';
@@ -87,6 +88,14 @@ describe('utils', () => {
 			const result = getUpdateSequenceNumberFrom('2023-11-05T23:08:49.123Z');
 
 			expect(result).toEqual(new Date('2023-11-05T23:08:49Z').getTime());
+		});
+	});
+
+	describe('truncateDisplayName', () => {
+		it('should truncate a string if it exceeds 255 characters', () => {
+			const result = truncateDisplayName(' Long Name '.repeat(256));
+
+			expect(result).toEqual(`${result.slice(0, 254)}…`);
 		});
 	});
 });

--- a/src/infrastructure/figma/transformers/utils.ts
+++ b/src/infrastructure/figma/transformers/utils.ts
@@ -1,5 +1,8 @@
 import { truncateToMillis } from '../../../common/date-utils';
+import { truncate } from '../../../common/string-utils';
 import { getConfig } from '../../../config';
+
+const MAX_DISPLAY_NAME_LENGTH = 255;
 
 /**
  * Builds a URL to a Figma design given Figma file/node metadata.
@@ -79,4 +82,8 @@ export const getUpdateSequenceNumberFrom = (dateIsoString: string): number => {
 	const lastUpdated = truncateToMillis(new Date(dateIsoString));
 
 	return lastUpdated.getTime();
+};
+
+export const truncateDisplayName = (displayName: string): string => {
+	return truncate(displayName, MAX_DISPLAY_NAME_LENGTH);
 };

--- a/src/infrastructure/jira/jira-design-service.test.ts
+++ b/src/infrastructure/jira/jira-design-service.test.ts
@@ -59,37 +59,6 @@ describe('JiraDesignService', () => {
 			);
 		});
 
-		it('should truncate the display name if it is too long', async () => {
-			const connectInstallation = generateConnectInstallation();
-			const design = generateAtlassianDesign({
-				displayName: 'a'.repeat(256),
-			});
-			const submitDesignsResponse = generateSuccessfulSubmitDesignsResponse([
-				design.id,
-			]);
-			jest
-				.spyOn(jiraClient, 'submitDesigns')
-				.mockResolvedValue(submitDesignsResponse);
-
-			await jiraDesignService.submitDesigns([{ design }], connectInstallation);
-
-			expect(jiraClient.submitDesigns).toHaveBeenCalledWith(
-				{
-					designs: [
-						{
-							...design,
-							displayName: 'a'.repeat(254) + '…',
-							addAssociations: null,
-							removeAssociations: null,
-							associationsLastUpdated: currentDate.toISOString(),
-							associationsUpdateSequenceNumber: currentDate.valueOf(),
-						},
-					],
-				},
-				connectInstallation,
-			);
-		});
-
 		it('should submit design and add/remove associations', async () => {
 			const connectInstallation = generateConnectInstallation();
 			const design1 = generateAtlassianDesign();

--- a/src/infrastructure/jira/jira-design-service.ts
+++ b/src/infrastructure/jira/jira-design-service.ts
@@ -2,7 +2,6 @@ import type { SubmitDesignsResponse } from './jira-client';
 import { jiraClient } from './jira-client';
 
 import { CauseAwareError } from '../../common/errors';
-import { truncate } from '../../common/string-utils';
 import type {
 	AtlassianDesign,
 	ConnectInstallation,
@@ -35,14 +34,11 @@ export class JiraDesignService {
 	): Promise<void> => {
 		const associationsLastUpdated = new Date();
 
-		// Jira does not allow display names longer than 255 characters.
-		const MAX_DISPLAY_NAME_LENGTH = 255;
 		const response = await jiraClient.submitDesigns(
 			{
 				designs: designs.map(
 					({ design, addAssociations, removeAssociations }) => ({
 						...design,
-						displayName: truncate(design.displayName, MAX_DISPLAY_NAME_LENGTH),
 						addAssociations: addAssociations ?? null,
 						removeAssociations: removeAssociations ?? null,
 						associationsLastUpdated: associationsLastUpdated.toISOString(),


### PR DESCRIPTION
## Changes

- **fix:** Resolves the issue with `AtlassianDesign` with a not truncated `displayName` being returned from the `/entities/associateEntity` endpoint (and causing the failure in the upstream service). Truncates `AtlassianDesign.displayName` on _the entry points_ to the application to ensure a consistent truncation among use cases.
- **fix:** Resolves the issue with `AtlassianDesign.displayName` being truncates based on bytes instead of UTF-16 code units (as expected by Jira).
- **feat:** Improves the `truncate` utility method to exclude lone surrogates that can appear due to the truncation (e.g., when "🐱", which contains 2 code units, to 1). 