### PR TITLE
HL-812 Bump node Docker base image to 20.15.0-bookworm-slim for VULN-1313552

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.12.2-bookworm-slim@sha256:72f2f046a5f8468db28730b990b37de63ce93fd1a72a40f531d6aa82afdf0d46 as build
+FROM node:20.15.0-bookworm-slim@sha256:b5e567dc37677a1485cec21e2f0c0df517c7afe40c1ebc28248c41520c77b3d0 as build
 
 # Compile TS
 WORKDIR /app
@@ -10,7 +10,7 @@ RUN npm run db:generate
 COPY src ./src
 RUN npm run build
 
-FROM node:20.12.2-bookworm-slim@sha256:72f2f046a5f8468db28730b990b37de63ce93fd1a72a40f531d6aa82afdf0d46 as app
+FROM node:20.15.0-bookworm-slim@sha256:b5e567dc37677a1485cec21e2f0c0df517c7afe40c1ebc28248c41520c77b3d0 as app
 
 RUN apt-get update -y && apt-get install -y openssl
 


### PR DESCRIPTION
https://asecurityteam.atlassian.net/browse/VULN-1313552 

Vulnerability is due to the Docker base image used (node:20.12.2-bookworm-slim), which uses `debian/systemd 252.22-1~deb12u1` ([reference](https://hub.docker.com/layers/library/node/20.12.2-bookworm-slim/images/sha256-61117b8169f1efa1c1e91c1ed01e8bfcc3ba79ceaaff2cbfcfc370f21e39046f?context=explore))

![Screenshot 2024-07-24 at 10 10 32 AM](https://github.com/user-attachments/assets/8206f1c7-c1bc-4a53-a14c-2b1a45d43809)


We need to bump this Docker base image up to node:20.15.0-bookworm-slim, which is the closest version that uses `debian/systemd 252.26-1~deb12u2` ([reference](https://hub.docker.com/layers/library/node/20.15.0-bookworm-slim/images/sha256-d71e0d460434ef500c6d962bcdc6ebe717e5939025dd8aa9746dd76fa12ee6e3?context=explore)), which is enough to fix the VULN, as the VULN suggests:

> Typically updating "systemd" to version `"252.23-1~deb12u1"` or the latest safe version is enough to remediate the vulnerability.

![Screenshot 2024-07-24 at 12 35 38 PM](https://github.com/user-attachments/assets/e8722e39-0521-4328-be53-c7b9d9b185e0)