### PR TITLE
NONE: env variable updates to support running on Figma's development and staging servers

### DIFF
--- a/admin/src/api/axiosInstance.ts
+++ b/admin/src/api/axiosInstance.ts
@@ -1,8 +1,10 @@
 import axios from 'axios';
+import { getAppBasePath } from '../utils';
 
 const THIRTY_SECONDS_IN_MS = 30_000;
 const axiosRest = axios.create({
 	timeout: THIRTY_SECONDS_IN_MS,
+	baseURL: getAppBasePath() ?? undefined,
 });
 // Adding the token in the headers through interceptors because it is an async value
 axiosRest.interceptors.request.use(async (config) => {

--- a/admin/src/components/connect-banner.tsx
+++ b/admin/src/components/connect-banner.tsx
@@ -1,5 +1,6 @@
 import Image from '@atlaskit/image';
 import { css } from '@emotion/react';
+import { getAppPath } from '../utils';
 
 export function ConnectBanner() {
 	return (
@@ -10,11 +11,11 @@ export function ConnectBanner() {
 			`}
 		>
 			<div css={css({ padding: 16 })}>
-				<Image src="/static/admin/jira-logo.svg" />
+				<Image src={getAppPath('/static/admin/jira-logo.svg')} />
 			</div>
-			<Image src="/static/admin/sync.svg" />
+			<Image src={getAppPath('/static/admin/sync.svg')} />
 			<div css={css({ padding: 16 })}>
-				<Image src="/static/admin/figma-logo.svg" />
+				<Image src={getAppPath('/static/admin/figma-logo.svg')} />
 			</div>
 		</div>
 	);

--- a/admin/src/components/figma-permissions-popup.tsx
+++ b/admin/src/components/figma-permissions-popup.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 
 import { FigmaPopup } from './figma-popup';
+import { getAppPath } from '../utils';
 
 type FigmaPermissionsPopupProps = {
 	children: React.ReactNode;
@@ -23,7 +24,7 @@ export function FigmaPermissionsPopup({
 	return (
 		<FigmaPopup
 			content={content}
-			imageSrc={'/static/admin/figma-teams-ui.svg'}
+			imageSrc={getAppPath('/static/admin/figma-teams-ui.svg')}
 			children={children}
 		/>
 	);

--- a/admin/src/components/figma-teams-popup.tsx
+++ b/admin/src/components/figma-teams-popup.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 
 import { FigmaPopup } from './figma-popup';
+import { getAppPath } from '../utils';
 
 type FigmaTeamsPopupProps = {
 	children: React.ReactNode;
@@ -22,7 +23,7 @@ export function FigmaTeamsPopup({ children }: FigmaTeamsPopupProps) {
 	return (
 		<FigmaPopup
 			content={content}
-			imageSrc={'/static/admin/figma-team-url.svg'}
+			imageSrc={getAppPath('/static/admin/figma-team-url.svg')}
 			children={children}
 		/>
 	);

--- a/admin/src/components/success-banner.tsx
+++ b/admin/src/components/success-banner.tsx
@@ -1,5 +1,6 @@
 import Image from '@atlaskit/image';
 import { css } from '@emotion/react';
+import { getAppPath } from '../utils';
 
 type SuccessBannerProps = {
 	size?: 'small' | 'large';
@@ -19,15 +20,15 @@ export function SuccessBanner({ size = 'large' }: SuccessBannerProps) {
 			})}
 		>
 			<div css={css({ padding: logoPadding, paddingRight: 0 })}>
-				<Image src="/static/admin/jira-logo.svg" width={logoWidth} />
+				<Image src={getAppPath('/static/admin/jira-logo.svg')} width={logoWidth} />
 			</div>
 			<Image
-				src="/static/admin/sync-success.svg"
+				src={getAppPath('/static/admin/sync-success.svg')}
 				width={connectorWidth}
 				height={connectorHeight}
 			/>
 			<div css={css({ padding: logoPadding, paddingLeft: 0 })}>
-				<Image src="/static/admin/figma-logo.svg" width={logoWidth} />
+				<Image src={getAppPath('/static/admin/figma-logo.svg')} width={logoWidth} />
 			</div>
 		</div>
 	);

--- a/admin/src/pages/teams/connect-teams-success-screen.tsx
+++ b/admin/src/pages/teams/connect-teams-success-screen.tsx
@@ -4,6 +4,7 @@ import { token } from '@atlaskit/tokens';
 import { css } from '@emotion/react';
 
 import { SuccessBanner } from '../../components';
+import { getAppPath } from '../../utils';
 
 type ConnectTeamSuccessScreenProps = {
 	teamName: string;
@@ -55,7 +56,7 @@ export function ConnectTeamSuccessScreen({
 					background: ${token('elevation.surface.sunken')};
 				`}
 			>
-				<Image src="/static/admin/figma-jira-ui.svg" />
+				<Image src={getAppPath('/static/admin/figma-jira-ui.svg')} />
 				<div
 					css={css`
 						align-items: center;

--- a/admin/src/utils/config.ts
+++ b/admin/src/utils/config.ts
@@ -1,0 +1,7 @@
+export function getAppBasePath(): string | undefined {
+  return import.meta.env.VITE_FIGMA_FOR_JIRA_APP_BASE_PATH;
+}
+
+export function getAppPath(path: string): string {
+  return `${getAppBasePath()}${path}`;
+}

--- a/admin/src/utils/index.ts
+++ b/admin/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './openInBrowser';
 export * from './parseTeamIdFromFigmaUrl';
 export * from './pluralize';
+export * from './config';

--- a/admin/src/utils/parseTeamIdFromFigmaUrl.ts
+++ b/admin/src/utils/parseTeamIdFromFigmaUrl.ts
@@ -1,5 +1,9 @@
 const VALID_FIGMA_ORIGINS = ['www.figma.com', 'figma.com'];
 
+if (import.meta.env.VITE_FIGMA_FOR_JIRA_FIGMA_WEB_DOMAIN) {
+	VALID_FIGMA_ORIGINS.push(import.meta.env.VITE_FIGMA_FOR_JIRA_FIGMA_WEB_DOMAIN);
+}
+
 function withHttp(url: string) {
 	return !/^https?:\/\//i.test(url) ? `http://${url}` : url;
 }

--- a/admin/src/vite-env.d.ts
+++ b/admin/src/vite-env.d.ts
@@ -1,2 +1,11 @@
 /// <reference types="vite/client" />
 /// <reference types="@emotion/react/types/css-prop" />
+
+interface ImportMetaEnv {
+  readonly VITE_FIGMA_FOR_JIRA_APP_BASE_PATH?: string
+  readonly VITE_FIGMA_FOR_JIRA_FIGMA_WEB_DOMAIN?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/admin/vite.config.ts
+++ b/admin/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 // https://vitejs.dev/config/
 export default () => {
 	return defineConfig({
-		base: '/static/admin',
+		base: (process.env['FIGMA_FOR_JIRA_APP_BASE_PATH'] ?? '') + '/static/admin',
 		plugins: [
 			react({
 				jsxImportSource: '@emotion/react',

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import express, { json } from 'express';
 
 import { errorHandlerMiddleware, httpLoggerMiddleware } from './web/middleware';
 import { rootRouter } from './web/routes/router';
+import { getConfig } from './config';
 
 const app = express();
 
@@ -15,6 +16,11 @@ app.use(json());
 
 // Setting the routes
 app.use(rootRouter);
+
+// For internal Figma development purposes only.
+if (getConfig().app.basePath.length > 0) {
+  app.use(getConfig().app.basePath, rootRouter);
+}
 
 // Error handling
 app.use(errorHandlerMiddleware);

--- a/src/atlassian-connect.ts
+++ b/src/atlassian-connect.ts
@@ -1,4 +1,4 @@
-import { getConfig } from './config';
+import { getConfig, getAppPath, getAppUrl, getFigmaDomain } from './config';
 
 const APP_NAME = 'Figma for JIRA Cloud';
 
@@ -64,8 +64,8 @@ export const connectAppDescriptor = {
 	 *
 	 */
 	lifecycle: {
-		installed: '/lifecycleEvents/installed',
-		uninstalled: '/lifecycleEvents/uninstalled',
+		installed: getAppPath('/lifecycleEvents/installed'),
+		uninstalled: getAppPath('/lifecycleEvents/uninstalled'),
 	},
 
 	/**
@@ -79,7 +79,7 @@ export const connectAppDescriptor = {
 			name: {
 				value: 'Configure',
 			},
-			url: '/static/admin',
+			url: getAppPath('/static/admin'),
 			conditions: [{ condition: 'user_is_admin' }],
 		},
 		webSections: [
@@ -98,7 +98,7 @@ export const connectAppDescriptor = {
 					value: 'Configure',
 				},
 				location: 'admin_plugins_menu/figma-addon-admin-section',
-				url: '/static/admin',
+				url: getAppPath('/static/admin'),
 				conditions: [
 					{
 						condition: 'user_is_admin',
@@ -110,29 +110,27 @@ export const connectAppDescriptor = {
 		 * This module allows third-party providers to send design information to Jira and associate it with an issue.
 		 */
 		jiraDesignInfoProvider: {
-			homeUrl: 'https://www.figma.com/',
+			homeUrl: getConfig().figma.webBaseUrl,
 			name: {
 				value: 'Figma',
 			},
 			key: 'figma-integration',
-			handledDomainName: 'figma.com',
-			logoUrl: `${getConfig().app.baseUrl}/static/figma-logo.svg`,
+			handledDomainName: getFigmaDomain(),
+			logoUrl: getAppUrl('/static/figma-logo.svg'),
 			documentationUrl:
 				'https://help.figma.com/hc/en-us/articles/360039827834-Jira-and-Figma',
 			actions: {
 				getEntityByUrl: {
-					templateUrl: `${getConfig().app.baseUrl}/entities/getEntityByUrl`,
+					templateUrl: getAppUrl('/entities/getEntityByUrl'),
 				},
 				onEntityAssociated: {
-					templateUrl: `${getConfig().app.baseUrl}/entities/onEntityAssociated`,
+					templateUrl: getAppUrl('/entities/onEntityAssociated'),
 				},
 				onEntityDisassociated: {
-					templateUrl: `${
-						getConfig().app.baseUrl
-					}/entities/onEntityDisassociated`,
+					templateUrl: getAppUrl('/entities/onEntityDisassociated'),
 				},
 				checkAuth: {
-					templateUrl: `${getConfig().app.baseUrl}/auth/checkAuth`,
+					templateUrl: getAppUrl('/auth/checkAuth'),
 				},
 			},
 		},

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -4,6 +4,7 @@ export type Config = {
 	readonly app: {
 		readonly baseUrl: string;
 		readonly key: string;
+		readonly basePath: string;
 	};
 	readonly server: {
 		readonly port: number;
@@ -40,6 +41,7 @@ export const getConfig = (): Config => {
 			app: {
 				baseUrl: readEnvVarString('APP_URL'),
 				key: readEnvVarString('APP_KEY'),
+				basePath: readEnvVarString('APP_BASE_PATH', ''),
 			},
 			server: {
 				port: readEnvVarInt('SERVER_PORT'),
@@ -74,3 +76,18 @@ export const getConfig = (): Config => {
 
 	return config;
 };
+
+export function getAppPath(path: string): string {
+	const config = getConfig();
+	return `${config.app.basePath}${path}`;
+}
+
+export function getAppUrl(path: string): string {
+	const config = getConfig();
+	return `${config.app.baseUrl}${config.app.basePath}${path}`;
+}
+
+export function getFigmaDomain(): string {
+	const config = getConfig();
+	return new URL(config.figma.webBaseUrl).hostname;
+}

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -1,5 +1,7 @@
+const FIGMA_FOR_JIRA_FALLBACK_PREFIX = 'FIGMA_FOR_JIRA_';
+
 export function readEnvVarString(key: string, fallback?: string): string {
-	const value = process.env[key];
+	const value = process.env[key] ?? process.env[`${FIGMA_FOR_JIRA_FALLBACK_PREFIX}${key}`];
 	if (value) {
 		return value;
 	}

--- a/src/infrastructure/figma/figma-auth-service.ts
+++ b/src/infrastructure/figma/figma-auth-service.ts
@@ -12,7 +12,7 @@ import { CauseAwareError } from '../../common/errors';
 import type { JSONSchemaTypeWithId } from '../../common/schema-validation';
 import { assertSchema } from '../../common/schema-validation';
 import { ensureString } from '../../common/string-utils';
-import { getConfig } from '../../config';
+import { getAppUrl, getConfig } from '../../config';
 import type {
 	ConnectInstallation,
 	ConnectUserInfo,
@@ -138,7 +138,7 @@ export class FigmaAuthService {
 
 		authorizationEndpoint.search = new URLSearchParams({
 			client_id: getConfig().figma.oauth2.clientId,
-			redirect_uri: `${getConfig().app.baseUrl}/${redirectEndpoint}`,
+			redirect_uri: getAppUrl(redirectEndpoint),
 			scope: getConfig().figma.oauth2.scope,
 			state,
 			response_type: 'code',

--- a/src/infrastructure/figma/figma-client/figma-client.ts
+++ b/src/infrastructure/figma/figma-client/figma-client.ts
@@ -35,7 +35,7 @@ import type {
 } from './types';
 
 import { assertSchema } from '../../../common/schema-validation';
-import { getConfig } from '../../../config';
+import { getAppUrl, getConfig } from '../../../config';
 import { withAxiosErrorTranslation } from '../../axios-utils';
 
 const GET_FILE_RESPONSE_PROPERTIES = new Set<keyof GetFileResponse>([
@@ -86,7 +86,7 @@ export class FigmaClient {
 
 			url.searchParams.append(
 				'redirect_uri',
-				`${getConfig().app.baseUrl}/figma/oauth/callback`,
+				getAppUrl('/figma/oauth/callback')
 			);
 			url.searchParams.append('code', code);
 			url.searchParams.append('grant_type', 'authorization_code');

--- a/src/infrastructure/figma/figma-service.ts
+++ b/src/infrastructure/figma/figma-service.ts
@@ -19,7 +19,7 @@ import { CauseAwareError } from '../../common/errors';
 import { isNotNullOrUndefined } from '../../common/predicates';
 import { isOfSchema } from '../../common/schema-validation';
 import { isString } from '../../common/string-utils';
-import { getConfig } from '../../config';
+import { getAppUrl } from '../../config';
 import type {
 	AtlassianDesign,
 	ConnectUserInfo,
@@ -290,7 +290,7 @@ export class FigmaService {
 			const request: CreateWebhookRequest = {
 				event_type: 'FILE_UPDATE',
 				team_id: teamId,
-				endpoint: `${getConfig().app.baseUrl}/figma/webhook`,
+				endpoint: getAppUrl('/figma/webhook'),
 				passcode,
 				description: 'Figma for Jira Cloud',
 			};

--- a/src/web/routes/admin/auth/auth-router.ts
+++ b/src/web/routes/admin/auth/auth-router.ts
@@ -23,7 +23,7 @@ authRouter.get(
 					figmaAuthService.createOAuth2AuthorizationRequest({
 						atlassianUserId,
 						connectInstallation,
-						redirectEndpoint: `figma/oauth/callback`,
+						redirectEndpoint: `/figma/oauth/callback`,
 					});
 
 				if (currentUser) {

--- a/src/web/routes/auth/auth-router.ts
+++ b/src/web/routes/auth/auth-router.ts
@@ -34,7 +34,7 @@ authRouter.get(
 					figmaAuthService.createOAuth2AuthorizationRequest({
 						atlassianUserId,
 						connectInstallation,
-						redirectEndpoint: `figma/oauth/callback`,
+						redirectEndpoint: `/figma/oauth/callback`,
 					});
 
 				return res.send({

--- a/src/web/routes/figma/figma-router.ts
+++ b/src/web/routes/figma/figma-router.ts
@@ -17,9 +17,10 @@ import { handleFigmaFileUpdateEvent } from '../../../jobs';
 import { handleFigmaAuthorizationResponseUseCase } from '../../../usecases';
 import { requestSchemaValidationMiddleware } from '../../middleware';
 import { figmaWebhookAuthMiddleware } from '../../middleware/figma/figma-webhook-auth-middleware';
+import { getAppPath } from '../../../config';
 
-export const SUCCESS_PAGE_URL = `/static/auth-result/success`;
-export const FAILURE_PAGE_URL = `/static/auth-result/failure`;
+export const SUCCESS_PAGE_URL = getAppPath('/static/auth-result/success');
+export const FAILURE_PAGE_URL = getAppPath('/static/auth-result/failure');
 
 export const figmaRouter = Router();
 


### PR DESCRIPTION
This pull request introduces support for a configurable base path and domain for the application, improving flexibility and compatibility with different deployment environments. The most significant changes include adding utility functions for generating app paths and URLs, updating static asset references across the frontend, and modifying backend routes and configurations to use the new base path.

The app should continue to work with the existing environment variables, however we will fallback to env variables that are prefixed with `FIGMA_FOR_JIRA_` if they are missing. 