### PR TITLE
NONE: Figma OAuth Scope update

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -62,7 +62,7 @@ export const getConfig = (): Config => {
 					clientId: readEnvVarString('FIGMA_OAUTH2_CLIENT_ID'),
 					clientSecret: readEnvVarString('FIGMA_OAUTH2_CLIENT_SECRET'),
 					scope:
-						'files:read,file_dev_resources:read,file_dev_resources:write,webhooks:write',
+						'file_content:read,file_metadata:read,current_user:read,projects:read,file_dev_resources:read,file_dev_resources:write,webhooks:write',
 					stateSecretKey: readEnvVarString('FIGMA_OAUTH2_STATE_SECRET_KEY'),
 				},
 			},


### PR DESCRIPTION
Figma is encouraging our REST API clients to use granular [scopes](https://www.figma.com/developers/api#authentication-scopes), instead of legacy `files:read`. Using more specific scopes helps Figma customers understand what data your app is accessing. In this PR, we use the following granular scopes (`file_content:read,file_metadata:read,current_user:read,projects:read`) to replace `files:read`

*note: disregard the test app name/logo
Before | After
-- | --
<img width="250" alt="before" src="https://github.com/user-attachments/assets/10f171b5-9999-4e9a-b351-bdbaa481a1b3" /> |  <img width="250" alt="after" src="https://github.com/user-attachments/assets/7750f8bb-1408-4b16-96be-12f18098e799" />



## Test Plan
- integration tests pass
- unit tests pass
- manually tested authenticating locally