### PR TITLE
NONE: add launchdarkly feature flagging support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
 				"core-js": "^3.36.0",
 				"dd-trace": "^4.17.0",
 				"express": "^4.18.2",
+				"launchdarkly-node-server-sdk": "^7.0.4",
 				"pino": "^8.15.0",
 				"pino-http": "^8.4.0",
 				"prisma": "^5.1.1",
@@ -3397,6 +3398,12 @@
 			"version": "2.0.6",
 			"license": "MIT"
 		},
+		"node_modules/async": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+			"license": "MIT"
+		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"license": "MIT"
@@ -3840,6 +3847,15 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/clone": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+			"integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8"
 			}
 		},
 		"node_modules/co": {
@@ -6846,6 +6862,42 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/launchdarkly-eventsource": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/launchdarkly-eventsource/-/launchdarkly-eventsource-1.4.4.tgz",
+			"integrity": "sha512-GL+r2Y3WccJlhFyL2buNKel+9VaMnYpbE/FfCkOST5jSNSFodahlxtGyrE8o7R+Qhobyq0Ree4a7iafJDQi9VQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/launchdarkly-node-server-sdk": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/launchdarkly-node-server-sdk/-/launchdarkly-node-server-sdk-7.0.4.tgz",
+			"integrity": "sha512-LsbcWbzJNe6TSDQLwXvG1ZJyhm2zjYrpE/MYEvSv2ndt8Ddw8eaiOUruhhDgbMPMDoqV785RXV+8oS9o2sS0pA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"async": "^3.2.4",
+				"launchdarkly-eventsource": "1.4.4",
+				"lru-cache": "^6.0.0",
+				"node-cache": "^5.1.0",
+				"semver": "^7.5.4",
+				"tunnel": "0.0.6",
+				"uuid": "^8.3.2"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/launchdarkly-node-server-sdk/node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/leven": {
 			"version": "3.1.0",
 			"dev": true,
@@ -7206,6 +7258,18 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
 			"integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
+		},
+		"node_modules/node-cache": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+			"integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+			"license": "MIT",
+			"dependencies": {
+				"clone": "2.x"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
 		},
 		"node_modules/node-fetch": {
 			"version": "2.7.0",
@@ -9308,6 +9372,15 @@
 		"node_modules/tslib": {
 			"version": "2.6.2",
 			"license": "0BSD"
+		},
+		"node_modules/tunnel": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+			"integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+			}
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 				"@types/supertest": "^2.0.12",
 				"@types/uuid": "^9.0.2",
 				"@typescript-eslint/eslint-plugin": "^6.4.0",
-				"@typescript-eslint/parser": "^6.4.0",
+				"@typescript-eslint/parser": "^6.21.0",
 				"commander": "^11.1.0",
 				"dotenv": "^16.3.1",
 				"dotenv-cli": "^7.3.0",
@@ -2977,14 +2977,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "6.4.0",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+			"integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.4.0",
-				"@typescript-eslint/types": "6.4.0",
-				"@typescript-eslint/typescript-estree": "6.4.0",
-				"@typescript-eslint/visitor-keys": "6.4.0",
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/typescript-estree": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -3001,6 +3003,101 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"core-js": "^3.36.0",
 		"dd-trace": "^4.17.0",
 		"express": "^4.18.2",
+		"launchdarkly-node-server-sdk": "^7.0.4",
 		"pino": "^8.15.0",
 		"pino-http": "^8.4.0",
 		"prisma": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 		"@types/supertest": "^2.0.12",
 		"@types/uuid": "^9.0.2",
 		"@typescript-eslint/eslint-plugin": "^6.4.0",
-		"@typescript-eslint/parser": "^6.4.0",
+		"@typescript-eslint/parser": "^6.21.0",
 		"commander": "^11.1.0",
 		"dotenv": "^16.3.1",
 		"dotenv-cli": "^7.3.0",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -20,6 +20,7 @@ export type Config = {
 		readonly domain: string;
 		readonly webBaseUrl: URL;
 		readonly apiBaseUrl: URL;
+		readonly clusterName: string;
 		readonly oauth2: {
 			readonly authorizationServerBaseUrl: URL;
 			readonly clientId: string;
@@ -57,6 +58,7 @@ export const getConfig = (): Config => {
 				domain: readEnvVarString('FIGMA_DOMAIN', 'figma.com'),
 				webBaseUrl: new URL(readEnvVarString('FIGMA_WEB_BASE_URL')),
 				apiBaseUrl: new URL(readEnvVarString('FIGMA_API_BASE_URL')),
+				clusterName: readEnvVarString('CLUSTER_NAME'),
 				oauth2: {
 					authorizationServerBaseUrl: new URL(
 						readEnvVarString('FIGMA_OAUTH2_AUTHORIZATION_SERVER_BASE_URL'),

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -58,7 +58,7 @@ export const getConfig = (): Config => {
 				domain: readEnvVarString('FIGMA_DOMAIN', 'figma.com'),
 				webBaseUrl: new URL(readEnvVarString('FIGMA_WEB_BASE_URL')),
 				apiBaseUrl: new URL(readEnvVarString('FIGMA_API_BASE_URL')),
-				clusterName: readEnvVarString('CLUSTER_NAME'),
+				clusterName: readEnvVarString('CLUSTER_NAME', 'unknown'),
 				oauth2: {
 					authorizationServerBaseUrl: new URL(
 						readEnvVarString('FIGMA_OAUTH2_AUTHORIZATION_SERVER_BASE_URL'),

--- a/src/config/launch_darkly.ts
+++ b/src/config/launch_darkly.ts
@@ -62,7 +62,6 @@ function getLaunchDarklySecretKey(): string | undefined {
 
 		default: {
 			const rawMap = process.env['LAUNCH_DARKLY_SECRET_KEY_MAP'];
-			getLogger().info(`LaunchDarkly secret map: ${rawMap}`);
 			if (!rawMap) {
 				secretKey = undefined;
 			} else {

--- a/src/config/launch_darkly.ts
+++ b/src/config/launch_darkly.ts
@@ -1,0 +1,87 @@
+import type { LDClient, LDOptions } from 'launchdarkly-node-server-sdk';
+import { init } from 'launchdarkly-node-server-sdk';
+
+import { getLogger } from '../infrastructure';
+
+import { getConfig } from '.';
+
+export async function getLDClient(): Promise<LDClient | null> {
+	const ldSecretKey = getLaunchDarklySecretKey();
+
+	if (!ldSecretKey) {
+		getLogger().error(`No LaunchDarkly secret available.`);
+		return null;
+	}
+
+	const options: LDOptions = {
+		logger: {
+			error: (message) => getLogger().error(message),
+			warn: (message) => getLogger().warn(message),
+			info: () => {},
+			debug: () => {},
+		},
+	};
+	const client = init(ldSecretKey, options);
+	await client.waitForInitialization();
+	return client;
+}
+
+export async function getFeatureFlag<T>(
+	client: LDClient | null,
+	flag: string,
+	defaultValue: T,
+): Promise<T> {
+	if (!client) {
+		getLogger().error(
+			`No LaunchDarkly client provided, using default value for flag ${flag}: ${JSON.stringify(
+				defaultValue,
+			)}`,
+		);
+		return defaultValue;
+	}
+
+	const featureFlag = (await client.variation(
+		flag,
+		{ key: 'figma-for-jira' },
+		defaultValue,
+	)) as T;
+	return featureFlag;
+}
+
+function getLaunchDarklySecretKey(): string | undefined {
+	const env = getConfig().figma.clusterName;
+
+	let secretKey: string | undefined = undefined;
+
+	switch (env) {
+		case 'gov':
+		case 'production':
+		case 'staging':
+			secretKey = process.env['LAUNCH_DARKLY_SECRET_KEY'];
+			break;
+
+		default: {
+			const rawMap = process.env['LAUNCH_DARKLY_SECRET_KEY_MAP'];
+			getLogger().info(`LaunchDarkly secret map: ${rawMap}`);
+			if (!rawMap) {
+				secretKey = undefined;
+			} else {
+				const map = JSON.parse(rawMap) as unknown;
+				if (map && typeof map === 'object' && env in map) {
+					const value = map[env] as unknown;
+					if (typeof value === 'string') {
+						secretKey = value;
+					}
+				}
+			}
+		}
+	}
+
+	if (secretKey === undefined) {
+		getLogger().error('LaunchDarkly secret is undefined');
+	} else {
+		getLogger().info('LaunchDarkly secret is defined');
+	}
+
+	return secretKey;
+}


### PR DESCRIPTION
This PR adds a LaunchDarkly client so that we can feature flag new additions to the integration.

This PR adds the `CLUSTER_NAME` env variable so that we can use the appropriate secret in Figma's different environments. The use of `LAUNCH_DARKLY_SECRET_KEY` for production-like environments and `LAUNCH_DARKLY_SECRET_KEY_MAP` for local development matches how other Figma services connect to LaunchDarkly.

Testing:
- Set up devbox 
- Add some temporary logging in server.ts; make sure flag value correctly aligns with LaunchDarkly value
<img width="1177" alt="image" src="https://github.com/user-attachments/assets/d0205305-f61e-40d8-9433-d8a86a991b7b" />
