### PR TITLE
NONE: Update the app key for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 APP_URL=
 # A unique key to identify the app.
 # Use the default value, which corresponds to the app key in Atlassian Marketplace, or a custom one (e.g., `com.figma.jira-add-on-jsmith`)
-# if you need to install a locally running app side by side with the one from Atlassian Marketplace.
+# if you want to install a locally running app side by side with the one from Atlassian Marketplace.
 # See for more detail: https://developer.atlassian.com/cloud/jira/platform/connect-app-descriptor/
 APP_KEY=com.figma.jira-add-on
 

--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,10 @@
 # 3. Use a created domain as APP_URL (e.g., https://foo-bar-baz.ngrok-free.app).
 APP_URL=
 # A unique key to identify the app.
+# Use the default value, which corresponds to the app key in Atlassian Marketplace, or a custom one (e.g., `com.figma.jira-add-on-jsmith`)
+# if you need to install a locally running app side by side with the one from Atlassian Marketplace.
 # See for more detail: https://developer.atlassian.com/cloud/jira/platform/connect-app-descriptor/
-APP_KEY=com.figma.jira-add-on-dev
+APP_KEY=com.figma.jira-add-on
 
 # A port the server should listen on.
 SERVER_PORT=3000

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,5 @@
 APP_URL=https://figma-for-jira.figma.com
-APP_KEY=com.figma.jira-add-on-dev-test
+APP_KEY=com.figma.jira-add-on
 
 SERVER_PORT=3000
 

--- a/scripts/start-sandbox.sh
+++ b/scripts/start-sandbox.sh
@@ -14,7 +14,7 @@ else
   COMPOSE_PROJECT=development
 fi
 
-docker-compose --project-name "$COMPOSE_PROJECT" --file "$COMPOSE_FILE" --env-file "$ENV_FILE" up --detach
+docker compose --project-name "$COMPOSE_PROJECT" --file "$COMPOSE_FILE" --env-file "$ENV_FILE" up --detach
 
 echo 'Waiting for Postgres...'
 until [ "$(docker inspect -f '{{.State.Health.Status}}' "$DB_CONTAINER_NAME")" == "healthy" ]; do

--- a/scripts/stop-sandbox.sh
+++ b/scripts/stop-sandbox.sh
@@ -13,4 +13,4 @@ else
 fi
 
 echo 'Stopping app sandbox'
-docker-compose --project-name "$COMPOSE_PROJECT" --file "$COMPOSE_FILE" --env-file="$ENV_FILE" down
+docker compose --project-name "$COMPOSE_PROJECT" --file "$COMPOSE_FILE" --env-file="$ENV_FILE" down


### PR DESCRIPTION
### Changes

- **chore:** Updates `.env.example` and `.env.test` with the app key matching the official version of the app in Atlassian Marketplace. While any app key can be used with no limitations fo development and testing, the usage of the official one will help to get the full integration experience (incl. some advance secondary features in Jira) during testing.
- **ci:** Resolves the issue with a [failing CI](https://github.com/atlassian-labs/figma-for-jira/actions/runs/10313859962/job/28551326902) due to external changes. Please, see for more detail: https://github.com/actions/runner-images/issues/10384.