### PR TITLE
NONE: Fix submit design response schema validation

### DIFF
--- a/src/infrastructure/jira/jira-client/schemas.ts
+++ b/src/infrastructure/jira/jira-client/schemas.ts
@@ -19,9 +19,10 @@ import type {
 const DESIGN_KEY_SCHEMA: JSONSchemaType<DesignKey> = {
 	type: 'object',
 	properties: {
-		designId: { type: 'string' },
+		entityType: { type: 'string' },
+		entityId: { type: 'string' },
 	},
-	required: ['designId'],
+	required: ['entityId'],
 };
 
 const ASSOCIATION_SCHEMA: JSONSchemaType<Association> = {

--- a/src/infrastructure/jira/jira-client/testing/mocks.ts
+++ b/src/infrastructure/jira/jira-client/testing/mocks.ts
@@ -92,7 +92,10 @@ export const generateSubmitDesignsRequest = (
 export const generateSuccessfulSubmitDesignsResponse = (
 	designIds = [uuidv4()],
 ): SubmitDesignsResponse => ({
-	acceptedEntities: designIds.map((designId) => ({ designId })),
+	acceptedEntities: designIds.map((entityId) => ({
+		entityType: 'design',
+		entityId,
+	})),
 	rejectedEntities: [],
 });
 
@@ -100,8 +103,8 @@ export const generateFailedSubmitDesignsResponse = (
 	designIds = [uuidv4()],
 ): SubmitDesignsResponse => ({
 	acceptedEntities: [],
-	rejectedEntities: designIds.map((designId) => ({
-		key: { designId },
+	rejectedEntities: designIds.map((entityId) => ({
+		key: { entityId, entityType: 'design' },
 		errors: [{ message: 'Failure' }],
 	})),
 });

--- a/src/infrastructure/jira/jira-client/types.ts
+++ b/src/infrastructure/jira/jira-client/types.ts
@@ -36,7 +36,8 @@ export type SubmitDesignsRequest = {
 };
 
 export type DesignKey = {
-	readonly designId: string;
+	readonly entityType: string;
+	readonly entityId: string;
 };
 
 export type SubmitDesignsResponse = {

--- a/src/infrastructure/jira/jira-design-service.test.ts
+++ b/src/infrastructure/jira/jira-design-service.test.ts
@@ -113,7 +113,7 @@ describe('JiraDesignService', () => {
 				designs.map((design) => design.id),
 			);
 			const expectedError = JiraSubmitDesignServiceError.designRejected(
-				submitDesignsResponse.rejectedEntities[0].key.designId,
+				submitDesignsResponse.rejectedEntities[0].key.entityId,
 				submitDesignsResponse.rejectedEntities[0].errors,
 			);
 			jest

--- a/src/infrastructure/jira/jira-design-service.ts
+++ b/src/infrastructure/jira/jira-design-service.ts
@@ -60,7 +60,7 @@ export class JiraDesignService {
 	) => {
 		if (response.rejectedEntities.length) {
 			const { key, errors } = response.rejectedEntities[0];
-			throw JiraSubmitDesignServiceError.designRejected(key.designId, errors);
+			throw JiraSubmitDesignServiceError.designRejected(key.entityId, errors);
 		}
 
 		// TODO: Confirm whether we need to consider the use case below as a failure and throw or just leave a warning.


### PR DESCRIPTION
This PR fixes the 500s we're seeing when associating designs in Jira. It looks like the response we're getting back changed and as a result of us failing the schema validation, we were throwing 500s in the route.

This PR updates the response schema type to the new values we're seeing