### PR TITLE
NONE: Update last_touched_by schema validation to be nullable

### DIFF
--- a/src/infrastructure/figma/figma-client/schemas.ts
+++ b/src/infrastructure/figma/figma-client/schemas.ts
@@ -84,6 +84,7 @@ export const GET_FILE_META_RESPONSE_SCHEMA: JSONSchemaTypeWithId<GetFileMetaResp
 					last_touched_at: { type: 'string' },
 					last_touched_by: {
 						type: 'object',
+						nullable: true,
 						properties: {
 							id: { type: 'string' },
 						},

--- a/src/infrastructure/figma/figma-client/testing/mocks.ts
+++ b/src/infrastructure/figma/figma-client/testing/mocks.ts
@@ -114,6 +114,10 @@ export const generateGetFileMetaResponse = ({
 	name = generateFigmaFileName(),
 	lastModified = new Date(),
 	lastTouchedBy = { id: uuidv4() },
+}: {
+	name?: string;
+	lastModified?: Date;
+	lastTouchedBy?: { id: string } | null;
 } = {}): GetFileMetaResponse => ({
 	file: {
 		name,

--- a/src/infrastructure/figma/figma-client/types.ts
+++ b/src/infrastructure/figma/figma-client/types.ts
@@ -38,9 +38,9 @@ export type GetFileMetaResponse = {
 	readonly file: {
 		readonly name: string;
 		readonly last_touched_at: string;
-		readonly last_touched_by: {
+		readonly last_touched_by?: {
 			readonly id: string;
-		};
+		} | null;
 		readonly editorType: string;
 	};
 };

--- a/src/infrastructure/figma/figma-service.test.ts
+++ b/src/infrastructure/figma/figma-service.test.ts
@@ -169,7 +169,7 @@ describe('FigmaService', () => {
 			expect(result).toStrictEqual({
 				...expectedEntity,
 				lastUpdated: expect.anything(),
-				lastUpdatedBy: { id: fileMetaResponse.file.last_touched_by.id },
+				lastUpdatedBy: { id: fileMetaResponse.file.last_touched_by!.id },
 			});
 		});
 
@@ -267,7 +267,7 @@ describe('FigmaService', () => {
 			expect(result).toStrictEqual({
 				...expectedEntity,
 				lastUpdated: expect.anything(),
-				lastUpdatedBy: { id: fileMetaResponse.file.last_touched_by.id },
+				lastUpdatedBy: { id: fileMetaResponse.file.last_touched_by!.id },
 			});
 		});
 

--- a/src/infrastructure/figma/transformers/figma-file-meta-transformer.test.ts
+++ b/src/infrastructure/figma/transformers/figma-file-meta-transformer.test.ts
@@ -33,7 +33,7 @@ describe('transformFileMetaToAtlassianDesign', () => {
 			status: AtlassianDesignStatus.NONE,
 			type: AtlassianDesignType.FILE,
 			lastUpdated: fileMetaResponse.file.last_touched_at,
-			lastUpdatedBy: { id: fileMetaResponse.file.last_touched_by.id },
+			lastUpdatedBy: { id: fileMetaResponse.file.last_touched_by!.id },
 			updateSequenceNumber: getUpdateSequenceNumberFrom(
 				fileMetaResponse.file.last_touched_at,
 			),

--- a/src/infrastructure/figma/transformers/figma-file-meta-transformer.ts
+++ b/src/infrastructure/figma/transformers/figma-file-meta-transformer.ts
@@ -27,6 +27,7 @@ export const transformFileMetaToAtlassianDesign = ({
 	fileMetaResponse,
 }: TransformFileMetaToAtlassianDesignParams): AtlassianDesign => {
 	const designId = new FigmaDesignIdentifier(fileKey);
+	const lastUpdatedBy = fileMetaResponse.file.last_touched_by;
 
 	return {
 		id: designId.toAtlassianDesignId(),
@@ -37,7 +38,7 @@ export const transformFileMetaToAtlassianDesign = ({
 		status: AtlassianDesignStatus.NONE,
 		type: AtlassianDesignType.FILE,
 		lastUpdated: fileMetaResponse.file.last_touched_at,
-		lastUpdatedBy: { id: fileMetaResponse.file.last_touched_by.id },
+		...(lastUpdatedBy ? { lastUpdatedBy: { id: lastUpdatedBy.id } } : {}),
 		updateSequenceNumber: getUpdateSequenceNumberFrom(
 			fileMetaResponse.file.last_touched_at,
 		),

--- a/src/infrastructure/figma/transformers/figma-file-transformer.test.ts
+++ b/src/infrastructure/figma/transformers/figma-file-transformer.test.ts
@@ -44,7 +44,7 @@ describe('transformFileToAtlassianDesign', () => {
 			status: AtlassianDesignStatus.NONE,
 			type: AtlassianDesignType.FILE,
 			lastUpdated: fileResponse.lastModified,
-			lastUpdatedBy: { id: fileMetaResponse.file.last_touched_by.id },
+			lastUpdatedBy: { id: fileMetaResponse.file.last_touched_by!.id },
 			updateSequenceNumber: getUpdateSequenceNumberFrom(
 				fileResponse.lastModified,
 			),

--- a/src/infrastructure/figma/transformers/figma-file-transformer.ts
+++ b/src/infrastructure/figma/transformers/figma-file-transformer.ts
@@ -29,6 +29,7 @@ export const transformFileToAtlassianDesign = ({
 	fileMetaResponse,
 }: TransformFileToAtlassianDesignParams): AtlassianDesign => {
 	const designId = new FigmaDesignIdentifier(fileKey);
+	const lastUpdatedBy = fileMetaResponse.file.last_touched_by;
 
 	return {
 		id: designId.toAtlassianDesignId(),
@@ -39,7 +40,7 @@ export const transformFileToAtlassianDesign = ({
 		status: AtlassianDesignStatus.NONE,
 		type: AtlassianDesignType.FILE,
 		lastUpdated: fileResponse.lastModified,
-		lastUpdatedBy: { id: fileMetaResponse.file.last_touched_by.id },
+		...(lastUpdatedBy ? { lastUpdatedBy: { id: lastUpdatedBy.id } } : {}),
 		updateSequenceNumber: getUpdateSequenceNumberFrom(
 			fileResponse.lastModified,
 		),

--- a/src/infrastructure/figma/transformers/figma-node-transformer.test.ts
+++ b/src/infrastructure/figma/transformers/figma-node-transformer.test.ts
@@ -103,7 +103,7 @@ describe('tryTransformNodeToAtlassianDesign', () => {
 			status: AtlassianDesignStatus.NONE,
 			type: AtlassianDesignType.OTHER,
 			lastUpdated: nodeLastModified.toISOString(),
-			lastUpdatedBy: { id: fileMetaResponse.file.last_touched_by.id },
+			lastUpdatedBy: { id: fileMetaResponse.file.last_touched_by!.id },
 			updateSequenceNumber: getUpdateSequenceNumberFrom(
 				nodeLastModified.toISOString(),
 			),

--- a/src/infrastructure/figma/transformers/figma-node-transformer.ts
+++ b/src/infrastructure/figma/transformers/figma-node-transformer.ts
@@ -69,6 +69,7 @@ export const tryTransformNodeToAtlassianDesign = ({
 
 	const { node, extra } = nodeData;
 	const fileName = fileResponse.name;
+	const lastUpdatedBy = fileMetaResponse.file.last_touched_by;
 
 	return {
 		id: designId.toAtlassianDesignId(),
@@ -81,7 +82,7 @@ export const tryTransformNodeToAtlassianDesign = ({
 			: AtlassianDesignStatus.NONE,
 		type: mapNodeTypeToDesignType(node.type),
 		lastUpdated: extra.lastModified,
-		lastUpdatedBy: { id: fileMetaResponse.file.last_touched_by.id },
+		...(lastUpdatedBy ? { lastUpdatedBy: { id: lastUpdatedBy.id } } : {}),
 		updateSequenceNumber: getUpdateSequenceNumberFrom(extra.lastModified),
 	};
 };


### PR DESCRIPTION
We started seeing logs / 500 errors on `POST /associate/entities` because we were failing the schema validation for `GetFileMetaResponse`.

This is because `last_touched_by` can be `null` (eg. the user has since been deleted) which is different from the field being optional

This PR updates the app to be able to handle when `GetFileMetaResponse[file][last_touched_by]` is `null` and adds an integration test to check that this is handled properly

## Test Plan
- Revert all changes except for the integration test and assert that the integration test fails
- Apply the changes in this PR and assert that the integration test passes

