### PR TITLE
NONE: Figma OAuth updates

### DIFF
--- a/src/infrastructure/figma/figma-client/figma-client.ts
+++ b/src/infrastructure/figma/figma-client/figma-client.ts
@@ -78,11 +78,15 @@ export class FigmaClient {
 				'/api/oauth/token',
 				getConfig().figma.oauth2.authorizationServerBaseUrl,
 			);
-			url.searchParams.append('client_id', getConfig().figma.oauth2.clientId);
-			url.searchParams.append(
-				'client_secret',
-				getConfig().figma.oauth2.clientSecret,
-			);
+
+			const basicAuthHeader =
+				'Basic ' +
+				btoa(
+					`${getConfig().figma.oauth2.clientId}:${
+						getConfig().figma.oauth2.clientSecret
+					}`,
+				);
+
 			url.searchParams.append(
 				'redirect_uri',
 				`${getConfig().app.baseUrl}/figma/oauth/callback`,
@@ -90,7 +94,12 @@ export class FigmaClient {
 			url.searchParams.append('code', code);
 			url.searchParams.append('grant_type', 'authorization_code');
 
-			const response = await axios.post<unknown>(url.toString());
+			const response = await axios.post<unknown>(url.toString(), null, {
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+					Authorization: basicAuthHeader,
+				},
+			});
 
 			assertSchema(response.data, GET_OAUTH2_TOKEN_RESPONSE_SCHEMA);
 
@@ -112,14 +121,22 @@ export class FigmaClient {
 				'/api/oauth/refresh',
 				getConfig().figma.oauth2.authorizationServerBaseUrl,
 			);
-			url.searchParams.append('client_id', getConfig().figma.oauth2.clientId);
-			url.searchParams.append(
-				'client_secret',
-				getConfig().figma.oauth2.clientSecret,
-			);
+			const basicAuthHeader =
+				'Basic ' +
+				btoa(
+					`${getConfig().figma.oauth2.clientId}:${
+						getConfig().figma.oauth2.clientSecret
+					}`,
+				);
+
 			url.searchParams.append('refresh_token', refreshToken);
 
-			const response = await axios.post<unknown>(url.toString());
+			const response = await axios.post<unknown>(url.toString(), null, {
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+					Authorization: basicAuthHeader,
+				},
+			});
 
 			assertSchema(response.data, REFRESH_OAUTH2_TOKEN_RESPONSE_SCHEMA);
 

--- a/src/infrastructure/figma/figma-client/figma-client.ts
+++ b/src/infrastructure/figma/figma-client/figma-client.ts
@@ -74,10 +74,7 @@ export class FigmaClient {
 	 */
 	getOAuth2Token = async (code: string): Promise<GetOAuth2TokenResponse> =>
 		withAxiosErrorTranslation(async () => {
-			const url = new URL(
-				'/api/oauth/token',
-				getConfig().figma.oauth2.authorizationServerBaseUrl,
-			);
+			const url = new URL('/v1/oauth/token', getConfig().figma.apiBaseUrl);
 
 			const basicAuthHeader =
 				'Basic ' +
@@ -117,10 +114,7 @@ export class FigmaClient {
 		refreshToken: string,
 	): Promise<RefreshOAuth2TokenResponse> =>
 		withAxiosErrorTranslation(async () => {
-			const url = new URL(
-				'/api/oauth/refresh',
-				getConfig().figma.oauth2.authorizationServerBaseUrl,
-			);
+			const url = new URL('/v1/oauth/refresh', getConfig().figma.apiBaseUrl);
 			const basicAuthHeader =
 				'Basic ' +
 				btoa(

--- a/src/infrastructure/figma/figma-client/testing/mocks.ts
+++ b/src/infrastructure/figma/figma-client/testing/mocks.ts
@@ -78,28 +78,25 @@ export const generateRefreshOAuth2TokenResponse = ({
 });
 
 export const generateGetOAuth2TokenQueryParams = ({
-	client_id = 'client-id',
-	client_secret = 'client-secret',
 	redirect_uri = 'https://www.example.com/auth/callback',
 	code = 'code-123',
 	grant_type = 'authorization_code',
 } = {}) => ({
-	client_id,
-	client_secret,
 	redirect_uri,
 	code,
 	grant_type,
 });
 
 export const generateRefreshOAuth2TokenQueryParams = ({
-	client_id = 'client-id',
-	client_secret = 'client-secret',
 	refresh_token = 'refresh_token',
 } = {}) => ({
-	client_id,
-	client_secret,
 	refresh_token,
 });
+
+export const generateOAuth2BasicAuthHeader = ({
+	client_id = 'client-id',
+	client_secret = 'client-secret',
+} = {}) => 'Basic ' + btoa(`${client_id}:${client_secret}`);
 
 export const generateGetMeResponse = ({
 	id = uuidv4(),


### PR DESCRIPTION
Figma is [encouraging our REST API clients](https://www.figma.com/developers/api#oauth_migration_guide) to use the Basic auth header to transmit OAuth credentials and use token exchange endpoints defined on `api.figma.com`. So this PR makes these updates.

## Test Plan
- updated integration tests such that they pass
- unit tests pass
- manually tested authenticating locally