### PR TITLE
NONE: Add support for new figma file urls

### DIFF
--- a/src/domain/entities/figma-design-identifier.test.ts
+++ b/src/domain/entities/figma-design-identifier.test.ts
@@ -112,6 +112,30 @@ describe('FigmaDesignIdentifier', () => {
 			expect(result).toStrictEqual(new FigmaDesignIdentifier(fileKey, nodeId));
 		});
 
+		it('should return an identifier when URL is a design link', () => {
+			const fileKey = generateFigmaFileKey();
+			const nodeId = '42:1';
+			const designUrl = new URL(
+				`https://www.figma.com/design/${fileKey}?node-id=42%3A1`,
+			);
+
+			const result = FigmaDesignIdentifier.fromFigmaDesignUrl(designUrl);
+
+			expect(result).toStrictEqual(new FigmaDesignIdentifier(fileKey, nodeId));
+		});
+
+		it('should return an identifier when URL is a board link', () => {
+			const fileKey = generateFigmaFileKey();
+			const nodeId = '42:1';
+			const designUrl = new URL(
+				`https://www.figma.com/board/${fileKey}?node-id=42%3A1`,
+			);
+
+			const result = FigmaDesignIdentifier.fromFigmaDesignUrl(designUrl);
+
+			expect(result).toStrictEqual(new FigmaDesignIdentifier(fileKey, nodeId));
+		});
+
 		it.each([
 			new URL(`https://www.figma.com`),
 			new URL(`https://www.figma.com/file`),

--- a/src/domain/entities/figma-design-identifier.ts
+++ b/src/domain/entities/figma-design-identifier.ts
@@ -36,7 +36,7 @@ export class FigmaDesignIdentifier {
 	static fromFigmaDesignUrl = (url: URL): FigmaDesignIdentifier => {
 		const pathComponents = url.pathname.split('/');
 		const filePathComponentId = pathComponents.findIndex(
-			(x) => x === 'file' || x === 'proto',
+			(x) => x === 'file' || x === 'proto' || x === 'board' || x === 'design',
 		);
 
 		const fileKey = pathComponents[filePathComponentId + 1];

--- a/static/issue-panel/issue-panel.js
+++ b/static/issue-panel/issue-panel.js
@@ -540,7 +540,7 @@ function getUrlParam(paramKey) {
 }
 var urlToDiv = {};
 var validURLChecker =
-	/^https:\/\/([\w\.-]+\.)?figma[.](?:com|engineering)\/(file|proto)\/([0-9a-zA-Z]{22,128})(?:\/([^\\?]*))?\\?.*$/;
+	/^https:\/\/([\w\.-]+\.)?figma[.](?:com|engineering)\/(file|proto|board|design)\/([0-9a-zA-Z]{22,128})(?:\/([^\\?]*))?\\?.*$/;
 function isValidFigmaFileURL(url) {
 	return validURLChecker.exec(url) != null;
 }


### PR DESCRIPTION
we're adding `/design` and `/board` where `/file` used to be, so update our url parsing accordingly

## Test plan
- Try to link a design or figjam file with this new path
- Assert that it works