### PR TITLE
NONE: Add support for branch file urls

### DIFF
--- a/src/domain/entities/figma-design-identifier.test.ts
+++ b/src/domain/entities/figma-design-identifier.test.ts
@@ -136,6 +136,33 @@ describe('FigmaDesignIdentifier', () => {
 			expect(result).toStrictEqual(new FigmaDesignIdentifier(fileKey, nodeId));
 		});
 
+		it('should use the branch file key when using a branch url', () => {
+			const fileKey = generateFigmaFileKey();
+			const nodeId = '42:1';
+			const branchFileKey = generateFigmaFileKey();
+			const designUrl = new URL(
+				`https://www.figma.com/file/${fileKey}/branch/${branchFileKey}/FileName?node-id=42%3A1`,
+			);
+
+			const result = FigmaDesignIdentifier.fromFigmaDesignUrl(designUrl);
+
+			expect(result).toStrictEqual(
+				new FigmaDesignIdentifier(branchFileKey, nodeId),
+			);
+		});
+
+		it('should ignore the resulting query params if there is no branch but the file name is branch', () => {
+			const fileKey = generateFigmaFileKey();
+			const nodeId = '42:1';
+			const designUrl = new URL(
+				`https://www.figma.com/file/${fileKey}/branch?node-id=42%3A1`,
+			);
+
+			const result = FigmaDesignIdentifier.fromFigmaDesignUrl(designUrl);
+
+			expect(result).toStrictEqual(new FigmaDesignIdentifier(fileKey, nodeId));
+		});
+
 		it.each([
 			new URL(`https://www.figma.com`),
 			new URL(`https://www.figma.com/file`),
@@ -145,6 +172,7 @@ describe('FigmaDesignIdentifier', () => {
 			new URL(
 				`https://www.figma.com/files/project/176167247/Team-project?fuid=1166427116484924636`,
 			),
+			new URL(`https://www.figma.com/file/176167247/branch/`),
 		])('should throw when URL has an unexpected format', (input: URL) => {
 			expect(() => FigmaDesignIdentifier.fromFigmaDesignUrl(input)).toThrow();
 		});

--- a/src/domain/entities/figma-design-identifier.ts
+++ b/src/domain/entities/figma-design-identifier.ts
@@ -40,12 +40,16 @@ export class FigmaDesignIdentifier {
 		);
 
 		const fileKey = pathComponents[filePathComponentId + 1];
+		const branchFileKey =
+			pathComponents[filePathComponentId + 2] === 'branch'
+				? pathComponents[filePathComponentId + 3]
+				: undefined;
 		const nodeId = url.searchParams.get('node-id')?.replace('-', ':');
 
 		if (!fileKey)
 			throw new Error(`Received invalid Figma URL: ${url.toString()}`);
 
-		return new FigmaDesignIdentifier(fileKey, nodeId);
+		return new FigmaDesignIdentifier(branchFileKey ?? fileKey, nodeId);
 	};
 
 	/**

--- a/src/infrastructure/figma/figma-backfill-service.test.ts
+++ b/src/infrastructure/figma/figma-backfill-service.test.ts
@@ -106,5 +106,32 @@ describe('FigmaBackfillService', () => {
 
 			expect(result?.displayName).toStrictEqual(truncateDisplayName(fileName));
 		});
+
+		it('should parse Figma file urls pointing to a branch', () => {
+			const fileKey = generateFigmaFileKey();
+			const nodeId = generateFigmaNodeId();
+			const branchFileKey = generateFigmaFileKey();
+
+			const fileName = 'Design1';
+			const designId = new FigmaDesignIdentifier(branchFileKey, nodeId);
+
+			const result = figmaBackfillService.buildMinimalDesignFromUrl(
+				new URL(
+					`https://www.figma.com/file/${fileKey}/branch/${branchFileKey}/${fileName}?node-id=${nodeId}`,
+				),
+			);
+
+			expect(result).toStrictEqual({
+				id: designId.toAtlassianDesignId(),
+				displayName: fileName,
+				url: buildDesignUrl(designId).toString(),
+				liveEmbedUrl: buildLiveEmbedUrl(designId).toString(),
+				inspectUrl: buildInspectUrl(designId).toString(),
+				status: AtlassianDesignStatus.UNKNOWN,
+				type: AtlassianDesignType.NODE,
+				lastUpdated: new Date(0).toISOString(),
+				updateSequenceNumber: 0,
+			});
+		});
 	});
 });

--- a/src/infrastructure/figma/figma-backfill-service.ts
+++ b/src/infrastructure/figma/figma-backfill-service.ts
@@ -30,7 +30,16 @@ export class FigmaBackfillService {
 	 */
 	buildMinimalDesignFromUrl(url: URL): AtlassianDesign {
 		const designId = FigmaDesignIdentifier.fromFigmaDesignUrl(url);
-		const [, , , name] = url.pathname.split('/');
+		const pathComponents = url.pathname.split('/');
+		const keyComponentIndex = pathComponents.indexOf(designId.fileKey);
+
+		// `name` goes after the `key` component (which can be a File Key or Branch File Key).
+		// In theory, the keyComponentIndex should always be found, but let's be defensive
+		// and treat the name as if it's not found if we're not able to match the fileKey
+		const name =
+			keyComponentIndex === -1
+				? undefined
+				: pathComponents[keyComponentIndex + 1];
 
 		const displayName = name
 			? decodeURIComponent(name).replaceAll('-', ' ')

--- a/src/infrastructure/figma/transformers/figma-file-meta-transformer.ts
+++ b/src/infrastructure/figma/transformers/figma-file-meta-transformer.ts
@@ -20,7 +20,7 @@ type TransformFileMetaToAtlassianDesignParams = {
 };
 
 /**
- * Transforms a Figma file medata to {@link AtlassianDesign}.
+ * Transforms a Figma file metadata to {@link AtlassianDesign}.
  */
 export const transformFileMetaToAtlassianDesign = ({
 	fileKey,


### PR DESCRIPTION
This PR re-adds support for branch file URLs. This is the short term approach outlined in https://figlassian.atlassian.net/wiki/spaces/FCS/pages/55115777/Supporting+Branching+in+Figma+for+Jira

We're not making any separate format / tracking branch file keys separately in the app. This will simply update the url parsing to prefer the branch file key over the main file key and use that when appropriate

## Test Plan
- Try to associate a branch file URL and see that the embed that shows up points to the branch file
- Try to associate a normal file URL and see that the embed that shows up points to the file
