### PR TITLE
NONE: fix processing large file jsons from get file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"pino": "^8.15.0",
 				"pino-http": "^8.4.0",
 				"prisma": "^5.1.1",
+				"stream-json": "^1.8.0",
 				"tslib": "^2.6.1",
 				"uuid": "^9.0.0"
 			},
@@ -29,6 +30,7 @@
 				"@types/express": "^4.17.16",
 				"@types/jest": "^29.5.3",
 				"@types/node": "^20.14.12",
+				"@types/stream-json": "^1.7.7",
 				"@types/supertest": "^2.0.12",
 				"@types/uuid": "^9.0.2",
 				"@typescript-eslint/eslint-plugin": "^6.4.0",
@@ -2872,6 +2874,25 @@
 			"version": "2.0.1",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/stream-chain": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/stream-chain/-/stream-chain-2.1.0.tgz",
+			"integrity": "sha512-guDyAl6s/CAzXUOWpGK2bHvdiopLIwpGu8v10+lb9hnQOyo4oj/ZUQFOvqFjKGsE3wJP1fpIesCcMvbXuWsqOg==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/stream-json": {
+			"version": "1.7.7",
+			"resolved": "https://registry.npmjs.org/@types/stream-json/-/stream-json-1.7.7.tgz",
+			"integrity": "sha512-hHG7cLQ09H/m9i0jzL6UJAeLLxIWej90ECn0svO4T8J0nGcl89xZDQ2ujT4WKlvg0GWkcxJbjIDzW/v7BYUM6Q==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*",
+				"@types/stream-chain": "*"
+			}
 		},
 		"node_modules/@types/strip-bom": {
 			"version": "3.0.0",
@@ -8765,6 +8786,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/stream-chain": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+			"integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA=="
+		},
+		"node_modules/stream-json": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.8.0.tgz",
+			"integrity": "sha512-HZfXngYHUAr1exT4fxlbc1IOce1RYxp2ldeaf97LYCOPSoOqY/1Psp7iGvpb+6JIOgkra9zDYnPX01hGAHzEPw==",
+			"dependencies": {
+				"stream-chain": "^2.2.5"
 			}
 		},
 		"node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"pino": "^8.15.0",
 		"pino-http": "^8.4.0",
 		"prisma": "^5.1.1",
+		"stream-json": "^1.8.0",
 		"tslib": "^2.6.1",
 		"uuid": "^9.0.0"
 	},
@@ -50,6 +51,7 @@
 		"@types/express": "^4.17.16",
 		"@types/jest": "^29.5.3",
 		"@types/node": "^20.14.12",
+		"@types/stream-json": "^1.7.7",
 		"@types/supertest": "^2.0.12",
 		"@types/uuid": "^9.0.2",
 		"@typescript-eslint/eslint-plugin": "^6.4.0",

--- a/src/infrastructure/figma/figma-client/figma-client.ts
+++ b/src/infrastructure/figma/figma-client/figma-client.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
-import { parser } from 'stream-json';
-import { streamValues } from 'stream-json/streamers/StreamValues';
+import { withParser } from 'stream-json/streamers/StreamValues';
 
 import type { Stream } from 'stream';
 
@@ -197,14 +196,11 @@ export class FigmaClient {
 			});
 
 			const fileJson = await new Promise((resolve, reject) => {
-				const result = {};
+				let result: unknown = {};
 				(response.data as Stream)
-					.pipe(parser())
-					.pipe(streamValues())
+					.pipe(withParser())
 					.on('data', ({ value }) => {
-						// Assuming the JSON is an object at the root level
-						// Merge each object into the result
-						Object.assign(result, value);
+						result = value;
 					})
 					.on('end', () => {
 						resolve(result);


### PR DESCRIPTION
We were running into `Cannot create a string longer than 0x1fffffe8 characters` errors that we were able to pinpoint to the `response.data` call when calling get file.

This is because the JSON string that gets returned from Figma can be over 512 MB in length. So instead of treating it as a single string, this PR updates that logic so we stream in and build up the JSON object for the file.

## Test Plan
- Create a very large file in Figma
- Try to attach the file to an issue
- Previously see that that it throws the error above
- With the changes, see that it's able to successfully parse the file json
- Assert that existing tests pass