### PR TITLE
NONE: Remove an unnecessary usage of URL template for the `checkAuth` action

### DIFF
--- a/src/atlassian-connect.ts
+++ b/src/atlassian-connect.ts
@@ -132,9 +132,7 @@ export const connectAppDescriptor = {
 					}/entities/onEntityDisassociated`,
 				},
 				checkAuth: {
-					templateUrl: `${
-						getConfig().app.baseUrl
-					}/auth/checkAuth?userId={userId}`,
+					templateUrl: `${getConfig().app.baseUrl}/auth/checkAuth`,
 				},
 			},
 		},


### PR DESCRIPTION
### Context

"_Figma for Jira_" has used a URL variable to define `userId` query parameter for the `checkAuth` action. However, it has **no functional impact** as the query parameters defined by the specification (like `userId` here) are provided anyway.

The PR removes the usage of a URL variable for query parameters as it adds extra complexity and might be deprecated in the future (due to creating ambiguity in some edge cases).

### Changes

- **refactor:** Removes an unnecessary usage of URL variables for the `checkAuth` action query parameters.

### Note

- The change requires releasing a new version as it affects a Connect descriptor. While it is not urgent, it might be better to do this to avoid mismatch between the source code and runtime.