### PR TITLE
MDTZ-1749: Improve the contract of `JiraDesignIssuePropertyService`

### DIFF
--- a/src/infrastructure/figma-backward-integration-service.test.ts
+++ b/src/infrastructure/figma-backward-integration-service.test.ts
@@ -28,7 +28,7 @@ describe('FigmaBackwardIntegrationService', () => {
 			jest.spyOn(jiraService, 'getIssue').mockResolvedValue(issue);
 
 			jest
-				.spyOn(jiraService, 'trySaveDesignUrlInIssueProperties')
+				.spyOn(jiraService, 'trySaveDesignInIssueProperties')
 				.mockResolvedValue();
 			jest
 				.spyOn(figmaService, 'tryCreateDevResourceForJiraIssue')
@@ -44,9 +44,7 @@ describe('FigmaBackwardIntegrationService', () => {
 				},
 			);
 
-			expect(
-				jiraService.trySaveDesignUrlInIssueProperties,
-			).toHaveBeenCalledWith(
+			expect(jiraService.trySaveDesignInIssueProperties).toHaveBeenCalledWith(
 				issue.id,
 				originalFigmaDesignId,
 				atlassianDesign,
@@ -85,7 +83,7 @@ describe('FigmaBackwardIntegrationService', () => {
 			jest.spyOn(jiraService, 'getIssue').mockResolvedValue(issue);
 
 			jest
-				.spyOn(jiraService, 'trySaveDesignUrlInIssueProperties')
+				.spyOn(jiraService, 'trySaveDesignInIssueProperties')
 				.mockResolvedValue();
 			jest
 				.spyOn(figmaService, 'tryCreateDevResourceForJiraIssue')
@@ -101,9 +99,7 @@ describe('FigmaBackwardIntegrationService', () => {
 				},
 			);
 
-			expect(
-				jiraService.trySaveDesignUrlInIssueProperties,
-			).toHaveBeenCalledWith(
+			expect(jiraService.trySaveDesignInIssueProperties).toHaveBeenCalledWith(
 				issue.id,
 				originalFigmaDesignId,
 				atlassianDesign,
@@ -167,7 +163,7 @@ describe('FigmaBackwardIntegrationService', () => {
 			jest.spyOn(jiraService, 'getIssue').mockResolvedValue(issue);
 
 			jest
-				.spyOn(jiraService, 'tryDeleteDesignUrlFromIssueProperties')
+				.spyOn(jiraService, 'tryDeleteDesignFromIssueProperties')
 				.mockResolvedValue();
 			jest.spyOn(figmaService, 'tryDeleteDevResource').mockResolvedValue();
 
@@ -181,7 +177,7 @@ describe('FigmaBackwardIntegrationService', () => {
 			);
 
 			expect(
-				jiraService.tryDeleteDesignUrlFromIssueProperties,
+				jiraService.tryDeleteDesignFromIssueProperties,
 			).toHaveBeenCalledWith(issue.id, figmaDesignId, connectInstallation);
 			expect(figmaService.tryDeleteDevResource).toHaveBeenCalledWith({
 				designId: figmaDesignId,

--- a/src/infrastructure/figma-backward-integration-service.test.ts
+++ b/src/infrastructure/figma-backward-integration-service.test.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { figmaService } from './figma';
 import { figmaBackwardIntegrationService } from './figma-backward-integration-service';
-import { jiraService, NotFoundInJiraServiceError } from './jira';
+import { jiraService } from './jira';
 
 import { FigmaDesignIdentifier } from '../domain/entities';
 import {
@@ -11,6 +11,7 @@ import {
 	generateFigmaFileKey,
 	generateFigmaNodeId,
 	generateJiraIssue,
+	generateJiraIssueId,
 } from '../domain/entities/testing';
 
 describe('FigmaBackwardIntegrationService', () => {
@@ -126,23 +127,21 @@ describe('FigmaBackwardIntegrationService', () => {
 		it('should not throw when Jira Issue is not found', async () => {
 			const connectInstallation = generateConnectInstallation();
 			const atlassianUserId = uuidv4();
-			const issue = generateJiraIssue();
+			const issueId = generateJiraIssueId();
 			const originalFigmaDesignId = new FigmaDesignIdentifier(
 				generateFigmaFileKey(),
 			);
 			const atlassianDesign = generateAtlassianDesign({
 				id: originalFigmaDesignId.toAtlassianDesignId(),
 			});
-			jest
-				.spyOn(jiraService, 'getIssue')
-				.mockRejectedValue(new NotFoundInJiraServiceError());
+			jest.spyOn(jiraService, 'getIssue').mockResolvedValue(null);
 
 			await expect(
 				figmaBackwardIntegrationService.tryNotifyFigmaOnAddedIssueDesignAssociation(
 					{
 						originalFigmaDesignId,
 						design: atlassianDesign,
-						issueId: issue.id,
+						issueId,
 						atlassianUserId,
 						connectInstallation,
 					},
@@ -192,17 +191,15 @@ describe('FigmaBackwardIntegrationService', () => {
 		it('should not throw when Jira Issue is not found', async () => {
 			const connectInstallation = generateConnectInstallation();
 			const atlassianUserId = uuidv4();
-			const issue = generateJiraIssue();
+			const issueId = generateJiraIssueId();
 			const atlassianDesign = generateAtlassianDesign();
-			jest
-				.spyOn(jiraService, 'getIssue')
-				.mockRejectedValue(new NotFoundInJiraServiceError());
+			jest.spyOn(jiraService, 'getIssue').mockResolvedValue(null);
 
 			await expect(
 				figmaBackwardIntegrationService.tryNotifyFigmaOnRemovedIssueDesignAssociation(
 					{
 						design: atlassianDesign,
-						issueId: issue.id,
+						issueId,
 						atlassianUserId,
 						connectInstallation,
 					},

--- a/src/infrastructure/figma-backward-integration-service.ts
+++ b/src/infrastructure/figma-backward-integration-service.ts
@@ -1,12 +1,8 @@
 import { figmaService } from './figma';
-import { jiraService, NotFoundInJiraServiceError } from './jira';
+import { jiraService } from './jira';
 import { getLogger } from './logger';
 
-import type {
-	AtlassianDesign,
-	ConnectInstallation,
-	JiraIssue,
-} from '../domain/entities';
+import type { AtlassianDesign, ConnectInstallation } from '../domain/entities';
 import { buildJiraIssueUrl, FigmaDesignIdentifier } from '../domain/entities';
 
 /**
@@ -35,19 +31,12 @@ export class FigmaBackwardIntegrationService {
 		readonly atlassianUserId: string;
 		readonly connectInstallation: ConnectInstallation;
 	}): Promise<void> => {
-		let issue: JiraIssue;
+		const issue = await jiraService.getIssue(issueId, connectInstallation);
 
-		try {
-			issue = await jiraService.getIssue(issueId, connectInstallation);
-		} catch (e) {
-			if (e instanceof NotFoundInJiraServiceError) {
-				return getLogger().warn(
-					'Skipping handling backward integration as the Issue has been deleted or the app does not have permission to read it.',
-					e,
-				);
-			}
-
-			throw e;
+		if (!issue) {
+			return getLogger().warn(
+				'Skipping handling backward integration as the Issue is not found: it has been deleted or the app does not have permission to read it.',
+			);
 		}
 
 		await Promise.all([
@@ -91,19 +80,12 @@ export class FigmaBackwardIntegrationService {
 		readonly atlassianUserId: string;
 		readonly connectInstallation: ConnectInstallation;
 	}): Promise<void> => {
-		let issue: JiraIssue;
+		const issue = await jiraService.getIssue(issueId, connectInstallation);
 
-		try {
-			issue = await jiraService.getIssue(issueId, connectInstallation);
-		} catch (e) {
-			if (e instanceof NotFoundInJiraServiceError) {
-				return getLogger().warn(
-					'Skipping handling backward integration as the Issue has been deleted or the app does not have permission to read it.',
-					e,
-				);
-			}
-
-			throw e;
+		if (!issue) {
+			return getLogger().warn(
+				'Skipping handling backward integration as the Issue is not found: it has been deleted or the app does not have permission to read it.',
+			);
 		}
 
 		const figmaDesignId = FigmaDesignIdentifier.fromAtlassianDesignId(

--- a/src/infrastructure/figma-backward-integration-service.ts
+++ b/src/infrastructure/figma-backward-integration-service.ts
@@ -51,7 +51,7 @@ export class FigmaBackwardIntegrationService {
 		}
 
 		await Promise.all([
-			jiraService.trySaveDesignUrlInIssueProperties(
+			jiraService.trySaveDesignInIssueProperties(
 				issueId,
 				originalFigmaDesignId,
 				design,
@@ -111,7 +111,7 @@ export class FigmaBackwardIntegrationService {
 		);
 
 		await Promise.all([
-			jiraService.tryDeleteDesignUrlFromIssueProperties(
+			jiraService.tryDeleteDesignFromIssueProperties(
 				issueId,
 				figmaDesignId,
 				connectInstallation,

--- a/src/infrastructure/jira/errors.ts
+++ b/src/infrastructure/jira/errors.ts
@@ -1,5 +1,3 @@
 import { CauseAwareError } from '../../common/errors';
 
 export class ForbiddenByJiraServiceError extends CauseAwareError {}
-
-export class NotFoundInJiraServiceError extends CauseAwareError {}

--- a/src/infrastructure/jira/jira-design-issue-property-service.test.ts
+++ b/src/infrastructure/jira/jira-design-issue-property-service.test.ts
@@ -30,7 +30,7 @@ const issuePropertyKeys = {
 };
 
 describe('JiraDesignIssuePropertyService', () => {
-	describe('trySaveDesignUrlInIssueProperties', () => {
+	describe('trySaveDesignInIssueProperties', () => {
 		afterEach(() => {
 			jest.resetAllMocks();
 		});
@@ -43,18 +43,18 @@ describe('JiraDesignIssuePropertyService', () => {
 			jest
 				.spyOn(
 					jiraDesignIssuePropertyService,
-					'setAttachedDesignUrlInIssuePropertiesIfMissing',
+					'setAttachedDesignInIssuePropertiesIfMissing',
 				)
 				.mockRejectedValue(new ForbiddenByJiraServiceError());
 			jest
 				.spyOn(
 					jiraDesignIssuePropertyService,
-					'updateAttachedDesignUrlV2IssueProperty',
+					'updateAttachedDesignV2IssueProperty',
 				)
 				.mockRejectedValue(new ForbiddenByJiraServiceError());
 
 			await expect(
-				jiraDesignIssuePropertyService.trySaveDesignUrlInIssueProperties(
+				jiraDesignIssuePropertyService.trySaveDesignInIssueProperties(
 					issueId,
 					figmaDesignIdToReplace,
 					design,
@@ -64,7 +64,7 @@ describe('JiraDesignIssuePropertyService', () => {
 		});
 	});
 
-	describe('tryDeleteDesignUrlFromIssueProperties', () => {
+	describe('tryDeleteDesignFromIssueProperties', () => {
 		afterEach(() => {
 			jest.resetAllMocks();
 		});
@@ -76,18 +76,18 @@ describe('JiraDesignIssuePropertyService', () => {
 			jest
 				.spyOn(
 					jiraDesignIssuePropertyService,
-					'deleteAttachedDesignUrlInIssuePropertiesIfPresent',
+					'deleteAttachedDesignInIssuePropertiesIfPresent',
 				)
 				.mockRejectedValue(new ForbiddenByJiraServiceError());
 			jest
 				.spyOn(
 					jiraDesignIssuePropertyService,
-					'deleteFromAttachedDesignUrlV2IssueProperties',
+					'deleteFromAttachedDesignV2IssueProperties',
 				)
 				.mockRejectedValue(new ForbiddenByJiraServiceError());
 
 			await expect(
-				jiraDesignIssuePropertyService.tryDeleteDesignUrlFromIssueProperties(
+				jiraDesignIssuePropertyService.tryDeleteDesignFromIssueProperties(
 					issueId,
 					figmaDesignId,
 					connectInstallation,
@@ -96,7 +96,7 @@ describe('JiraDesignIssuePropertyService', () => {
 		});
 	});
 
-	describe('setAttachedDesignUrlInIssuePropertiesIfMissing', () => {
+	describe('setAttachedDesignInIssuePropertiesIfMissing', () => {
 		it('should set the Issue Property if not present', async () => {
 			const issueId = generateJiraIssueId();
 			const connectInstallation = generateConnectInstallation();
@@ -108,7 +108,7 @@ describe('JiraDesignIssuePropertyService', () => {
 				.mockRejectedValue(new NotFoundHttpClientError());
 			jest.spyOn(jiraClient, 'setIssueProperty').mockImplementation();
 
-			await jiraDesignIssuePropertyService.setAttachedDesignUrlInIssuePropertiesIfMissing(
+			await jiraDesignIssuePropertyService.setAttachedDesignInIssuePropertiesIfMissing(
 				issueId,
 				design,
 				connectInstallation,
@@ -135,7 +135,7 @@ describe('JiraDesignIssuePropertyService', () => {
 			);
 			jest.spyOn(jiraClient, 'setIssueProperty');
 
-			await jiraDesignIssuePropertyService.setAttachedDesignUrlInIssuePropertiesIfMissing(
+			await jiraDesignIssuePropertyService.setAttachedDesignInIssuePropertiesIfMissing(
 				issueId,
 				design,
 				connectInstallation,
@@ -158,7 +158,7 @@ describe('JiraDesignIssuePropertyService', () => {
 				.mockRejectedValue(new ForbiddenHttpClientError());
 
 			await expect(
-				jiraDesignIssuePropertyService.setAttachedDesignUrlInIssuePropertiesIfMissing(
+				jiraDesignIssuePropertyService.setAttachedDesignInIssuePropertiesIfMissing(
 					issueId,
 					design,
 					connectInstallation,
@@ -178,7 +178,7 @@ describe('JiraDesignIssuePropertyService', () => {
 				.mockRejectedValue(unexpectedError);
 
 			await expect(
-				jiraDesignIssuePropertyService.setAttachedDesignUrlInIssuePropertiesIfMissing(
+				jiraDesignIssuePropertyService.setAttachedDesignInIssuePropertiesIfMissing(
 					issueId,
 					design,
 					connectInstallation,
@@ -187,7 +187,7 @@ describe('JiraDesignIssuePropertyService', () => {
 		});
 	});
 
-	describe('updateAttachedDesignUrlV2IssueProperty', () => {
+	describe('updateAttachedDesignV2IssueProperty', () => {
 		it('should set Issue Property if not present', async () => {
 			const issueId = generateJiraIssueId();
 			const connectInstallation = generateConnectInstallation();
@@ -199,7 +199,7 @@ describe('JiraDesignIssuePropertyService', () => {
 				.mockRejectedValue(new NotFoundHttpClientError());
 			jest.spyOn(jiraClient, 'setIssueProperty').mockImplementation(jest.fn());
 
-			await jiraDesignIssuePropertyService.updateAttachedDesignUrlV2IssueProperty(
+			await jiraDesignIssuePropertyService.updateAttachedDesignV2IssueProperty(
 				issueId,
 				FigmaDesignIdentifier.fromAtlassianDesignId(design.id),
 				design,
@@ -241,7 +241,7 @@ describe('JiraDesignIssuePropertyService', () => {
 			);
 			jest.spyOn(jiraClient, 'setIssueProperty').mockImplementation(jest.fn());
 
-			await jiraDesignIssuePropertyService.updateAttachedDesignUrlV2IssueProperty(
+			await jiraDesignIssuePropertyService.updateAttachedDesignV2IssueProperty(
 				issueId,
 				FigmaDesignIdentifier.fromAtlassianDesignId(design.id),
 				design,
@@ -292,7 +292,7 @@ describe('JiraDesignIssuePropertyService', () => {
 			);
 			jest.spyOn(jiraClient, 'setIssueProperty').mockImplementation(jest.fn());
 
-			await jiraDesignIssuePropertyService.updateAttachedDesignUrlV2IssueProperty(
+			await jiraDesignIssuePropertyService.updateAttachedDesignV2IssueProperty(
 				issueId,
 				FigmaDesignIdentifier.fromAtlassianDesignId(design.id),
 				design,
@@ -350,7 +350,7 @@ describe('JiraDesignIssuePropertyService', () => {
 			);
 			jest.spyOn(jiraClient, 'setIssueProperty').mockImplementation(jest.fn());
 
-			await jiraDesignIssuePropertyService.updateAttachedDesignUrlV2IssueProperty(
+			await jiraDesignIssuePropertyService.updateAttachedDesignV2IssueProperty(
 				issueId,
 				designId,
 				parentDesign,
@@ -409,7 +409,7 @@ describe('JiraDesignIssuePropertyService', () => {
 			);
 			jest.spyOn(jiraClient, 'setIssueProperty').mockImplementation(jest.fn());
 
-			await jiraDesignIssuePropertyService.updateAttachedDesignUrlV2IssueProperty(
+			await jiraDesignIssuePropertyService.updateAttachedDesignV2IssueProperty(
 				issueId,
 				designId,
 				parentDesign,
@@ -454,7 +454,7 @@ describe('JiraDesignIssuePropertyService', () => {
 				);
 				jest.spyOn(jiraClient, 'setIssueProperty').mockResolvedValue();
 
-				await jiraDesignIssuePropertyService.updateAttachedDesignUrlV2IssueProperty(
+				await jiraDesignIssuePropertyService.updateAttachedDesignV2IssueProperty(
 					issueId,
 					FigmaDesignIdentifier.fromAtlassianDesignId(design.id),
 					design,
@@ -488,7 +488,7 @@ describe('JiraDesignIssuePropertyService', () => {
 				.mockResolvedValue(generateGetIssuePropertyResponse({ value: 1 }));
 			jest.spyOn(jiraClient, 'setIssueProperty').mockResolvedValue();
 
-			await jiraDesignIssuePropertyService.updateAttachedDesignUrlV2IssueProperty(
+			await jiraDesignIssuePropertyService.updateAttachedDesignV2IssueProperty(
 				issueId,
 				FigmaDesignIdentifier.fromAtlassianDesignId(design.id),
 				design,
@@ -524,7 +524,7 @@ describe('JiraDesignIssuePropertyService', () => {
 				.mockRejectedValue(new ForbiddenHttpClientError());
 
 			await expect(
-				jiraDesignIssuePropertyService.updateAttachedDesignUrlV2IssueProperty(
+				jiraDesignIssuePropertyService.updateAttachedDesignV2IssueProperty(
 					issueId,
 					FigmaDesignIdentifier.fromAtlassianDesignId(design.id),
 					design,
@@ -545,7 +545,7 @@ describe('JiraDesignIssuePropertyService', () => {
 				.mockRejectedValue(unexpectedError);
 
 			await expect(
-				jiraDesignIssuePropertyService.updateAttachedDesignUrlV2IssueProperty(
+				jiraDesignIssuePropertyService.updateAttachedDesignV2IssueProperty(
 					issueId,
 					FigmaDesignIdentifier.fromAtlassianDesignId(design.id),
 					design,
@@ -555,7 +555,7 @@ describe('JiraDesignIssuePropertyService', () => {
 		});
 	});
 
-	describe('deleteAttachedDesignUrlInIssuePropertiesIfPresent', () => {
+	describe('deleteAttachedDesignInIssuePropertiesIfPresent', () => {
 		it('should delete Issue Property if its value is URL of given design', async () => {
 			const issueId = generateJiraIssueId();
 			const connectInstallation = generateConnectInstallation();
@@ -572,7 +572,7 @@ describe('JiraDesignIssuePropertyService', () => {
 				.spyOn(jiraClient, 'deleteIssueProperty')
 				.mockImplementation(jest.fn());
 
-			await jiraDesignIssuePropertyService.deleteAttachedDesignUrlInIssuePropertiesIfPresent(
+			await jiraDesignIssuePropertyService.deleteAttachedDesignInIssuePropertiesIfPresent(
 				issueId,
 				figmaDesignId,
 				connectInstallation,
@@ -598,7 +598,7 @@ describe('JiraDesignIssuePropertyService', () => {
 				.spyOn(jiraClient, 'deleteIssueProperty')
 				.mockImplementation(jest.fn());
 
-			await jiraDesignIssuePropertyService.deleteAttachedDesignUrlInIssuePropertiesIfPresent(
+			await jiraDesignIssuePropertyService.deleteAttachedDesignInIssuePropertiesIfPresent(
 				issueId,
 				figmaDesignId,
 				connectInstallation,
@@ -617,7 +617,7 @@ describe('JiraDesignIssuePropertyService', () => {
 				.mockRejectedValue(unexpectedError);
 
 			await expect(
-				jiraDesignIssuePropertyService.deleteAttachedDesignUrlInIssuePropertiesIfPresent(
+				jiraDesignIssuePropertyService.deleteAttachedDesignInIssuePropertiesIfPresent(
 					issueId,
 					figmaDesignId,
 					connectInstallation,
@@ -636,7 +636,7 @@ describe('JiraDesignIssuePropertyService', () => {
 			jest.spyOn(jiraClient, 'setIssueProperty').mockImplementation(jest.fn());
 
 			await expect(
-				jiraDesignIssuePropertyService.deleteAttachedDesignUrlInIssuePropertiesIfPresent(
+				jiraDesignIssuePropertyService.deleteAttachedDesignInIssuePropertiesIfPresent(
 					issueId,
 					figmaDesignId,
 					connectInstallation,
@@ -647,7 +647,7 @@ describe('JiraDesignIssuePropertyService', () => {
 		});
 	});
 
-	describe('deleteFromAttachedDesignUrlV2IssueProperties', () => {
+	describe('deleteFromAttachedDesignV2IssueProperties', () => {
 		it('should delete the URL from the array stored in Issue Properties', async () => {
 			const issueId = generateJiraIssueId();
 			const connectInstallation = generateConnectInstallation();
@@ -674,7 +674,7 @@ describe('JiraDesignIssuePropertyService', () => {
 			);
 			jest.spyOn(jiraClient, 'setIssueProperty').mockImplementation(jest.fn());
 
-			await jiraDesignIssuePropertyService.deleteFromAttachedDesignUrlV2IssueProperties(
+			await jiraDesignIssuePropertyService.deleteFromAttachedDesignV2IssueProperties(
 				issueId,
 				targetFigmaDesignId,
 				connectInstallation,
@@ -706,7 +706,7 @@ describe('JiraDesignIssuePropertyService', () => {
 			);
 			jest.spyOn(jiraClient, 'setIssueProperty').mockImplementation(jest.fn());
 
-			await jiraDesignIssuePropertyService.deleteFromAttachedDesignUrlV2IssueProperties(
+			await jiraDesignIssuePropertyService.deleteFromAttachedDesignV2IssueProperties(
 				issueId,
 				targetFigmaDesignId,
 				connectInstallation,
@@ -735,7 +735,7 @@ describe('JiraDesignIssuePropertyService', () => {
 				);
 
 				await expect(
-					jiraDesignIssuePropertyService.deleteFromAttachedDesignUrlV2IssueProperties(
+					jiraDesignIssuePropertyService.deleteFromAttachedDesignV2IssueProperties(
 						issueId,
 						figmaDesignId,
 						connectInstallation,
@@ -754,7 +754,7 @@ describe('JiraDesignIssuePropertyService', () => {
 			jest.spyOn(jiraClient, 'setIssueProperty').mockImplementation(jest.fn());
 
 			await expect(
-				jiraDesignIssuePropertyService.deleteFromAttachedDesignUrlV2IssueProperties(
+				jiraDesignIssuePropertyService.deleteFromAttachedDesignV2IssueProperties(
 					issueId,
 					figmaDesignId,
 					connectInstallation,
@@ -786,7 +786,7 @@ describe('JiraDesignIssuePropertyService', () => {
 				.mockRejectedValue(new ForbiddenHttpClientError());
 
 			await expect(
-				jiraDesignIssuePropertyService.deleteFromAttachedDesignUrlV2IssueProperties(
+				jiraDesignIssuePropertyService.deleteFromAttachedDesignV2IssueProperties(
 					issueId,
 					figmaDesignId,
 					connectInstallation,
@@ -804,7 +804,7 @@ describe('JiraDesignIssuePropertyService', () => {
 				.mockRejectedValue(unexpectedError);
 
 			await expect(
-				jiraDesignIssuePropertyService.deleteFromAttachedDesignUrlV2IssueProperties(
+				jiraDesignIssuePropertyService.deleteFromAttachedDesignV2IssueProperties(
 					issueId,
 					figmaDesignId,
 					connectInstallation,
@@ -823,7 +823,7 @@ describe('JiraDesignIssuePropertyService', () => {
 			jest.spyOn(jiraClient, 'setIssueProperty').mockImplementation(jest.fn());
 
 			await expect(
-				jiraDesignIssuePropertyService.deleteFromAttachedDesignUrlV2IssueProperties(
+				jiraDesignIssuePropertyService.deleteFromAttachedDesignV2IssueProperties(
 					issueId,
 					figmaDesignId,
 					connectInstallation,

--- a/src/infrastructure/jira/jira-design-issue-property-service.ts
+++ b/src/infrastructure/jira/jira-design-issue-property-service.ts
@@ -10,16 +10,18 @@ import {
 } from '../../common/schema-validation';
 import { ensureString, isString } from '../../common/string-utils';
 import { appendToPathname } from '../../common/url-utils';
-import type {
-	AtlassianDesign,
-	ConnectInstallation,
-} from '../../domain/entities';
+import type { ConnectInstallation } from '../../domain/entities';
 import { FigmaDesignIdentifier } from '../../domain/entities';
 import {
 	ForbiddenHttpClientError,
 	NotFoundHttpClientError,
 } from '../http-client-errors';
 import { getLogger } from '../logger';
+
+export type IssuePropertyInputDesignData = {
+	readonly displayName: string;
+	readonly url: string;
+};
 
 type AttachedDesignUrlV2IssuePropertyValue = {
 	readonly url: string;
@@ -46,23 +48,23 @@ const ATTACHED_DESIGN_URL_V2_VALUE_SCHEMA: JSONSchemaTypeWithId<AttachedDesignUr
 	};
 
 export class JiraDesignIssuePropertyService {
-	trySaveDesignUrlInIssueProperties = async (
+	trySaveDesignInIssueProperties = async (
 		issueIdOrKey: string,
 		figmaDesignIdToReplace: FigmaDesignIdentifier,
-		design: AtlassianDesign,
+		designData: IssuePropertyInputDesignData,
 		connectInstallation: ConnectInstallation,
 	): Promise<void> => {
 		try {
 			await Promise.all([
-				this.setAttachedDesignUrlInIssuePropertiesIfMissing(
+				this.setAttachedDesignInIssuePropertiesIfMissing(
 					issueIdOrKey,
-					design,
+					designData,
 					connectInstallation,
 				),
-				this.updateAttachedDesignUrlV2IssueProperty(
+				this.updateAttachedDesignV2IssueProperty(
 					issueIdOrKey,
 					figmaDesignIdToReplace,
-					design,
+					designData,
 					connectInstallation,
 				),
 			]);
@@ -78,19 +80,19 @@ export class JiraDesignIssuePropertyService {
 		}
 	};
 
-	tryDeleteDesignUrlFromIssueProperties = async (
+	tryDeleteDesignFromIssueProperties = async (
 		issueIdOrKey: string,
 		figmaDesignId: FigmaDesignIdentifier,
 		connectInstallation: ConnectInstallation,
 	): Promise<void> => {
 		try {
 			await Promise.all([
-				await this.deleteAttachedDesignUrlInIssuePropertiesIfPresent(
+				await this.deleteAttachedDesignInIssuePropertiesIfPresent(
 					issueIdOrKey,
 					figmaDesignId,
 					connectInstallation,
 				),
-				await this.deleteFromAttachedDesignUrlV2IssueProperties(
+				await this.deleteFromAttachedDesignV2IssueProperties(
 					issueIdOrKey,
 					figmaDesignId,
 					connectInstallation,
@@ -119,9 +121,9 @@ export class JiraDesignIssuePropertyService {
 	//  It should be safe to do so since:
 	//  - The "Jira" widget reads from `attached-design-url-v2`
 	//  - The previous version of the "Figma for Jira" did not set `attached-design-url` anyway
-	setAttachedDesignUrlInIssuePropertiesIfMissing = async (
+	setAttachedDesignInIssuePropertiesIfMissing = async (
 		issueIdOrKey: string,
-		design: AtlassianDesign,
+		designData: IssuePropertyInputDesignData,
 		connectInstallation: ConnectInstallation,
 	): Promise<void> =>
 		this.withErrorTranslation(async () => {
@@ -135,7 +137,7 @@ export class JiraDesignIssuePropertyService {
 				if (error instanceof NotFoundHttpClientError) {
 					const value =
 						JiraDesignIssuePropertyService.buildDesignUrlForIssueProperties(
-							design,
+							designData,
 						);
 
 					await jiraClient.setIssueProperty(
@@ -156,10 +158,10 @@ export class JiraDesignIssuePropertyService {
 	 *
 	 * @throws {ForbiddenByJiraServiceError} The app does not have permission to edit the Issue.
 	 */
-	updateAttachedDesignUrlV2IssueProperty = async (
+	updateAttachedDesignV2IssueProperty = async (
 		issueIdOrKey: string,
 		figmaDesignIdToReplace: FigmaDesignIdentifier,
-		design: AtlassianDesign,
+		designData: IssuePropertyInputDesignData,
 		connectInstallation: ConnectInstallation,
 	): Promise<void> =>
 		this.withErrorTranslation(async () => {
@@ -173,9 +175,9 @@ export class JiraDesignIssuePropertyService {
 
 			const newItem = {
 				url: JiraDesignIssuePropertyService.buildDesignUrlForIssueProperties(
-					design,
+					designData,
 				),
-				name: design.displayName,
+				name: designData.displayName,
 			};
 
 			const newValue =
@@ -198,7 +200,7 @@ export class JiraDesignIssuePropertyService {
 	 * @internal
 	 * Visible only for testing.
 	 */
-	deleteAttachedDesignUrlInIssuePropertiesIfPresent = async (
+	deleteAttachedDesignInIssuePropertiesIfPresent = async (
 		issueIdOrKey: string,
 		figmaDesignId: FigmaDesignIdentifier,
 		connectInstallation: ConnectInstallation,
@@ -235,7 +237,7 @@ export class JiraDesignIssuePropertyService {
 	 *
 	 * @throws {ForbiddenByJiraServiceError} The app does not have permission to edit the Issue.
 	 */
-	deleteFromAttachedDesignUrlV2IssueProperties = async (
+	deleteFromAttachedDesignV2IssueProperties = async (
 		issueIdOrKey: string,
 		figmaDesignId: FigmaDesignIdentifier,
 		connectInstallation: ConnectInstallation,
@@ -354,7 +356,7 @@ export class JiraDesignIssuePropertyService {
 	static buildDesignUrlForIssueProperties({
 		url,
 		displayName,
-	}: AtlassianDesign): string {
+	}: IssuePropertyInputDesignData): string {
 		// In addition to standard encoding, encodes the "-" character, which is treated by the "Jira" widget
 		// as space.
 		const encodedName = encodeURIComponent(displayName).replaceAll('-', '%2D');

--- a/src/infrastructure/jira/jira-design-issue-property-service.ts
+++ b/src/infrastructure/jira/jira-design-issue-property-service.ts
@@ -50,7 +50,7 @@ const ATTACHED_DESIGN_URL_V2_VALUE_SCHEMA: JSONSchemaTypeWithId<AttachedDesignUr
 export class JiraDesignIssuePropertyService {
 	trySaveDesignInIssueProperties = async (
 		issueIdOrKey: string,
-		figmaDesignIdToReplace: FigmaDesignIdentifier,
+		figmaDesignId: FigmaDesignIdentifier,
 		designData: IssuePropertyInputDesignData,
 		connectInstallation: ConnectInstallation,
 	): Promise<void> => {
@@ -63,7 +63,7 @@ export class JiraDesignIssuePropertyService {
 				),
 				this.updateAttachedDesignV2IssueProperty(
 					issueIdOrKey,
-					figmaDesignIdToReplace,
+					figmaDesignId,
 					designData,
 					connectInstallation,
 				),
@@ -160,7 +160,7 @@ export class JiraDesignIssuePropertyService {
 	 */
 	updateAttachedDesignV2IssueProperty = async (
 		issueIdOrKey: string,
-		figmaDesignIdToReplace: FigmaDesignIdentifier,
+		figmaDesignId: FigmaDesignIdentifier,
 		designData: IssuePropertyInputDesignData,
 		connectInstallation: ConnectInstallation,
 	): Promise<void> =>
@@ -182,7 +182,7 @@ export class JiraDesignIssuePropertyService {
 
 			const newValue =
 				storedValue?.filter(
-					(item) => !this.isUrlForDesign(item.url, figmaDesignIdToReplace),
+					(item) => !this.isUrlForDesign(item.url, figmaDesignId),
 				) || [];
 
 			newValue.push(newItem);

--- a/src/infrastructure/jira/jira-issue-service.test.ts
+++ b/src/infrastructure/jira/jira-issue-service.test.ts
@@ -1,4 +1,3 @@
-import { NotFoundInJiraServiceError } from './errors';
 import { jiraClient } from './jira-client';
 import { jiraService } from './jira-service';
 
@@ -28,16 +27,16 @@ describe('JiraIssueService', () => {
 			);
 		});
 
-		it('should throw `NotFoundInJiraServiceError` when issue is not found', async () => {
+		it('should return `null` when issue is not found', async () => {
 			const connectInstallation = generateConnectInstallation();
 			const issueKey = generateJiraIssueKey();
 			jest
 				.spyOn(jiraClient, 'getIssue')
 				.mockRejectedValue(new NotFoundHttpClientError());
 
-			await expect(() =>
-				jiraService.getIssue(issueKey, connectInstallation),
-			).rejects.toThrow(NotFoundInJiraServiceError);
+			const result = await jiraService.getIssue(issueKey, connectInstallation);
+
+			expect(result).toBeNull();
 		});
 	});
 });

--- a/src/infrastructure/jira/jira-issue-service.ts
+++ b/src/infrastructure/jira/jira-issue-service.ts
@@ -1,4 +1,3 @@
-import { NotFoundInJiraServiceError } from './errors';
 import { jiraClient } from './jira-client';
 
 import type { ConnectInstallation, JiraIssue } from '../../domain/entities';
@@ -6,18 +5,18 @@ import { NotFoundHttpClientError } from '../http-client-errors';
 
 export class JiraIssueService {
 	/**
-	 * @throws {NotFoundInJiraServiceError} Issue does not exist or the app does not have permission to read it.
+	 * Returns an Issue by the given ID or key.
+	 *
+	 * If the Issue does not exist or the app does not have does not have permission to read it, return `null`.
 	 */
 	getIssue = async (
 		issueIdOrKey: string,
 		connectInstallation: ConnectInstallation,
-	): Promise<JiraIssue> => {
+	): Promise<JiraIssue | null> => {
 		try {
 			return await jiraClient.getIssue(issueIdOrKey, connectInstallation);
 		} catch (error) {
-			if (error instanceof NotFoundHttpClientError) {
-				throw new NotFoundInJiraServiceError('Issue is not found.', error);
-			}
+			if (error instanceof NotFoundHttpClientError) return null;
 
 			throw error;
 		}

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -15,9 +15,6 @@ export class JiraService {
 	 */
 	submitDesigns = jiraDesignService.submitDesigns.bind(jiraDesignService);
 
-	/**
-	 * @throws {NotFoundInJiraServiceError} Issue does not exist or the app does not have permission to read it.
-	 */
 	getIssue = jiraIssueService.getIssue.bind(jiraIssueService);
 
 	setAppConfigurationState =

--- a/src/infrastructure/jira/jira-service.ts
+++ b/src/infrastructure/jira/jira-service.ts
@@ -30,13 +30,13 @@ export class JiraService {
 			jiraAppConfigurationService,
 		);
 
-	trySaveDesignUrlInIssueProperties =
-		jiraDesignIssuePropertyService.trySaveDesignUrlInIssueProperties.bind(
+	trySaveDesignInIssueProperties =
+		jiraDesignIssuePropertyService.trySaveDesignInIssueProperties.bind(
 			jiraDesignIssuePropertyService,
 		);
 
-	tryDeleteDesignUrlFromIssueProperties =
-		jiraDesignIssuePropertyService.tryDeleteDesignUrlFromIssueProperties.bind(
+	tryDeleteDesignFromIssueProperties =
+		jiraDesignIssuePropertyService.tryDeleteDesignFromIssueProperties.bind(
 			jiraDesignIssuePropertyService,
 		);
 


### PR DESCRIPTION
The PR includes the changes extracted from another working branch for reducing the scope of changes and code review convenience.

### Changes

- **refactor:** Improves the `JiraDesignIssuePropertyService` contract: 
  - Updates  API to accept the minimal required data (`url` and `displayName`) instead of the whole `AtlassianDesign`. This is required for the coming changes as a whole `AtlassianDesign` might not be available in all the use cases.
  - Improve naming of the methods to reflect better their responsibilities.
- **refactor:** Improves the `JiraIssueService` contract:
  - Returns `null` instead of throwing an exception when an Issue is not found. This forces service consumers to handle this common use case and is consistent with other services.