### PR TITLE
NONE: return 400s when receiving invalid node ids

### DIFF
--- a/src/infrastructure/figma/figma-service.ts
+++ b/src/infrastructure/figma/figma-service.ts
@@ -58,6 +58,7 @@ export class FigmaService {
 	/**
 	 * Returns Atlassian design for the Figma design with the given ID if it exists; otherwise -- `null`.
 	 *
+	 * @throws {InvalidInputFigmaServiceError} Invalid node ids specified.
 	 * @throws {UnauthorizedFigmaServiceError} Not authorized to access Figma.
 	 */
 	getDesign = async (
@@ -81,6 +82,7 @@ export class FigmaService {
 	 * for the given ID doesn't exist, returns the parent design identified by the
 	 * fileKey part of the design ID. If the parent design does not exist, returns `null`.
 	 *
+	 * @throws {InvalidInputFigmaServiceError} Invalid node ids specified.
 	 * @throws {UnauthorizedFigmaServiceError} Not authorized to access Figma.
 	 */
 	getDesignOrParent = async (
@@ -112,6 +114,7 @@ export class FigmaService {
 	 *
 	 * @param designIds IDs of designs within the same Figma file.
 	 *
+	 * @throws {InvalidInputFigmaServiceError} Invalid node ids specified.
 	 * @throws {UnauthorizedFigmaServiceError} Not authorized to access Figma.
 	 */
 	getAvailableDesignsFromSameFile = async (
@@ -407,6 +410,7 @@ export class FigmaService {
 	/**
 	 * Returns Atlassian design representation for the given Figma Node if it exists; otherwise -- `null`.
 	 *
+	 * @throws {InvalidInputFigmaServiceError} Invalid node ids specified.
 	 * @throws {UnauthorizedFigmaServiceError} Not authorized to access Figma.
 	 */
 	private getDesignForNode = async (
@@ -445,6 +449,7 @@ export class FigmaService {
 	 * Returns Atlassian design representation for the given Figma Node if it exists; Figma File if Node does not exist;
 	 * otherwise -- `null`.
 	 *
+	 * @throws {InvalidInputFigmaServiceError} Invalid node ids specified.
 	 * @throws {UnauthorizedFigmaServiceError} Not authorized to access Figma.
 	 */
 	private getDesignForNodeOrFile = async (
@@ -503,6 +508,18 @@ export class FigmaService {
 					'Not allowed to perform the operation.',
 					e,
 				);
+			}
+
+			if (e instanceof BadRequestHttpClientError) {
+				const response = e.response;
+				if (
+					typeof response === 'object' &&
+					response != null &&
+					'err' in response &&
+					typeof response.err === 'string'
+				) {
+					throw new InvalidInputFigmaServiceError(response.err, e);
+				}
 			}
 
 			throw e;

--- a/src/usecases/associate-design-use-case.ts
+++ b/src/usecases/associate-design-use-case.ts
@@ -13,6 +13,7 @@ import {
 import { figmaBackwardIntegrationService } from '../infrastructure';
 import {
 	figmaService,
+	InvalidInputFigmaServiceError,
 	UnauthorizedFigmaServiceError,
 } from '../infrastructure/figma';
 import { jiraService } from '../infrastructure/jira';
@@ -84,6 +85,10 @@ export const associateDesignUseCase = {
 
 			return design;
 		} catch (e) {
+			if (e instanceof InvalidInputFigmaServiceError) {
+				throw new InvalidInputUseCaseResultError(e.message, e);
+			}
+
 			if (e instanceof UnauthorizedFigmaServiceError) {
 				throw new ForbiddenByFigmaUseCaseResultError(e);
 			}


### PR DESCRIPTION
Describe:

We're currently getting a lot of 500 error alerting when users are inputing design URLs with invalid node ids. For example: `https://www.figma.com/design/<file_key>/<file_name>?node-id=0-a`. When this happens, Figma's REST API returns a 400 w a response like: `ID 0:a is not a valid node_id` in `response.err`.

This PR:
- updates the functions calling `figmaClient.getFile()` to parse the `BadRequestHttpClientError` and throw an `InvalidInputFigmaServiceError`
- updates `associateDesignUseCase` to throw an `InvalidInputUseCaseResultError` when receiving an `InvalidInputFigmaServiceError` (`submit-full-design` and `handle-figma-file-update-event-use-case` don't need their error handling to be updated :D)

## Test Plan
- Try attaching an invalid url to an issue
- Assert in the dev console that the server is now returning a 400 instead of a 500 with the appropriate error message

