### PR TITLE
HL-1722 Update mutation APIs to receive userId in body

### DIFF
--- a/src/web/routes/entities-v2/entities-router.ts
+++ b/src/web/routes/entities-v2/entities-router.ts
@@ -44,7 +44,7 @@ entitiesRouterV2.post(
 		next: NextFunction,
 	) => {
 		const { connectInstallation } = res.locals;
-		const atlassianUserId = req.query.userId;
+		const atlassianUserId = req.body.user.id;
 
 		const designUrl = tryParseUrl(req.body.entity.url);
 
@@ -97,7 +97,7 @@ entitiesRouterV2.put(
 		next: NextFunction,
 	) => {
 		const { connectInstallation } = res.locals;
-		const atlassianUserId = req.query.userId;
+		const atlassianUserId = req.body.user.id;
 
 		onDesignAssociatedWithIssueUseCaseParams
 			.execute({
@@ -123,7 +123,7 @@ entitiesRouterV2.put(
 		next: NextFunction,
 	) => {
 		const { connectInstallation } = res.locals;
-		const atlassianUserId = req.query.userId;
+		const atlassianUserId = req.body.user.id;
 
 		onDesignDisassociatedFromIssueUseCase
 			.execute({

--- a/src/web/routes/entities-v2/integration.test.ts
+++ b/src/web/routes/entities-v2/integration.test.ts
@@ -127,17 +127,16 @@ describe('/entities', () => {
 
 			return request(app)
 				.post('/entities/getEntityByUrl')
-				.query({ userId: atlassianUserId })
 				.send(
 					generateGetEntityByUrlRequestBody({
 						url: inputFigmaFileUrl.toString(),
+						userId: atlassianUserId,
 					}),
 				)
 				.set(
 					'Authorization',
 					generateGetEntityByUrlAuthorisationHeader({
 						connectInstallation,
-						userId: atlassianUserId,
 					}),
 				)
 				.set('Content-Type', 'application/json')
@@ -192,17 +191,16 @@ describe('/entities', () => {
 
 			return request(app)
 				.post('/entities/getEntityByUrl')
-				.query({ userId: atlassianUserId })
 				.send(
 					generateGetEntityByUrlRequestBody({
 						url: inputFigmaFileNodeUrl.toString(),
+						userId: atlassianUserId,
 					}),
 				)
 				.set(
 					'Authorization',
 					generateGetEntityByUrlAuthorisationHeader({
 						connectInstallation,
-						userId: atlassianUserId,
 					}),
 				)
 				.set('Content-Type', 'application/json')
@@ -210,7 +208,7 @@ describe('/entities', () => {
 				.expect(expectedDesign);
 		});
 
-		it('should respond with `HTTP 400` when `userId` query parameter is not given', async () => {
+		it('should respond with `HTTP 400` when `user` parameter is not given', async () => {
 			const connectInstallation = await connectInstallationRepository.upsert(
 				generateConnectInstallationCreateParams(),
 			);
@@ -224,7 +222,11 @@ describe('/entities', () => {
 
 			return request(app)
 				.post('/entities/getEntityByUrl')
-				.send(generateGetEntityByUrlRequestBody())
+				.send({
+					entity: {
+						url: generateFigmaDesignUrl().toString(),
+					},
+				})
 				.set('Authorization', `JWT ${jwt}`)
 				.set('Content-Type', 'application/json')
 				.expect(HttpStatusCode.BadRequest);
@@ -234,6 +236,7 @@ describe('/entities', () => {
 			const connectInstallation = await connectInstallationRepository.upsert(
 				generateConnectInstallationCreateParams(),
 			);
+			const atlassianUserId = uuidv4();
 			const jwt = generateJiraServerSymmetricJwtToken({
 				request: {
 					method: 'POST',
@@ -247,6 +250,7 @@ describe('/entities', () => {
 				.send(
 					generateGetEntityByUrlRequestBody({
 						url: 'http://figma.com/invalid',
+						userId: atlassianUserId,
 					}),
 				)
 				.set('Authorization', `JWT ${jwt}`)
@@ -255,9 +259,11 @@ describe('/entities', () => {
 		});
 
 		it('should respond with `HTTP 401` when given JWT token is not valid', async () => {
+			const atlassianUserId = uuidv4();
+
 			return request(app)
 				.post('/entities/getEntityByUrl')
-				.send(generateGetEntityByUrlRequestBody())
+				.send(generateGetEntityByUrlRequestBody({ userId: atlassianUserId }))
 				.set('Authorization', `JWT INVALID_TOKEN`)
 				.set('Content-Type', 'application/json')
 				.expect(HttpStatusCode.Unauthorized);
@@ -271,13 +277,11 @@ describe('/entities', () => {
 
 			return request(app)
 				.post('/entities/getEntityByUrl')
-				.query({ userId: atlassianUserId })
-				.send(generateGetEntityByUrlRequestBody())
+				.send(generateGetEntityByUrlRequestBody({ userId: atlassianUserId }))
 				.set(
 					'Authorization',
 					generateGetEntityByUrlAuthorisationHeader({
 						connectInstallation,
-						userId: atlassianUserId,
 					}),
 				)
 				.set('Content-Type', 'application/json')
@@ -310,17 +314,16 @@ describe('/entities', () => {
 
 			await request(app)
 				.post('/entities/getEntityByUrl')
-				.query({ userId: atlassianUserId })
 				.send(
 					generateGetEntityByUrlRequestBody({
 						url: inputFigmaUrl.toString(),
+						userId: atlassianUserId,
 					}),
 				)
 				.set(
 					'Authorization',
 					generateGetEntityByUrlAuthorisationHeader({
 						connectInstallation,
-						userId: atlassianUserId,
 					}),
 				)
 				.set('Content-Type', 'application/json')
@@ -368,17 +371,16 @@ describe('/entities', () => {
 
 				await request(app)
 					.post('/entities/getEntityByUrl')
-					.query({ userId: atlassianUserId })
 					.send(
 						generateGetEntityByUrlRequestBody({
 							url: inputFigmaDesignUrl.toString(),
+							userId: atlassianUserId,
 						}),
 					)
 					.set(
 						'Authorization',
 						generateGetEntityByUrlAuthorisationHeader({
 							connectInstallation,
-							userId: atlassianUserId,
 						}),
 					)
 					.set('Content-Type', 'application/json')
@@ -418,17 +420,16 @@ describe('/entities', () => {
 
 				await request(app)
 					.post('/entities/getEntityByUrl')
-					.query({ userId: atlassianUserId })
 					.send(
 						generateGetEntityByUrlRequestBody({
 							url: inputFigmaUrl.toString(),
+							userId: atlassianUserId,
 						}),
 					)
 					.set(
 						'Authorization',
 						generateGetEntityByUrlAuthorisationHeader({
 							connectInstallation,
-							userId: atlassianUserId,
 						}),
 					)
 					.set('Content-Type', 'application/json')
@@ -519,19 +520,18 @@ describe('/entities', () => {
 
 			await request(app)
 				.put('/entities/onEntityAssociated')
-				.query({ userId: atlassianUserId })
 				.send(
 					generateOnEntityAssociatedRequestBody({
 						issueId: issue.id,
 						issueAri,
 						entityId: figmaDesignId.toAtlassianDesignId(),
+						userId: atlassianUserId,
 					}),
 				)
 				.set(
 					'Authorization',
 					generateOnEntityAssociatedAuthorisationHeader({
 						connectInstallation,
-						userId: atlassianUserId,
 					}),
 				)
 				.set('Content-Type', 'application/json')
@@ -615,19 +615,18 @@ describe('/entities', () => {
 
 			await request(app)
 				.put('/entities/onEntityAssociated')
-				.query({ userId: atlassianUserId })
 				.send(
 					generateOnEntityAssociatedRequestBody({
 						issueId,
 						issueAri,
 						entityId: figmaDesignId.toAtlassianDesignId(),
+						userId: atlassianUserId,
 					}),
 				)
 				.set(
 					'Authorization',
 					generateOnEntityAssociatedAuthorisationHeader({
 						connectInstallation,
-						userId: atlassianUserId,
 					}),
 				)
 				.set('Content-Type', 'application/json')
@@ -641,7 +640,7 @@ describe('/entities', () => {
 			});
 		});
 
-		it('should skip creating Figma Dev Resource when `user` query parameter is not given', async () => {
+		it('should skip creating Figma Dev Resource when `user` parameter is not given', async () => {
 			const connectInstallation = await connectInstallationRepository.upsert(
 				generateConnectInstallationCreateParams(),
 			);
@@ -961,19 +960,18 @@ describe('/entities', () => {
 
 			await request(app)
 				.put('/entities/onEntityAssociated')
-				.query({ userId: atlassianUserId })
 				.send(
 					generateOnEntityAssociatedRequestBody({
 						issueId: issue.id,
 						issueAri,
 						entityId: figmaDesignId.toAtlassianDesignId(),
+						userId: atlassianUserId,
 					}),
 				)
 				.set(
 					'Authorization',
 					generateOnEntityAssociatedAuthorisationHeader({
 						connectInstallation,
-						userId: atlassianUserId,
 					}),
 				)
 				.set('Content-Type', 'application/json')
@@ -1077,19 +1075,18 @@ describe('/entities', () => {
 
 			await request(app)
 				.put('/entities/onEntityAssociated')
-				.query({ userId: atlassianUserId })
 				.send(
 					generateOnEntityAssociatedRequestBody({
 						issueId: issue.id,
 						issueAri,
 						entityId: figmaDesignId.toAtlassianDesignId(),
+						userId: atlassianUserId,
 					}),
 				)
 				.set(
 					'Authorization',
 					generateOnEntityAssociatedAuthorisationHeader({
 						connectInstallation,
-						userId: atlassianUserId,
 					}),
 				)
 				.set('Content-Type', 'application/json')
@@ -1107,17 +1104,16 @@ describe('/entities', () => {
 
 			await request(app)
 				.put('/entities/onEntityAssociated')
-				.query({ userId: atlassianUserId })
 				.send(
 					generateOnEntityAssociatedRequestBody({
 						entityId: '',
+						userId: atlassianUserId,
 					}),
 				)
 				.set(
 					'Authorization',
 					generateOnEntityAssociatedAuthorisationHeader({
 						connectInstallation,
-						userId: atlassianUserId,
 					}),
 				)
 				.set('Content-Type', 'application/json')
@@ -1214,19 +1210,18 @@ describe('/entities', () => {
 
 			await request(app)
 				.put('/entities/onEntityDisassociated')
-				.query({ userId: atlassianUserId })
 				.send(
 					generateOnEntityDisassociatedRequestBody({
 						issueId: issue.id,
 						issueAri,
 						entityId: figmaDesignId.toAtlassianDesignId(),
+						userId: atlassianUserId,
 					}),
 				)
 				.set(
 					'Authorization',
 					generateOnEntityDisassociatedAuthorisationHeader({
 						connectInstallation,
-						userId: atlassianUserId,
 					}),
 				)
 				.set('Content-Type', 'application/json')
@@ -1298,19 +1293,18 @@ describe('/entities', () => {
 
 			await request(app)
 				.put('/entities/onEntityDisassociated')
-				.query({ userId: atlassianUserId })
 				.send(
 					generateOnEntityDisassociatedRequestBody({
 						issueId,
 						issueAri,
 						entityId: figmaDesignId.toAtlassianDesignId(),
+						userId: atlassianUserId,
 					}),
 				)
 				.set(
 					'Authorization',
 					generateOnEntityDisassociatedAuthorisationHeader({
 						connectInstallation,
-						userId: atlassianUserId,
 					}),
 				)
 				.set('Content-Type', 'application/json')
@@ -1320,7 +1314,7 @@ describe('/entities', () => {
 			);
 		});
 
-		it('should skip creating Figma Dev Resource when `user` query parameter is not given', async () => {
+		it('should skip creating Figma Dev Resource when `user` parameter is not given', async () => {
 			const connectInstallation = await connectInstallationRepository.upsert(
 				generateConnectInstallationCreateParams(),
 			);
@@ -1484,19 +1478,18 @@ describe('/entities', () => {
 
 			await request(app)
 				.put('/entities/onEntityDisassociated')
-				.query({ userId: atlassianUserId })
 				.send(
 					generateOnEntityDisassociatedRequestBody({
 						issueId: issue.id,
 						issueAri,
 						entityId: figmaDesignId.toAtlassianDesignId(),
+						userId: atlassianUserId,
 					}),
 				)
 				.set(
 					'Authorization',
 					generateOnEntityDisassociatedAuthorisationHeader({
 						connectInstallation,
-						userId: atlassianUserId,
 					}),
 				)
 				.set('Content-Type', 'application/json')
@@ -1588,19 +1581,18 @@ describe('/entities', () => {
 
 			await request(app)
 				.put('/entities/onEntityDisassociated')
-				.query({ userId: atlassianUserId })
 				.send(
 					generateOnEntityDisassociatedRequestBody({
 						issueId: issue.id,
 						issueAri,
 						entityId: figmaDesignId.toAtlassianDesignId(),
+						userId: atlassianUserId,
 					}),
 				)
 				.set(
 					'Authorization',
 					generateOnEntityDisassociatedAuthorisationHeader({
 						connectInstallation,
-						userId: atlassianUserId,
 					}),
 				)
 				.set('Content-Type', 'application/json')
@@ -1691,19 +1683,18 @@ describe('/entities', () => {
 
 			await request(app)
 				.put('/entities/onEntityDisassociated')
-				.query({ userId: atlassianUserId })
 				.send(
 					generateOnEntityDisassociatedRequestBody({
 						issueId: issue.id,
 						issueAri,
 						entityId: figmaDesignId.toAtlassianDesignId(),
+						userId: atlassianUserId,
 					}),
 				)
 				.set(
 					'Authorization',
 					generateOnEntityDisassociatedAuthorisationHeader({
 						connectInstallation,
-						userId: atlassianUserId,
 					}),
 				)
 				.set('Content-Type', 'application/json')
@@ -1756,19 +1747,18 @@ describe('/entities', () => {
 
 			await request(app)
 				.put('/entities/onEntityDisassociated')
-				.query({ userId: atlassianUserId })
 				.send(
 					generateOnEntityDisassociatedRequestBody({
 						issueId: issue.id,
 						issueAri,
 						entityId: figmaDesignId.toAtlassianDesignId(),
+						userId: atlassianUserId,
 					}),
 				)
 				.set(
 					'Authorization',
 					generateOnEntityDisassociatedAuthorisationHeader({
 						connectInstallation,
-						userId: atlassianUserId,
 					}),
 				)
 				.set('Content-Type', 'application/json')
@@ -1783,17 +1773,16 @@ describe('/entities', () => {
 
 			await request(app)
 				.put('/entities/onEntityDisassociated')
-				.query({ userId: atlassianUserId })
 				.send(
 					generateOnEntityDisassociatedRequestBody({
 						entityId: '',
+						userId: atlassianUserId,
 					}),
 				)
 				.set(
 					'Authorization',
 					generateOnEntityDisassociatedAuthorisationHeader({
 						connectInstallation,
-						userId: atlassianUserId,
 					}),
 				)
 				.set('Content-Type', 'application/json')

--- a/src/web/routes/entities-v2/schemas.ts
+++ b/src/web/routes/entities-v2/schemas.ts
@@ -22,15 +22,15 @@ export const GET_ENTITY_BY_URL_REQUEST_SCHEMA: JSONSchemaTypeWithId<{
 					},
 					required: ['url'],
 				},
+				user: {
+					type: 'object',
+					properties: {
+						id: { type: 'string' },
+					},
+					required: ['id'],
+				},
 			},
-			required: ['entity'],
-		},
-		query: {
-			type: 'object',
-			properties: {
-				userId: { type: 'string' },
-			},
-			required: ['userId'],
+			required: ['entity', 'user'],
 		},
 	},
 	required: ['body'],
@@ -63,14 +63,14 @@ export const ON_ENTITY_ASSOCIATED_REQUEST_SCHEMA: JSONSchemaTypeWithId<{
 					},
 					required: ['ati', 'ari', 'cloudId', 'id'],
 				},
+				user: {
+					type: 'object',
+					properties: {
+						id: { type: 'string', nullable: true },
+					},
+				},
 			},
-			required: ['entity', 'associatedWith'],
-		},
-		query: {
-			type: 'object',
-			properties: {
-				userId: { type: 'string' },
-			},
+			required: ['entity', 'associatedWith', 'user'],
 		},
 	},
 	required: ['body'],
@@ -103,14 +103,14 @@ export const ON_ENTITY_DISASSOCIATED_REQUEST_SCHEMA: JSONSchemaTypeWithId<{
 					},
 					required: ['ati', 'ari', 'cloudId', 'id'],
 				},
+				user: {
+					type: 'object',
+					properties: {
+						id: { type: 'string', nullable: true },
+					},
+				},
 			},
-			required: ['entity', 'disassociatedFrom'],
-		},
-		query: {
-			type: 'object',
-			properties: {
-				userId: { type: 'string' },
-			},
+			required: ['entity', 'disassociatedFrom', 'user'],
 		},
 	},
 	required: ['body'],

--- a/src/web/routes/entities-v2/testing/mocks.ts
+++ b/src/web/routes/entities-v2/testing/mocks.ts
@@ -16,16 +16,13 @@ import type {
 
 export const generateGetEntityByUrlAuthorisationHeader = ({
 	connectInstallation,
-	userId,
 }: {
 	readonly connectInstallation: ConnectInstallation;
-	readonly userId: string;
 }): string => {
 	const jwt = generateJiraServerSymmetricJwtToken({
 		request: {
 			method: 'POST',
 			pathname: '/entities/getEntityByUrl',
-			query: { userId },
 		},
 		connectInstallation,
 	});
@@ -35,26 +32,28 @@ export const generateGetEntityByUrlAuthorisationHeader = ({
 
 export const generateGetEntityByUrlRequestBody = ({
 	url = generateFigmaDesignUrl().toString(),
+	userId,
 }: {
 	readonly url?: string;
-} = {}): GetEntityByUrlRequestBody => ({
+	readonly userId: string;
+}): GetEntityByUrlRequestBody => ({
 	entity: {
 		url,
+	},
+	user: {
+		id: userId,
 	},
 });
 
 export const generateOnEntityAssociatedAuthorisationHeader = ({
 	connectInstallation,
-	userId,
 }: {
 	readonly connectInstallation: ConnectInstallation;
-	readonly userId?: string;
 }): string => {
 	return generateJiraServerSymmetricJwtToken({
 		request: {
 			method: 'PUT',
 			pathname: '/entities/onEntityAssociated',
-			query: userId ? { userId } : undefined,
 		},
 		connectInstallation,
 	});
@@ -64,10 +63,12 @@ export const generateOnEntityAssociatedRequestBody = ({
 	entityId = generateFigmaDesignIdentifier().toAtlassianDesignId(),
 	issueId = generateJiraIssueId(),
 	issueAri = generateJiraIssueAri({ issueId }),
+	userId,
 }: {
 	readonly entityId?: string;
 	readonly issueId?: string;
 	readonly issueAri?: string;
+	readonly userId?: string;
 } = {}): OnEntityAssociatedRequestBody => ({
 	entity: {
 		ari: 'NOT_USED',
@@ -79,20 +80,20 @@ export const generateOnEntityAssociatedRequestBody = ({
 		cloudId: uuidv4(),
 		id: issueId,
 	},
+	user: {
+		id: userId,
+	},
 });
 
 export const generateOnEntityDisassociatedAuthorisationHeader = ({
 	connectInstallation,
-	userId,
 }: {
 	readonly connectInstallation: ConnectInstallation;
-	readonly userId?: string;
 }): string => {
 	return generateJiraServerSymmetricJwtToken({
 		request: {
 			method: 'PUT',
 			pathname: '/entities/onEntityDisassociated',
-			query: userId ? { userId } : undefined,
 		},
 		connectInstallation,
 	});
@@ -102,10 +103,12 @@ export const generateOnEntityDisassociatedRequestBody = ({
 	entityId = generateFigmaDesignIdentifier().toAtlassianDesignId(),
 	issueId = generateJiraIssueId(),
 	issueAri = generateJiraIssueAri({ issueId }),
+	userId,
 }: {
 	readonly entityId?: string;
 	readonly issueId?: string;
 	readonly issueAri?: string;
+	readonly userId?: string;
 } = {}): OnEntityDisassociatedRequestBody => ({
 	entity: {
 		ari: 'NOT_USED',
@@ -116,5 +119,8 @@ export const generateOnEntityDisassociatedRequestBody = ({
 		ari: issueAri,
 		cloudId: uuidv4(),
 		id: issueId,
+	},
+	user: {
+		id: userId,
 	},
 });

--- a/src/web/routes/entities-v2/types.ts
+++ b/src/web/routes/entities-v2/types.ts
@@ -11,13 +11,14 @@ export type EntitiesRequestLocals = {
 
 /*
  * The contract of the `getEntityByUrl` action.
- * See https://developer.atlassian.com/cloud/devops-provider-actions/specifications/current/#get-entity-by-url
+ * See https://developer.atlassian.com/cloud/devops-provider-actions/specification_v2/get-entity-by-url/
  */
-export type GetEntityByUrlRequestQueryParameters = { readonly userId: string };
-
 export type GetEntityByUrlRequestBody = {
 	readonly entity: {
 		readonly url: string;
+	};
+	readonly user: {
+		readonly id: string;
 	};
 };
 
@@ -27,7 +28,7 @@ export type GetEntityByUrlRequest = Request<
 	Record<string, never>,
 	GetEntityByUrlRequestResponseBody,
 	GetEntityByUrlRequestBody,
-	GetEntityByUrlRequestQueryParameters,
+	Record<string, never>,
 	EntitiesRequestLocals
 >;
 
@@ -38,12 +39,8 @@ export type GetEntityByUrlResponse = Response<
 
 /*
  * The contract of the `onEntityAssociated` action.
- * See https://developer.atlassian.com/cloud/devops-provider-actions/specifications/current/#on-entity-associated
+ * See https://developer.atlassian.com/cloud/devops-provider-actions/specification_v2/on-entity-associated/
  */
-export type OnEntityAssociatedRequestQueryParameters = {
-	readonly userId?: string;
-};
-
 export type OnEntityAssociatedRequestBody = {
 	readonly entity: {
 		readonly ari: string;
@@ -55,13 +52,16 @@ export type OnEntityAssociatedRequestBody = {
 		readonly cloudId: string;
 		readonly id: string;
 	};
+	readonly user: {
+		readonly id?: string;
+	};
 };
 
 export type OnEntityAssociatedRequest = Request<
 	Record<string, never>,
 	void,
 	OnEntityAssociatedRequestBody,
-	OnEntityAssociatedRequestQueryParameters,
+	Record<string, never>,
 	EntitiesRequestLocals
 >;
 
@@ -69,12 +69,8 @@ export type OnEntityAssociatedResponse = Response<void, EntitiesRequestLocals>;
 
 /*
  * The contract of the `onEntityDisassociated` action.
- * See https://developer.atlassian.com/cloud/devops-provider-actions/specifications/current/#on-entity-disassociated
+ * See https://developer.atlassian.com/cloud/devops-provider-actions/specification_v2/on-entity-disassociated/
  */
-export type OnEntityDisassociatedRequestQueryParameters = {
-	readonly userId?: string;
-};
-
 export type OnEntityDisassociatedRequestBody = {
 	readonly entity: {
 		readonly ari: string;
@@ -86,13 +82,16 @@ export type OnEntityDisassociatedRequestBody = {
 		readonly cloudId: string;
 		readonly id: string;
 	};
+	readonly user: {
+		readonly id?: string;
+	};
 };
 
 export type OnEntityDisassociatedRequest = Request<
 	Record<string, never>,
 	void,
 	OnEntityDisassociatedRequestBody,
-	OnEntityDisassociatedRequestQueryParameters,
+	Record<string, never>,
 	EntitiesRequestLocals
 >;
 


### PR DESCRIPTION
We are updating POST and PUT APIs to receive all input params in the request body instead of some as the query params. This involves moving the `userId` query param to the body for the following API endpoints:
* getEntityByUrl
* onEntityAssociated
* onEntityDisassociated

This is being done for compatibility reasons on the Atlassian platform which has already been updated to send these values in the body (it is currently sending both query and body params with the query to be removed at a later date).