### PR TITLE
NONE: handle when the issue has been deleted or the user is not able to view the issue

### DIFF
--- a/src/infrastructure/jira/errors.ts
+++ b/src/infrastructure/jira/errors.ts
@@ -1,3 +1,4 @@
 import { CauseAwareError } from '../../common/errors';
 
 export class ForbiddenByJiraServiceError extends CauseAwareError {}
+export class NotFoundByJiraServiceError extends CauseAwareError {}

--- a/src/infrastructure/jira/jira-design-issue-property-service.ts
+++ b/src/infrastructure/jira/jira-design-issue-property-service.ts
@@ -1,4 +1,7 @@
-import { ForbiddenByJiraServiceError } from './errors';
+import {
+	ForbiddenByJiraServiceError,
+	NotFoundByJiraServiceError,
+} from './errors';
 import type { GetIssuePropertyResponse } from './jira-client';
 import { jiraClient } from './jira-client';
 
@@ -74,6 +77,11 @@ export class JiraDesignIssuePropertyService {
 					'The app does not have permission to edit the Issue.',
 					error,
 				);
+			} else if (error instanceof NotFoundByJiraServiceError) {
+				return getLogger().warn(
+					'The Issue does not exist or the user does not have permission to view the Issue.',
+					error,
+				);
 			}
 
 			throw error;
@@ -104,6 +112,11 @@ export class JiraDesignIssuePropertyService {
 					'The app does not have permission to edit the Issue.',
 					error,
 				);
+			} else if (error instanceof NotFoundByJiraServiceError) {
+				return getLogger().warn(
+					'The Issue does not exist or the user does not have permission to view the Issue.',
+					error,
+				);
 			}
 
 			throw error;
@@ -115,6 +128,7 @@ export class JiraDesignIssuePropertyService {
 	 * Visible only for testing.
 	 *
 	 * @throws {ForbiddenByJiraServiceError} The app does not have permission to edit the Issue.
+	 * @throws {NotFoundByJiraServiceError} The Issue does not exist or the user does not have permission to view the Issue.
 	 */
 	// TODO: Consider removing this method after deprecating the previous version of
 	//  "Figma for Jira" (which is included in this app as the fallback).
@@ -157,6 +171,7 @@ export class JiraDesignIssuePropertyService {
 	 * Visible only for testing.
 	 *
 	 * @throws {ForbiddenByJiraServiceError} The app does not have permission to edit the Issue.
+	 * @throws {NotFoundByJiraServiceError} The Issue does not exist or the user does not have permission to view the Issue.
 	 */
 	updateAttachedDesignV2IssueProperty = async (
 		issueIdOrKey: string,
@@ -236,6 +251,7 @@ export class JiraDesignIssuePropertyService {
 	 * Only visible for testing.
 	 *
 	 * @throws {ForbiddenByJiraServiceError} The app does not have permission to edit the Issue.
+	 * @throws {NotFoundByJiraServiceError} The Issue does not exist or the user does not have permission to view the Issue.
 	 */
 	deleteFromAttachedDesignV2IssueProperties = async (
 		issueIdOrKey: string,
@@ -326,6 +342,7 @@ export class JiraDesignIssuePropertyService {
 
 	/**
 	 * @throws {ForbiddenByJiraServiceError} Forbidden to perform this operation in Jira.
+	 * @throws {NotFoundByJiraServiceError} Not found or the user does not have permission to view the resource.
 	 */
 	private withErrorTranslation = async <T>(fn: () => Promise<T>) => {
 		try {
@@ -334,6 +351,11 @@ export class JiraDesignIssuePropertyService {
 			if (e instanceof ForbiddenHttpClientError) {
 				throw new ForbiddenByJiraServiceError(
 					'Forbidden to perform the operation.',
+					e,
+				);
+			} else if (e instanceof NotFoundHttpClientError) {
+				throw new NotFoundByJiraServiceError(
+					'Not found or the user does not have permission to view the resource.',
 					e,
 				);
 			}


### PR DESCRIPTION
We're currently 500ing in `PUT /entities/onEntityAssociated` when `jiraClient.setIssueProperty` 404s (eg. the issue was deleted or the user doesn't have the permission to view the issue)

I believe in this case it's ok to no-op on these calls similar to when we get a 403

## Test Plan
- unit and integration tests pass